### PR TITLE
[codex] Fix exported version drift

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
 	"packages": {
 		".": {
 			"release-type": "node",
+			"extra-files": ["src/index.ts"],
 			"changelog-sections": [
 				{ "type": "feat", "section": "Features" },
 				{ "type": "fix", "section": "Bug Fixes" },

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+import pkg from "../package.json" with { type: "json" };
+import { version } from "./index.js";
+
+describe("version", () => {
+	it("matches the package version", () => {
+		expect(version).toBe(pkg.version);
+	});
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,4 +93,4 @@ export {
 export { formatNumber } from "./ssf/format.js";
 
 // Version
-export const version = "1.0.0-alpha.0";
+export const version = "2.0.0"; // x-release-please-version


### PR DESCRIPTION
## Summary
- update the exported version constant to match package.json
- let Release Please update src/index.ts via the generic updater annotation
- add a drift test that compares the public export against package.json

Closes #18

## Validation
- pnpm exec vitest run src/index.test.ts
- pnpm run check
- pnpm run format:check
- push hook: tsc, eslint src/, prettier --check src/