### PR TITLE
docs: add Sebastian Software README branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # xlsx-format
 
+[![Powered by Sebastian Software](https://img.shields.io/badge/Powered%20by-Sebastian%20Software-00718d?style=flat-square)](https://oss.sebastian-software.com)
 [![npm version](https://img.shields.io/npm/v/xlsx-format)](https://www.npmjs.com/package/xlsx-format)
 [![CI](https://github.com/sebastian-software/xlsx-format/actions/workflows/ci.yml/badge.svg)](https://github.com/sebastian-software/xlsx-format/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/sebastian-software/xlsx-format/graph/badge.svg)](https://codecov.io/gh/sebastian-software/xlsx-format)
@@ -120,5 +121,19 @@ Based on the work of [SheetJS](https://github.com/SheetJS/sheetjs), originally c
 
 Apache 2.0 -- see [LICENSE](LICENSE) for details.
 
-Copyright (C) 2012-present SheetJS LLC (original work)\
-Copyright (C) 2025-present [Sebastian Software GmbH](https://sebastian-software.de) (modifications)
+Copyright (C) 2012-present SheetJS LLC (original work)
+
+---
+
+<!-- sebastian-software-branding:start -->
+<p align="center">
+  <a href="https://oss.sebastian-software.com">
+    <img src="https://sebastian-brand.vercel.app/sebastian-software/logo-software.svg" alt="Sebastian Software" width="240" />
+  </a>
+</p>
+
+<p align="center">
+  <a href="https://oss.sebastian-software.com">Open Source at Sebastian Software</a><br />
+  Copyright &copy; 2025&ndash;2026 Sebastian Software GmbH
+</p>
+<!-- sebastian-software-branding:end -->


### PR DESCRIPTION
Adds a consistent Sebastian Software brand badge near the existing README badge/header area and a shared footer linking to https://oss.sebastian-software.com.\n\nThis keeps the open-source project READMEs visually aligned across the organization while preserving each README's existing structure.\n\nFollow-ups applied from review:\n- Badge placement now follows each project's existing badge/header layout.\n- Existing Sebastian Software copyright lines are replaced by the managed footer instead of duplicated.\n- Footer separator has a blank line before it.\n- Links target the .com OSS site for the English version.\n- Footer copyright years are mapped from the relevant project history: 2025&ndash;2026.\n- Footer logo uses the hosted Sebastian Brand asset.