### PR TITLE
[codex] Add sheetToArray and typed worksheet cell helpers

### DIFF
--- a/docs/app/routes/guide/getting-started.mdx
+++ b/docs/app/routes/guide/getting-started.mdx
@@ -112,14 +112,23 @@ link.click();
 xlsx-format converts between sheets and common data formats in both directions.
 
 ```typescript
-import { sheetToJson, jsonToSheet, arrayToSheet, sheetToCsv, sheetToHtml, csvToSheet, htmlToSheet } from "xlsx-format";
+import {
+	sheetToJson,
+	jsonToSheet,
+	arrayToSheet,
+	sheetToArray,
+	sheetToCsv,
+	sheetToHtml,
+	csvToSheet,
+	htmlToSheet,
+} from "xlsx-format";
 
 // Sheet -> JSON objects (first row = headers)
 const rows = sheetToJson(sheet);
 // [{ Name: "Alice", Age: 30 }, { Name: "Bob", Age: 25 }]
 
 // Sheet -> array of arrays
-const arrays = sheetToJson(sheet, { header: 1 });
+const arrays = sheetToArray(sheet);
 // [["Name", "Age"], ["Alice", 30], ["Bob", 25]]
 
 // Sheet -> CSV / HTML
@@ -155,6 +164,15 @@ setCellNumberFormat(sheet["B2"], "#,##0.00");
 setCellHyperlink(sheet["A1"], "https://example.com");
 addCellComment(sheet["C3"], "Check this value", "Alice");
 setArrayFormula(sheet, "D1:D10", "=A1:A10*B1:B10");
+```
+
+Use `formatCell` when you need the displayed value for one cell without
+converting a whole sheet.
+
+```typescript
+import { formatCell } from "xlsx-format";
+
+const displayValue = formatCell(sheet["B2"]);
 ```
 
 ## Styled Workbooks

--- a/src/api/aoa.test.ts
+++ b/src/api/aoa.test.ts
@@ -1,6 +1,21 @@
-import { describe, it, expect } from "vitest";
-import { arrayToSheet } from "../index.js";
-import { addArrayToSheet } from "./aoa.js";
+import { describe, expect, it } from "vitest";
+import { addArrayToSheet, arrayToSheet, sheetToArray } from "./aoa.js";
+
+describe("sheetToArray", () => {
+	it("returns worksheet values as an array of arrays", () => {
+		const ws = arrayToSheet([
+			["Name", "Age"],
+			["Alice", 30],
+			["Bob", 25],
+		]);
+
+		expect(sheetToArray(ws)).toEqual([
+			["Name", "Age"],
+			["Alice", 30],
+			["Bob", 25],
+		]);
+	});
+});
 
 describe("aoa.ts — addArrayToSheet edge cases", () => {
 	it("should create dense worksheet", () => {
@@ -100,5 +115,25 @@ describe("aoa.ts — addArrayToSheet edge cases", () => {
 		const ws = arrayToSheet([[[null, "=NOW()"]]]);
 		expect((ws as any)["A1"].t).toBe("n");
 		expect((ws as any)["A1"].f).toBe("=NOW()");
+	});
+
+	it("preserves existing number formats in sparse worksheets", () => {
+		const ws = arrayToSheet([[1]]);
+		ws["A1"].z = "0.00";
+
+		addArrayToSheet(ws, [[2]]);
+
+		expect(ws["A1"].v).toBe(2);
+		expect(ws["A1"].z).toBe("0.00");
+	});
+
+	it("preserves existing number formats in dense worksheets", () => {
+		const ws = arrayToSheet([[1]], { dense: true });
+		ws["!data"]![0]![0]!.z = "0.00";
+
+		addArrayToSheet(ws, [[2]]);
+
+		expect(ws["!data"]![0]![0]!.v).toBe(2);
+		expect(ws["!data"]![0]![0]!.z).toBe("0.00");
 	});
 });

--- a/src/api/aoa.test.ts
+++ b/src/api/aoa.test.ts
@@ -127,6 +127,17 @@ describe("aoa.ts — addArrayToSheet edge cases", () => {
 		expect(ws["A1"].z).toBe("0.00");
 	});
 
+	it("keeps caller number formats on pre-built sparse cells", () => {
+		const ws = arrayToSheet([[1]]);
+		ws["A1"].z = "0.00";
+		const cell = { t: "n" as const, v: 42, z: "$#,##0.00" };
+
+		addArrayToSheet(ws, [[cell]]);
+
+		expect(ws["A1"].z).toBe("$#,##0.00");
+		expect(cell.z).toBe("$#,##0.00");
+	});
+
 	it("preserves existing number formats in dense worksheets", () => {
 		const ws = arrayToSheet([[1]], { dense: true });
 		ws["!data"]![0]![0]!.z = "0.00";
@@ -135,5 +146,16 @@ describe("aoa.ts — addArrayToSheet edge cases", () => {
 
 		expect(ws["!data"]![0]![0]!.v).toBe(2);
 		expect(ws["!data"]![0]![0]!.z).toBe("0.00");
+	});
+
+	it("keeps caller number formats on pre-built dense cells", () => {
+		const ws = arrayToSheet([[1]], { dense: true });
+		ws["!data"]![0]![0]!.z = "0.00";
+		const cell = { t: "n" as const, v: 42, z: "$#,##0.00" };
+
+		addArrayToSheet(ws, [[cell]]);
+
+		expect(ws["!data"]![0]![0]!.z).toBe("$#,##0.00");
+		expect(cell.z).toBe("$#,##0.00");
 	});
 });

--- a/src/api/aoa.ts
+++ b/src/api/aoa.ts
@@ -145,7 +145,7 @@ export function addArrayToSheet(worksheet: WorkSheet | null, data: any[][], opts
 
 			// Preserve any existing number format from a prior cell at this position
 			const existingCell = getCell(ws, targetRow, targetCol);
-			if (existingCell?.z) {
+			if (existingCell?.z && !cell.z) {
 				cell.z = existingCell.z;
 			}
 			setCell(ws, targetRow, targetCol, cell);

--- a/src/api/aoa.ts
+++ b/src/api/aoa.ts
@@ -1,8 +1,9 @@
-import type { WorkSheet, AOA2SheetOpts, Range } from "../types.js";
-import { decodeCell, encodeCol, encodeRange, safeDecodeRange } from "../utils/cell.js";
+import type { WorkSheet, AOA2SheetOpts, Range, Sheet2JSONOpts } from "../types.js";
+import { decodeCell, encodeRange, safeDecodeRange, getCell, setCell } from "../utils/cell.js";
 import { dateToSerialNumber, localToUtc } from "../utils/date.js";
 import { formatNumber } from "../ssf/format.js";
 import { formatTable } from "../ssf/table.js";
+import { sheetToJson } from "./json.js";
 
 /**
  * Add an array-of-arrays to an existing worksheet, or create a new one.
@@ -17,9 +18,9 @@ import { formatTable } from "../ssf/table.js";
  * @returns The updated or newly created worksheet
  */
 export function addArrayToSheet(worksheet: WorkSheet | null, data: any[][], opts?: AOA2SheetOpts): WorkSheet {
-	const options = opts || ({} as any);
-	const dense = worksheet ? (worksheet as any)["!data"] != null : !!options.dense;
-	const ws: any = worksheet || (dense ? { "!data": [] } : {});
+	const options = opts || {};
+	const dense = worksheet ? worksheet["!data"] != null : !!options.dense;
+	const ws: WorkSheet = worksheet || (dense ? { "!data": [] } : {});
 	if (dense && !ws["!data"]) {
 		ws["!data"] = [];
 	}
@@ -54,7 +55,6 @@ export function addArrayToSheet(worksheet: WorkSheet | null, data: any[][], opts
 		range.s.c = range.e.c = range.s.r = range.e.r = 0;
 	}
 
-	let row: any[] = [];
 	let seen = false;
 	for (let rowIdx = 0; rowIdx < data.length; ++rowIdx) {
 		if (!data[rowIdx]) {
@@ -64,12 +64,6 @@ export function addArrayToSheet(worksheet: WorkSheet | null, data: any[][], opts
 			throw new Error("arrayToSheet expects an array of arrays");
 		}
 		const targetRow = originRow + rowIdx;
-		if (dense) {
-			if (!ws["!data"][targetRow]) {
-				ws["!data"][targetRow] = [];
-			}
-			row = ws["!data"][targetRow];
-		}
 		const rowData = data[rowIdx];
 		for (let colIdx = 0; colIdx < rowData.length; ++colIdx) {
 			if (typeof rowData[colIdx] === "undefined") {
@@ -149,26 +143,19 @@ export function addArrayToSheet(worksheet: WorkSheet | null, data: any[][], opts
 				}
 			}
 
-			if (dense) {
-				// Preserve any existing number format from a prior cell at this position
-				if (row[targetCol] && row[targetCol].z) {
-					cell.z = row[targetCol].z;
-				}
-				row[targetCol] = cell;
-			} else {
-				const cell_ref = encodeCol(targetCol) + (targetRow + 1);
-				if (ws[cell_ref] && ws[cell_ref].z) {
-					cell.z = ws[cell_ref].z;
-				}
-				ws[cell_ref] = cell;
+			// Preserve any existing number format from a prior cell at this position
+			const existingCell = getCell(ws, targetRow, targetCol);
+			if (existingCell?.z) {
+				cell.z = existingCell.z;
 			}
+			setCell(ws, targetRow, targetCol, cell);
 		}
 	}
 	// Only write the ref if we actually saw data (sentinel check: 10000000 > max valid column)
 	if (seen && range.s.c < 10400000) {
 		ws["!ref"] = encodeRange(range);
 	}
-	return ws as WorkSheet;
+	return ws;
 }
 
 /**
@@ -183,4 +170,19 @@ export function addArrayToSheet(worksheet: WorkSheet | null, data: any[][], opts
  */
 export function arrayToSheet(data: any[][], opts?: AOA2SheetOpts): WorkSheet {
 	return addArrayToSheet(null, data, opts);
+}
+
+/**
+ * Convert a worksheet to an array-of-arrays.
+ *
+ * This is a convenience wrapper around `sheetToJson(sheet, { header: 1 })`
+ * that mirrors `arrayToSheet` for callers that prefer explicit conversion
+ * pairs.
+ *
+ * @param sheet - The worksheet to convert
+ * @param opts - Optional conversion settings, except `header` which is fixed to array output
+ * @returns A two-dimensional array of worksheet values
+ */
+export function sheetToArray<T = unknown>(sheet: WorkSheet, opts?: Omit<Sheet2JSONOpts, "header">): T[][] {
+	return sheetToJson<T[]>(sheet, { ...opts, header: 1 });
 }

--- a/src/api/book.test.ts
+++ b/src/api/book.test.ts
@@ -175,6 +175,23 @@ describe("setArrayFormula", () => {
 		expect((ws as any)["C2"].F).toBe("C1:C2");
 		expect((ws as any)["C2"].f).toBeUndefined();
 	});
+
+	it("should set formula cells in dense worksheets", () => {
+		const ws = arrayToSheet(
+			[
+				[1, 2],
+				[3, 4],
+			],
+			{ dense: true },
+		);
+
+		setArrayFormula(ws, "C1:C2", "=A1:A2*B1:B2");
+
+		expect(ws["!data"]![0]![2]!.f).toBe("=A1:A2*B1:B2");
+		expect(ws["!data"]![0]![2]!.F).toBe("C1:C2");
+		expect(ws["!data"]![1]![2]!.F).toBe("C1:C2");
+		expect(ws["!data"]![1]![2]!.f).toBeUndefined();
+	});
 });
 
 describe("sheetToFormulae", () => {

--- a/src/api/book.ts
+++ b/src/api/book.ts
@@ -1,6 +1,14 @@
 import type { WorkBook, WorkSheet, CellObject, Hyperlink, CellStyle, Range } from "../types.js";
 import { validateSheetName } from "../xlsx/workbook.js";
-import { encodeCol, encodeRow, encodeRange, decodeRange, safeDecodeRange, encodeCell } from "../utils/cell.js";
+import {
+	encodeCol,
+	encodeRow,
+	encodeRange,
+	decodeRange,
+	safeDecodeRange,
+	getCell,
+	getOrCreateCell,
+} from "../utils/cell.js";
 
 /**
  * Create a new blank workbook, optionally containing an initial worksheet.
@@ -147,7 +155,11 @@ export function setCellNumberFormat(cell: CellObject, fmt: string | number): Cel
 	return cell;
 }
 
-/** Set or replace the style object on a cell. */
+/**
+ * Set or replace the style object on a cell.
+ *
+ * Mutates `cell` in place and returns the same object for chaining.
+ */
 export function setCellStyle(cell: CellObject, style: CellStyle): CellObject {
 	cell.s = style;
 	return cell;
@@ -174,32 +186,12 @@ function expandSheetRef(ws: WorkSheet, range: Range): void {
 	ws["!ref"] = encodeRange(current);
 }
 
-function getOrCreateCell(ws: WorkSheet, row: number, col: number, create: boolean): CellObject | undefined {
-	if (ws["!data"]) {
-		if (!ws["!data"][row]) {
-			if (!create) {
-				return undefined;
-			}
-			ws["!data"][row] = [];
-		}
-		const cells = ws["!data"][row];
-		let cell = cells[col];
-		if (!cell && create) {
-			cell = { t: "z" };
-			cells[col] = cell;
-		}
-		return cell;
-	}
-	const ref = encodeCell({ r: row, c: col });
-	let cell = ws[ref] as CellObject | undefined;
-	if (!cell && create) {
-		cell = { t: "z" };
-		ws[ref] = cell;
-	}
-	return cell;
-}
-
-/** Apply a style to every existing cell in a range, optionally creating styled stub cells. */
+/**
+ * Apply a style to every existing cell in a range.
+ *
+ * Mutates `ws` in place and returns the same worksheet for chaining. When
+ * `createCells` is true, missing cells in the range are created as styled stubs.
+ */
 export function styleRange(
 	ws: WorkSheet,
 	range: string | Range,
@@ -210,7 +202,7 @@ export function styleRange(
 	const createCells = !!opts?.createCells;
 	for (let R = rng.s.r; R <= rng.e.r; ++R) {
 		for (let C = rng.s.c; C <= rng.e.c; ++C) {
-			const cell = getOrCreateCell(ws, R, C, createCells);
+			const cell = createCells ? getOrCreateCell(ws, R, C) : getCell(ws, R, C);
 			if (cell) {
 				cell.s = style;
 			}
@@ -222,7 +214,11 @@ export function styleRange(
 	return ws;
 }
 
-/** Add a merged-cell range and expand `!ref` to include it. */
+/**
+ * Add a merged-cell range and expand `!ref` to include it.
+ *
+ * Mutates `ws` in place and returns the same worksheet for chaining.
+ */
 export function mergeCells(ws: WorkSheet, range: string | Range): WorkSheet {
 	const rng = typeof range === "string" ? safeDecodeRange(range) : range;
 	if (!ws["!merges"]) {
@@ -233,7 +229,12 @@ export function mergeCells(ws: WorkSheet, range: string | Range): WorkSheet {
 	return ws;
 }
 
-/** Set a row height in points. Row indexes are zero-based. */
+/**
+ * Set a row height in points.
+ *
+ * Mutates `ws` in place and returns the same worksheet for chaining. Row indexes
+ * are zero-based.
+ */
 export function setRowHeight(ws: WorkSheet, row: number, hpt: number): WorkSheet {
 	if (!ws["!rows"]) {
 		ws["!rows"] = [];
@@ -245,7 +246,12 @@ export function setRowHeight(ws: WorkSheet, row: number, hpt: number): WorkSheet
 	return ws;
 }
 
-/** Set a column width. Column indexes are zero-based. */
+/**
+ * Set a column width.
+ *
+ * Mutates `ws` in place and returns the same worksheet for chaining. Column
+ * indexes are zero-based.
+ */
 export function setColumnWidth(ws: WorkSheet, col: number, width: number): WorkSheet {
 	if (!ws["!cols"]) {
 		ws["!cols"] = [];
@@ -257,7 +263,11 @@ export function setColumnWidth(ws: WorkSheet, col: number, width: number): WorkS
 	return ws;
 }
 
-/** Freeze rows and/or columns in a worksheet view. */
+/**
+ * Freeze rows and/or columns in a worksheet view.
+ *
+ * Mutates `ws` in place and returns the same worksheet for chaining.
+ */
 export function freezePanes(ws: WorkSheet, pane: { xSplit?: number; ySplit?: number }): WorkSheet {
 	ws["!views"] = [
 		{
@@ -317,9 +327,9 @@ export function setCellInternalLink(cell: CellObject, range: string, tooltip?: s
  */
 export function addCellComment(cell: CellObject, text: string, author?: string): void {
 	if (!cell.c) {
-		cell.c = [] as any;
+		cell.c = [];
 	}
-	cell.c!.push({ t: text, a: author || "SheetJS" });
+	cell.c.push({ t: text, a: author || "SheetJS" });
 }
 
 /**
@@ -346,17 +356,7 @@ export function setArrayFormula(
 
 	for (let R = rng.s.r; R <= rng.e.r; ++R) {
 		for (let C = rng.s.c; C <= rng.e.c; ++C) {
-			const ref = encodeCol(C) + encodeRow(R);
-			const dense = (ws as any)["!data"] != null;
-			let cell: any;
-			if (dense) {
-				if (!(ws as any)["!data"][R]) {
-					(ws as any)["!data"][R] = [];
-				}
-				cell = (ws as any)["!data"][R][C] || ((ws as any)["!data"][R][C] = { t: "z" });
-			} else {
-				cell = (ws as any)[ref] || ((ws as any)[ref] = { t: "z" });
-			}
+			const cell = getOrCreateCell(ws, R, C);
 			cell.t = "n";
 			cell.F = rngstr; // array formula range shared by all cells in the group
 			delete cell.v;
@@ -407,7 +407,6 @@ export function sheetToFormulae(ws: WorkSheet): string[] {
 	const r = safeDecodeRange(ws["!ref"]);
 	const cols: string[] = [];
 	const cmds: string[] = [];
-	const dense = (ws as any)["!data"] != null;
 
 	// Pre-compute column letters for the range
 	for (let C = r.s.c; C <= r.e.c; ++C) {
@@ -418,7 +417,7 @@ export function sheetToFormulae(ws: WorkSheet): string[] {
 		const rr = encodeRow(R);
 		for (let C = r.s.c; C <= r.e.c; ++C) {
 			const y = cols[C] + rr;
-			const x: any = dense ? ((ws as any)["!data"][R] || [])[C] : (ws as any)[y];
+			const x = getCell(ws, R, C);
 			if (x === undefined) {
 				continue;
 			}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,5 +1,5 @@
 export { formatCell } from "./format.js";
-export { arrayToSheet, addArrayToSheet } from "./aoa.js";
+export { arrayToSheet, sheetToArray, addArrayToSheet } from "./aoa.js";
 export { sheetToJson, jsonToSheet, addJsonToSheet } from "./json.js";
 export { sheetToCsv, sheetToTxt } from "./csv.js";
 export { sheetToHtml } from "./html.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,7 @@ export {
 } from "./api/book.js";
 
 // Utilities - format conversions
-export { arrayToSheet, addArrayToSheet } from "./api/aoa.js";
+export { arrayToSheet, sheetToArray, addArrayToSheet } from "./api/aoa.js";
 export { jsonToSheet, sheetToJson, addJsonToSheet } from "./api/json.js";
 export { sheetToCsv, sheetToTxt, csvToSheet } from "./api/csv.js";
 export { sheetToHtml, htmlToSheet } from "./api/html.js";

--- a/src/utils/cell.ts
+++ b/src/utils/cell.ts
@@ -244,13 +244,32 @@ export function safeDecodeRange(range: string): Range {
 	return result;
 }
 
-/** Retrieve a cell from a worksheet, handling both dense (array) and sparse (object) storage */
+/** Retrieve a cell from a worksheet, handling both dense (array) and sparse (object) storage. */
 export function getCell(sheet: WorkSheet, row: number, col: number): CellObject | undefined {
-	const data = (sheet as any)["!data"];
+	const data = sheet["!data"];
 	if (data != null) {
-		return (data[row] || [])[col];
+		return data[row]?.[col];
 	}
-	return (sheet as any)[encodeCol(col) + encodeRow(row)];
+	return sheet[encodeCol(col) + encodeRow(row)] as CellObject | undefined;
+}
+
+/** Store a cell in a worksheet, handling both dense and sparse storage. */
+export function setCell(sheet: WorkSheet, row: number, col: number, cell: CellObject): CellObject {
+	const data = sheet["!data"];
+	if (data != null) {
+		if (!data[row]) {
+			data[row] = [];
+		}
+		data[row][col] = cell;
+		return cell;
+	}
+	sheet[encodeCell({ r: row, c: col })] = cell;
+	return cell;
+}
+
+/** Retrieve a cell or create a blank stub cell at the requested position. */
+export function getOrCreateCell(sheet: WorkSheet, row: number, col: number): CellObject {
+	return getCell(sheet, row, col) || setCell(sheet, row, col, { t: "z" });
 }
 
 /**


### PR DESCRIPTION
## Summary
- add sheetToArray as the arrayToSheet counterpart
- centralize dense/sparse worksheet cell reads and writes in typed cell helpers
- route AOA/book mutation paths through the helpers and document in-place mutator semantics
- add focused tests for sheetToArray, dense number-format preservation, and dense array formulas
- document sheetToArray and formatCell in the getting-started guide

Closes #26
Closes #27

## Validation
- pnpm run check
- pnpm exec vitest run src/api/aoa.test.ts src/api/book.test.ts src/utils/cell.test.ts
- pnpm run lint
- pnpm run format:check
- push hook: tsc, eslint src/, prettier --check src/