### PR TITLE
[codex] Harden spreadsheet exports against malicious data

### DIFF
--- a/src/api/csv.ts
+++ b/src/api/csv.ts
@@ -1,93 +1,11 @@
 import type { WorkSheet, Sheet2CSVOpts, Range } from "../types.js";
 import { encodeCol, safeDecodeRange, getCell } from "../utils/cell.js";
+import { clampLargeExportRange } from "../utils/export-range.js";
 import { formatCell } from "./format.js";
 import { arrayToSheet } from "./aoa.js";
 
 /** Regex to match double-quote characters for CSV escaping (doubled inside quoted fields) */
 const qreg = /"/g;
-const CELL_REF_RE = /^[A-Z]+[1-9][0-9]*$/;
-const MAX_EXPORT_CELLS = 1000000;
-
-function rangeCellCount(range: Range): number {
-	const rows = range.e.r - range.s.r + 1;
-	const cols = range.e.c - range.s.c + 1;
-	return rows > 0 && cols > 0 ? rows * cols : 0;
-}
-
-function occupiedRangeEnd(sheet: WorkSheet, range: Range): { r: number; c: number } | null {
-	let maxRow = -1;
-	let maxCol = -1;
-	const data = (sheet as any)["!data"];
-	if (data != null) {
-		for (const rowKey of Object.keys(data)) {
-			const rowIdx = Number(rowKey);
-			if (!Number.isInteger(rowIdx) || rowIdx < range.s.r || rowIdx > range.e.r) {
-				continue;
-			}
-			const row = data[rowIdx];
-			if (!row) {
-				continue;
-			}
-			for (const colKey of Object.keys(row)) {
-				const colIdx = Number(colKey);
-				if (!Number.isInteger(colIdx) || colIdx < range.s.c || colIdx > range.e.c || row[colIdx] == null) {
-					continue;
-				}
-				if (rowIdx > maxRow) {
-					maxRow = rowIdx;
-				}
-				if (colIdx > maxCol) {
-					maxCol = colIdx;
-				}
-			}
-		}
-	} else {
-		for (const ref of Object.keys(sheet)) {
-			if (!CELL_REF_RE.test(ref) || (sheet as any)[ref] == null) {
-				continue;
-			}
-			let rowIdx = 0;
-			let colIdx = 0;
-			for (let i = 0; i < ref.length; ++i) {
-				const charCode = ref.charCodeAt(i);
-				if (charCode >= 65 && charCode <= 90) {
-					colIdx = 26 * colIdx + charCode - 64;
-				} else {
-					rowIdx = 10 * rowIdx + charCode - 48;
-				}
-			}
-			--rowIdx;
-			--colIdx;
-			if (rowIdx < range.s.r || rowIdx > range.e.r || colIdx < range.s.c || colIdx > range.e.c) {
-				continue;
-			}
-			if (rowIdx > maxRow) {
-				maxRow = rowIdx;
-			}
-			if (colIdx > maxCol) {
-				maxCol = colIdx;
-			}
-		}
-	}
-	return maxRow === -1 ? null : { r: maxRow, c: maxCol };
-}
-
-function clampLargeExportRange(sheet: WorkSheet, range: Range): Range | null {
-	if (rangeCellCount(range) <= MAX_EXPORT_CELLS) {
-		return range;
-	}
-	const end = occupiedRangeEnd(sheet, range);
-	if (!end) {
-		return null;
-	}
-	return {
-		s: { r: range.s.r, c: range.s.c },
-		e: {
-			r: Math.max(range.s.r, Math.min(range.e.r, end.r)),
-			c: Math.max(range.s.c, Math.min(range.e.c, end.c)),
-		},
-	};
-}
 
 function escapeFormulaText(txt: string, options: any): string {
 	if (!options.escapeFormulae || txt.length === 0) {

--- a/src/api/csv.ts
+++ b/src/api/csv.ts
@@ -5,6 +5,106 @@ import { arrayToSheet } from "./aoa.js";
 
 /** Regex to match double-quote characters for CSV escaping (doubled inside quoted fields) */
 const qreg = /"/g;
+const CELL_REF_RE = /^[A-Z]+[1-9][0-9]*$/;
+const MAX_EXPORT_CELLS = 1000000;
+
+function rangeCellCount(range: Range): number {
+	const rows = range.e.r - range.s.r + 1;
+	const cols = range.e.c - range.s.c + 1;
+	return rows > 0 && cols > 0 ? rows * cols : 0;
+}
+
+function occupiedRangeEnd(sheet: WorkSheet, range: Range): { r: number; c: number } | null {
+	let maxRow = -1;
+	let maxCol = -1;
+	const data = (sheet as any)["!data"];
+	if (data != null) {
+		for (const rowKey of Object.keys(data)) {
+			const rowIdx = Number(rowKey);
+			if (!Number.isInteger(rowIdx) || rowIdx < range.s.r || rowIdx > range.e.r) {
+				continue;
+			}
+			const row = data[rowIdx];
+			if (!row) {
+				continue;
+			}
+			for (const colKey of Object.keys(row)) {
+				const colIdx = Number(colKey);
+				if (!Number.isInteger(colIdx) || colIdx < range.s.c || colIdx > range.e.c || row[colIdx] == null) {
+					continue;
+				}
+				if (rowIdx > maxRow) {
+					maxRow = rowIdx;
+				}
+				if (colIdx > maxCol) {
+					maxCol = colIdx;
+				}
+			}
+		}
+	} else {
+		for (const ref of Object.keys(sheet)) {
+			if (!CELL_REF_RE.test(ref) || (sheet as any)[ref] == null) {
+				continue;
+			}
+			let rowIdx = 0;
+			let colIdx = 0;
+			for (let i = 0; i < ref.length; ++i) {
+				const charCode = ref.charCodeAt(i);
+				if (charCode >= 65 && charCode <= 90) {
+					colIdx = 26 * colIdx + charCode - 64;
+				} else {
+					rowIdx = 10 * rowIdx + charCode - 48;
+				}
+			}
+			--rowIdx;
+			--colIdx;
+			if (rowIdx < range.s.r || rowIdx > range.e.r || colIdx < range.s.c || colIdx > range.e.c) {
+				continue;
+			}
+			if (rowIdx > maxRow) {
+				maxRow = rowIdx;
+			}
+			if (colIdx > maxCol) {
+				maxCol = colIdx;
+			}
+		}
+	}
+	return maxRow === -1 ? null : { r: maxRow, c: maxCol };
+}
+
+function clampLargeExportRange(sheet: WorkSheet, range: Range): Range | null {
+	if (rangeCellCount(range) <= MAX_EXPORT_CELLS) {
+		return range;
+	}
+	const end = occupiedRangeEnd(sheet, range);
+	if (!end) {
+		return null;
+	}
+	return {
+		s: { r: range.s.r, c: range.s.c },
+		e: {
+			r: Math.max(range.s.r, Math.min(range.e.r, end.r)),
+			c: Math.max(range.s.c, Math.min(range.e.c, end.c)),
+		},
+	};
+}
+
+function escapeFormulaText(txt: string, options: any): string {
+	if (!options.escapeFormulae || txt.length === 0) {
+		return txt;
+	}
+	switch (txt.charCodeAt(0)) {
+		case 0x09:
+		case 0x0d:
+		case 0x2b:
+		case 0x2d:
+		case 0x3d:
+		case 0x40:
+			return "'" + txt;
+		default:
+			return txt;
+	}
+}
 
 /**
  * Build a single CSV row string from a worksheet row.
@@ -41,6 +141,7 @@ function buildCsvRow(
 		} else if (val.v != null) {
 			isempty = false;
 			txt = "" + (options.rawNumbers && val.t === "n" ? val.v : formatCell(val, null, options));
+			txt = escapeFormulaText(txt, options);
 			// Check each character: if the text contains the field separator,
 			// record separator, LF (10), CR (13), or double-quote (34), wrap in quotes
 			for (let i = 0, charCode = 0; i !== txt.length; ++i) {
@@ -64,6 +165,7 @@ function buildCsvRow(
 			// Cell has a formula but no cached value and is not part of an array formula
 			isempty = false;
 			txt = "=" + val.f;
+			txt = escapeFormulaText(txt, options);
 			if (txt.indexOf(",") >= 0) {
 				txt = '"' + txt.replace(qreg, '""') + '"';
 			}
@@ -100,7 +202,10 @@ export function sheetToCsv(sheet: WorkSheet, opts?: Sheet2CSVOpts): string {
 	if (sheet == null || sheet["!ref"] == null) {
 		return "";
 	}
-	const range = safeDecodeRange(sheet["!ref"]);
+	const range = clampLargeExportRange(sheet, safeDecodeRange(sheet["!ref"]));
+	if (!range) {
+		return "";
+	}
 	const fieldSeparator = options.FS !== undefined ? options.FS : ",";
 	const fieldSepCode = fieldSeparator.charCodeAt(0);
 	const recordSeparator = options.RS !== undefined ? options.RS : "\n";

--- a/src/api/html.ts
+++ b/src/api/html.ts
@@ -1,6 +1,7 @@
 import type { WorkSheet, Sheet2HTMLOpts, Range } from "../types.js";
 import { BErr } from "../types.js";
-import { encodeCol, encodeRow, decodeRange, decodeCell, getCell } from "../utils/cell.js";
+import { encodeCol, encodeRow, decodeRange, getCell } from "../utils/cell.js";
+import { clampLargeExportRange } from "../utils/export-range.js";
 import { escapeHtml } from "../xml/escape.js";
 import { writeXmlElement } from "../xml/writer.js";
 import { formatCell } from "./format.js";
@@ -10,90 +11,31 @@ import { arrayToSheet } from "./aoa.js";
 const HTML_BEGIN = '<html><head><meta charset="utf-8"/><title>SheetJS Table Export</title></head><body>';
 /** Default HTML document suffix closing the body and html tags */
 const HTML_END = "</body></html>";
-const CELL_REF_RE = /^[A-Z]+[1-9][0-9]*$/;
-const MAX_EXPORT_CELLS = 1000000;
+const UNSAFE_LINK_TARGET_RE = /^(?:javascript|vbscript|data):/;
 
-function rangeCellCount(range: Range): number {
-	const rows = range.e.r - range.s.r + 1;
-	const cols = range.e.c - range.s.c + 1;
-	return rows > 0 && cols > 0 ? rows * cols : 0;
-}
-
-function occupiedRangeEnd(sheet: WorkSheet, range: Range): { r: number; c: number } | null {
-	let maxRow = -1;
-	let maxCol = -1;
-	const data = (sheet as any)["!data"];
-	if (data != null) {
-		for (const rowKey of Object.keys(data)) {
-			const rowIdx = Number(rowKey);
-			if (!Number.isInteger(rowIdx) || rowIdx < range.s.r || rowIdx > range.e.r) {
-				continue;
-			}
-			const row = data[rowIdx];
-			if (!row) {
-				continue;
-			}
-			for (const colKey of Object.keys(row)) {
-				const colIdx = Number(colKey);
-				if (!Number.isInteger(colIdx) || colIdx < range.s.c || colIdx > range.e.c || row[colIdx] == null) {
-					continue;
-				}
-				if (rowIdx > maxRow) {
-					maxRow = rowIdx;
-				}
-				if (colIdx > maxCol) {
-					maxCol = colIdx;
-				}
-			}
-		}
-	} else {
-		for (const ref of Object.keys(sheet)) {
-			if (!CELL_REF_RE.test(ref) || (sheet as any)[ref] == null) {
-				continue;
-			}
-			const cell = decodeCell(ref);
-			if (cell.r < range.s.r || cell.r > range.e.r || cell.c < range.s.c || cell.c > range.e.c) {
-				continue;
-			}
-			if (cell.r > maxRow) {
-				maxRow = cell.r;
-			}
-			if (cell.c > maxCol) {
-				maxCol = cell.c;
-			}
-		}
-	}
-	return maxRow === -1 ? null : { r: maxRow, c: maxCol };
-}
-
-function clampLargeExportRange(sheet: WorkSheet, range: Range): Range | null {
-	if (rangeCellCount(range) <= MAX_EXPORT_CELLS) {
-		return range;
-	}
-	const end = occupiedRangeEnd(sheet, range);
-	if (!end) {
-		return null;
-	}
-	return {
-		s: { r: range.s.r, c: range.s.c },
-		e: {
-			r: Math.max(range.s.r, Math.min(range.e.r, end.r)),
-			c: Math.max(range.s.c, Math.min(range.e.c, end.c)),
-		},
-	};
+function isIgnorableLinkTargetCode(code: number): boolean {
+	return (
+		code <= 0x20 ||
+		code === 0x7f ||
+		code === 0xad ||
+		code === 0x61c ||
+		code === 0x180e ||
+		(code >= 0x200b && code <= 0x200f) ||
+		(code >= 0x202a && code <= 0x202e) ||
+		(code >= 0x2060 && code <= 0x206f) ||
+		code === 0xfeff
+	);
 }
 
 function isSanitizedLinkTarget(target: string): boolean {
 	let normalized = "";
 	for (let i = 0; i < target.length; ++i) {
-		const code = target.charCodeAt(i);
-		if (code <= 0x20 || code === 0x7f) {
-			continue;
+		if (!isIgnorableLinkTargetCode(target.charCodeAt(i))) {
+			normalized += target[i];
 		}
-		normalized += target[i];
 	}
 	normalized = normalized.toLowerCase();
-	return normalized.slice(0, 11) !== "javascript:";
+	return !UNSAFE_LINK_TARGET_RE.test(normalized);
 }
 
 /**
@@ -172,7 +114,7 @@ function buildHtmlRow(ws: WorkSheet, range: Range, rowIndex: number, options: Sh
 				cellAttrs["data-f"] = escapeHtml(cell.f);
 			}
 			// Wrap in an anchor tag if the cell has a non-internal hyperlink,
-			// filtering out javascript: URIs when sanitizeLinks is enabled
+			// filtering out unsafe URI schemes when sanitizeLinks is enabled
 			if (
 				cell.l &&
 				(cell.l.Target || "#").charAt(0) !== "#" &&

--- a/src/api/html.ts
+++ b/src/api/html.ts
@@ -1,6 +1,6 @@
 import type { WorkSheet, Sheet2HTMLOpts, Range } from "../types.js";
 import { BErr } from "../types.js";
-import { encodeCol, encodeRow, decodeRange, getCell } from "../utils/cell.js";
+import { encodeCol, encodeRow, decodeRange, decodeCell, getCell } from "../utils/cell.js";
 import { escapeHtml } from "../xml/escape.js";
 import { writeXmlElement } from "../xml/writer.js";
 import { formatCell } from "./format.js";
@@ -10,6 +10,91 @@ import { arrayToSheet } from "./aoa.js";
 const HTML_BEGIN = '<html><head><meta charset="utf-8"/><title>SheetJS Table Export</title></head><body>';
 /** Default HTML document suffix closing the body and html tags */
 const HTML_END = "</body></html>";
+const CELL_REF_RE = /^[A-Z]+[1-9][0-9]*$/;
+const MAX_EXPORT_CELLS = 1000000;
+
+function rangeCellCount(range: Range): number {
+	const rows = range.e.r - range.s.r + 1;
+	const cols = range.e.c - range.s.c + 1;
+	return rows > 0 && cols > 0 ? rows * cols : 0;
+}
+
+function occupiedRangeEnd(sheet: WorkSheet, range: Range): { r: number; c: number } | null {
+	let maxRow = -1;
+	let maxCol = -1;
+	const data = (sheet as any)["!data"];
+	if (data != null) {
+		for (const rowKey of Object.keys(data)) {
+			const rowIdx = Number(rowKey);
+			if (!Number.isInteger(rowIdx) || rowIdx < range.s.r || rowIdx > range.e.r) {
+				continue;
+			}
+			const row = data[rowIdx];
+			if (!row) {
+				continue;
+			}
+			for (const colKey of Object.keys(row)) {
+				const colIdx = Number(colKey);
+				if (!Number.isInteger(colIdx) || colIdx < range.s.c || colIdx > range.e.c || row[colIdx] == null) {
+					continue;
+				}
+				if (rowIdx > maxRow) {
+					maxRow = rowIdx;
+				}
+				if (colIdx > maxCol) {
+					maxCol = colIdx;
+				}
+			}
+		}
+	} else {
+		for (const ref of Object.keys(sheet)) {
+			if (!CELL_REF_RE.test(ref) || (sheet as any)[ref] == null) {
+				continue;
+			}
+			const cell = decodeCell(ref);
+			if (cell.r < range.s.r || cell.r > range.e.r || cell.c < range.s.c || cell.c > range.e.c) {
+				continue;
+			}
+			if (cell.r > maxRow) {
+				maxRow = cell.r;
+			}
+			if (cell.c > maxCol) {
+				maxCol = cell.c;
+			}
+		}
+	}
+	return maxRow === -1 ? null : { r: maxRow, c: maxCol };
+}
+
+function clampLargeExportRange(sheet: WorkSheet, range: Range): Range | null {
+	if (rangeCellCount(range) <= MAX_EXPORT_CELLS) {
+		return range;
+	}
+	const end = occupiedRangeEnd(sheet, range);
+	if (!end) {
+		return null;
+	}
+	return {
+		s: { r: range.s.r, c: range.s.c },
+		e: {
+			r: Math.max(range.s.r, Math.min(range.e.r, end.r)),
+			c: Math.max(range.s.c, Math.min(range.e.c, end.c)),
+		},
+	};
+}
+
+function isSanitizedLinkTarget(target: string): boolean {
+	let normalized = "";
+	for (let i = 0; i < target.length; ++i) {
+		const code = target.charCodeAt(i);
+		if (code <= 0x20 || code === 0x7f) {
+			continue;
+		}
+		normalized += target[i];
+	}
+	normalized = normalized.toLowerCase();
+	return normalized.slice(0, 11) !== "javascript:";
+}
 
 /**
  * Build a single HTML `<tr>` row from a worksheet row, handling merged cells,
@@ -91,7 +176,7 @@ function buildHtmlRow(ws: WorkSheet, range: Range, rowIndex: number, options: Sh
 			if (
 				cell.l &&
 				(cell.l.Target || "#").charAt(0) !== "#" &&
-				(!options.sanitizeLinks || (cell.l.Target || "").slice(0, 11).toLowerCase() !== "javascript:")
+				(!options.sanitizeLinks || isSanitizedLinkTarget(cell.l.Target || ""))
 			) {
 				cellContent = '<a href="' + escapeHtml(cell.l.Target) + '">' + cellContent + "</a>";
 			}
@@ -120,9 +205,9 @@ export function sheetToHtml(ws: WorkSheet, opts?: Sheet2HTMLOpts): string {
 	const header = options.header != null ? options.header : HTML_BEGIN;
 	const footer = options.footer != null ? options.footer : HTML_END;
 	const out: string[] = [header];
-	const range = decodeRange(ws["!ref"] || "A1");
+	const range = clampLargeExportRange(ws, decodeRange(ws["!ref"] || "A1"));
 	out.push("<table" + (options.id ? ' id="' + options.id + '"' : "") + ">");
-	if (ws["!ref"]) {
+	if (ws["!ref"] && range) {
 		for (let rowIdx = range.s.r; rowIdx <= range.e.r; ++rowIdx) {
 			out.push(buildHtmlRow(ws, range, rowIdx, options));
 		}

--- a/src/api/json.ts
+++ b/src/api/json.ts
@@ -5,6 +5,87 @@ import { isDateFormat } from "../ssf/format.js";
 import { formatTable } from "../ssf/table.js";
 import { formatCell } from "./format.js";
 
+const CELL_REF_RE = /^[A-Z]+[1-9][0-9]*$/;
+const MAX_EXPORT_CELLS = 1000000;
+
+function rangeCellCount(range: Range): number {
+	const rows = range.e.r - range.s.r + 1;
+	const cols = range.e.c - range.s.c + 1;
+	return rows > 0 && cols > 0 ? rows * cols : 0;
+}
+
+function occupiedRangeEnd(sheet: WorkSheet, range: Range): { r: number; c: number } | null {
+	let maxRow = -1;
+	let maxCol = -1;
+	const data = (sheet as any)["!data"];
+	if (data != null) {
+		for (const rowKey of Object.keys(data)) {
+			const rowIdx = Number(rowKey);
+			if (!Number.isInteger(rowIdx) || rowIdx < range.s.r || rowIdx > range.e.r) {
+				continue;
+			}
+			const row = data[rowIdx];
+			if (!row) {
+				continue;
+			}
+			for (const colKey of Object.keys(row)) {
+				const colIdx = Number(colKey);
+				if (!Number.isInteger(colIdx) || colIdx < range.s.c || colIdx > range.e.c || row[colIdx] == null) {
+					continue;
+				}
+				if (rowIdx > maxRow) {
+					maxRow = rowIdx;
+				}
+				if (colIdx > maxCol) {
+					maxCol = colIdx;
+				}
+			}
+		}
+	} else {
+		for (const ref of Object.keys(sheet)) {
+			if (!CELL_REF_RE.test(ref) || (sheet as any)[ref] == null) {
+				continue;
+			}
+			const cell = decodeCell(ref);
+			if (cell.r < range.s.r || cell.r > range.e.r || cell.c < range.s.c || cell.c > range.e.c) {
+				continue;
+			}
+			if (cell.r > maxRow) {
+				maxRow = cell.r;
+			}
+			if (cell.c > maxCol) {
+				maxCol = cell.c;
+			}
+		}
+	}
+	return maxRow === -1 ? null : { r: maxRow, c: maxCol };
+}
+
+function clampLargeExportRange(sheet: WorkSheet, range: Range): Range | null {
+	if (rangeCellCount(range) <= MAX_EXPORT_CELLS) {
+		return range;
+	}
+	const end = occupiedRangeEnd(sheet, range);
+	if (!end) {
+		return null;
+	}
+	return {
+		s: { r: range.s.r, c: range.s.c },
+		e: {
+			r: Math.max(range.s.r, Math.min(range.e.r, end.r)),
+			c: Math.max(range.s.c, Math.min(range.e.c, end.c)),
+		},
+	};
+}
+
+function setRowValue(row: any, key: any, value: any): void {
+	if (key === "__proto__" || key === "constructor" || key === "prototype") {
+		Object.defineProperty(row, key, { value, enumerable: true, configurable: true, writable: true });
+	} else {
+		row[key] = value;
+	}
+}
+
 /**
  * Build a single JSON row object (or array) from a worksheet row.
  *
@@ -45,7 +126,7 @@ function buildJsonRow(
 				continue;
 			}
 			if (headers[colIdx] != null) {
-				row[headers[colIdx]] = defval;
+				setRowValue(row, headers[colIdx], defval);
 			}
 			continue;
 		}
@@ -84,21 +165,23 @@ function buildJsonRow(
 		if (headers[colIdx] != null) {
 			if (cellValue == null) {
 				if (val.t === "e" && cellValue === null) {
-					row[headers[colIdx]] = null;
+					setRowValue(row, headers[colIdx], null);
 				} else if (defval !== undefined) {
-					row[headers[colIdx]] = defval;
+					setRowValue(row, headers[colIdx], defval);
 				} else if (raw && cellValue === null) {
-					row[headers[colIdx]] = null;
+					setRowValue(row, headers[colIdx], null);
 				} else {
 					continue;
 				}
 			} else {
 				// Use raw value when rawNumbers/raw is set, otherwise format for display
-				row[headers[colIdx]] = (
-					val.t === "n" && typeof options.rawNumbers === "boolean" ? options.rawNumbers : raw
-				)
-					? cellValue
-					: formatCell(val, cellValue, options);
+				setRowValue(
+					row,
+					headers[colIdx],
+					(val.t === "n" && typeof options.rawNumbers === "boolean" ? options.rawNumbers : raw)
+						? cellValue
+						: formatCell(val, cellValue, options),
+				);
 			}
 			if (cellValue != null) {
 				isempty = false;
@@ -157,6 +240,13 @@ export function sheetToJson<T = any>(sheet: WorkSheet, opts?: Sheet2JSONOpts): T
 		default:
 			decodedRange = range;
 	}
+	if (options.range == null || typeof options.range === "number") {
+		const clampedRange = clampLargeExportRange(sheet, decodedRange);
+		if (!clampedRange) {
+			return [];
+		}
+		decodedRange = clampedRange;
+	}
 	// When headers are explicitly provided, data starts at the first row (no offset)
 	if (header > 0) {
 		offset = 0;
@@ -165,7 +255,7 @@ export function sheetToJson<T = any>(sheet: WorkSheet, opts?: Sheet2JSONOpts): T
 	const out: any[] = [];
 	let outputIndex = 0;
 	let rowIdx = decodedRange.s.r;
-	const header_cnt: Record<string, number> = {};
+	const header_cnt: Record<string, number> = Object.create(null);
 	const colinfo: any[] = (options.skipHidden && sheet["!cols"]) || [];
 	const rowinfo: any[] = (options.skipHidden && sheet["!rows"]) || [];
 

--- a/src/api/json.ts
+++ b/src/api/json.ts
@@ -1,82 +1,10 @@
 import type { WorkSheet, Sheet2JSONOpts, JSON2SheetOpts, CellObject, Range } from "../types.js";
 import { decodeCell, encodeCol, encodeRow, encodeRange, safeDecodeRange, getCell } from "../utils/cell.js";
 import { dateToSerialNumber, serialNumberToDate, utcToLocal, localToUtc } from "../utils/date.js";
+import { clampLargeExportRange } from "../utils/export-range.js";
 import { isDateFormat } from "../ssf/format.js";
 import { formatTable } from "../ssf/table.js";
 import { formatCell } from "./format.js";
-
-const CELL_REF_RE = /^[A-Z]+[1-9][0-9]*$/;
-const MAX_EXPORT_CELLS = 1000000;
-
-function rangeCellCount(range: Range): number {
-	const rows = range.e.r - range.s.r + 1;
-	const cols = range.e.c - range.s.c + 1;
-	return rows > 0 && cols > 0 ? rows * cols : 0;
-}
-
-function occupiedRangeEnd(sheet: WorkSheet, range: Range): { r: number; c: number } | null {
-	let maxRow = -1;
-	let maxCol = -1;
-	const data = (sheet as any)["!data"];
-	if (data != null) {
-		for (const rowKey of Object.keys(data)) {
-			const rowIdx = Number(rowKey);
-			if (!Number.isInteger(rowIdx) || rowIdx < range.s.r || rowIdx > range.e.r) {
-				continue;
-			}
-			const row = data[rowIdx];
-			if (!row) {
-				continue;
-			}
-			for (const colKey of Object.keys(row)) {
-				const colIdx = Number(colKey);
-				if (!Number.isInteger(colIdx) || colIdx < range.s.c || colIdx > range.e.c || row[colIdx] == null) {
-					continue;
-				}
-				if (rowIdx > maxRow) {
-					maxRow = rowIdx;
-				}
-				if (colIdx > maxCol) {
-					maxCol = colIdx;
-				}
-			}
-		}
-	} else {
-		for (const ref of Object.keys(sheet)) {
-			if (!CELL_REF_RE.test(ref) || (sheet as any)[ref] == null) {
-				continue;
-			}
-			const cell = decodeCell(ref);
-			if (cell.r < range.s.r || cell.r > range.e.r || cell.c < range.s.c || cell.c > range.e.c) {
-				continue;
-			}
-			if (cell.r > maxRow) {
-				maxRow = cell.r;
-			}
-			if (cell.c > maxCol) {
-				maxCol = cell.c;
-			}
-		}
-	}
-	return maxRow === -1 ? null : { r: maxRow, c: maxCol };
-}
-
-function clampLargeExportRange(sheet: WorkSheet, range: Range): Range | null {
-	if (rangeCellCount(range) <= MAX_EXPORT_CELLS) {
-		return range;
-	}
-	const end = occupiedRangeEnd(sheet, range);
-	if (!end) {
-		return null;
-	}
-	return {
-		s: { r: range.s.r, c: range.s.c },
-		e: {
-			r: Math.max(range.s.r, Math.min(range.e.r, end.r)),
-			c: Math.max(range.s.c, Math.min(range.e.c, end.c)),
-		},
-	};
-}
 
 function setRowValue(row: any, key: any, value: any): void {
 	if (key === "__proto__" || key === "constructor" || key === "prototype") {

--- a/src/security-export-guards.test.ts
+++ b/src/security-export-guards.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import {
+	appendSheet,
+	arrayToSheet,
+	createWorkbook,
+	read,
+	sheetToCsv,
+	sheetToHtml,
+	sheetToJson,
+	write,
+} from "./index.js";
+import type { WorkSheet } from "./types.js";
+import { zipRead } from "./zip/index.js";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+describe("export security guards", () => {
+	it("preserves dangerous sheetToJson headers without prototype pollution", () => {
+		const ws = arrayToSheet([
+			["__proto__", "constructor", "prototype", "safe"],
+			["polluted", "ctor", "proto", "ok"],
+		]);
+		const [row] = sheetToJson<Record<string, unknown>>(ws);
+
+		expect(Object.prototype).not.toHaveProperty("polluted");
+		expect(Object.hasOwn(row, "__proto__")).toBe(true);
+		expect(Object.hasOwn(row, "constructor")).toBe(true);
+		expect(Object.hasOwn(row, "prototype")).toBe(true);
+		expect(row["__proto__"]).toBe("polluted");
+		expect(row.constructor).toBe("ctor");
+		expect(row.prototype).toBe("proto");
+		expect(row.safe).toBe("ok");
+	});
+
+	it("keeps malicious workbook sheet names as own properties", async () => {
+		const source = createWorkbook();
+		appendSheet(source, arrayToSheet([["value"]]), "Safe");
+
+		const zip = await zipRead(await write(source));
+		zip.files["xl/workbook.xml"] = encoder.encode(
+			decoder.decode(zip.files["xl/workbook.xml"]).replace('name="Safe"', 'name="__proto__"'),
+		);
+
+		const parsed = await read(await import("./zip/index.js").then(({ zipWrite }) => zipWrite(zip)));
+
+		expect(parsed.SheetNames).toEqual(["__proto__"]);
+		expect(Object.getPrototypeOf(parsed.Sheets)).toBeNull();
+		expect(Object.hasOwn(parsed.Sheets, "__proto__")).toBe(true);
+		expect(Object.prototype).not.toHaveProperty("value");
+	});
+
+	it("escapes formula-like CSV fields when requested", () => {
+		const ws = arrayToSheet([["=1+1", "+SUM(A1)", "-cmd", "@handle", "plain"]]);
+
+		expect(sheetToCsv(ws)).toBe("=1+1,+SUM(A1),-cmd,@handle,plain");
+		expect(sheetToCsv(ws, { escapeFormulae: true })).toBe("'=1+1,'+SUM(A1),'-cmd,'@handle,plain");
+	});
+
+	it("escapes formula-only CSV cells when requested", () => {
+		const ws = { A1: { t: "z", f: "SUM(B1:B10)" }, "!ref": "A1:A1" } as WorkSheet;
+
+		expect(sheetToCsv(ws, { escapeFormulae: true })).toBe("'=SUM(B1:B10)");
+	});
+
+	it("sanitizes javascript links with embedded whitespace", () => {
+		const ws = {
+			"!ref": "A1",
+			A1: { t: "s", v: "Bad", l: { Target: "java\nscript:alert(1)" } },
+		} as WorkSheet;
+
+		expect(sheetToHtml(ws, { sanitizeLinks: true })).not.toContain("href=");
+	});
+
+	it("clamps oversized declared ranges to occupied cells for exporters", () => {
+		const ws = {
+			"!ref": "A1:XFD1048576",
+			A1: { t: "s", v: "Name" },
+			B2: { t: "s", v: "Done" },
+		} as WorkSheet;
+
+		expect(sheetToCsv(ws)).toBe("Name,\n,Done");
+
+		const rows = sheetToJson<unknown[]>(ws, { header: 1 });
+		expect(rows).toHaveLength(2);
+		expect(rows[0]).toEqual(["Name"]);
+		expect(rows[1][1]).toBe("Done");
+
+		const html = sheetToHtml(ws);
+		expect(html.match(/<tr>/g)).toHaveLength(2);
+		expect(html).toContain("Name");
+		expect(html).toContain("Done");
+	});
+});

--- a/src/security-export-guards.test.ts
+++ b/src/security-export-guards.test.ts
@@ -72,6 +72,26 @@ describe("export security guards", () => {
 		expect(sheetToHtml(ws, { sanitizeLinks: true })).not.toContain("href=");
 	});
 
+	it("sanitizes script links with invisible unicode characters", () => {
+		const ws = {
+			"!ref": "A1",
+			A1: { t: "s", v: "Bad", l: { Target: "java\u200bscript:alert(1)" } },
+		} as WorkSheet;
+
+		expect(sheetToHtml(ws, { sanitizeLinks: true })).not.toContain("href=");
+	});
+
+	it("sanitizes data and vbscript links", () => {
+		for (const target of ["data:text/html,<script>alert(1)</script>", "vbscript:msgbox(1)"]) {
+			const ws = {
+				"!ref": "A1",
+				A1: { t: "s", v: "Bad", l: { Target: target } },
+			} as WorkSheet;
+
+			expect(sheetToHtml(ws, { sanitizeLinks: true })).not.toContain("href=");
+		}
+	});
+
 	it("clamps oversized declared ranges to occupied cells for exporters", () => {
 		const ws = {
 			"!ref": "A1:XFD1048576",
@@ -90,5 +110,36 @@ describe("export security guards", () => {
 		expect(html.match(/<tr>/g)).toHaveLength(2);
 		expect(html).toContain("Name");
 		expect(html).toContain("Done");
+	});
+
+	it("clamps oversized dense worksheet ranges to occupied cells", () => {
+		const ws = arrayToSheet([["Name"], [undefined, "Done"]], { dense: true });
+		ws["!ref"] = "A1:XFD1048576";
+
+		expect(sheetToCsv(ws)).toBe("Name,\n,Done");
+		expect(sheetToJson<unknown[]>(ws, { header: 1 })[1][1]).toBe("Done");
+		expect(sheetToHtml(ws)).toContain("Done");
+	});
+
+	it("ignores occupied cells outside a numeric oversized JSON range", () => {
+		const ws = {
+			"!ref": "A1:XFD1048576",
+			A1: { t: "s", v: "Skip" },
+			B2: { t: "s", v: "Done" },
+		} as WorkSheet;
+
+		const rows = sheetToJson<unknown[]>(ws, { header: 1, range: 1 });
+
+		expect(rows).toHaveLength(1);
+		expect(rows[0][0]).toBeUndefined();
+		expect(rows[0][1]).toBe("Done");
+	});
+
+	it("skips oversized declared ranges with no occupied cells", () => {
+		const ws = { "!ref": "A1:XFD1048576" } as WorkSheet;
+
+		expect(sheetToCsv(ws)).toBe("");
+		expect(sheetToJson(ws)).toEqual([]);
+		expect(sheetToHtml(ws)).not.toContain("<tr>");
 	});
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -500,6 +500,8 @@ export interface Sheet2CSVOpts {
 	forceQuotes?: boolean;
 	/** If true, emit raw numeric values instead of formatted text */
 	rawNumbers?: boolean;
+	/** If true, prefix formula-like text fields with a single quote */
+	escapeFormulae?: boolean;
 	/** Override date format for date cells */
 	dateNF?: NumberFormat;
 }

--- a/src/utils/export-range.ts
+++ b/src/utils/export-range.ts
@@ -1,0 +1,75 @@
+import type { Range, WorkSheet } from "../types.js";
+import { decodeCell } from "./cell.js";
+
+const CELL_REF_RE = /^[A-Z]+[1-9][0-9]*$/;
+const MAX_EXPORT_CELLS = 1000000;
+
+function rangeCellCount(range: Range): number {
+	const rows = range.e.r - range.s.r + 1;
+	const cols = range.e.c - range.s.c + 1;
+	return rows > 0 && cols > 0 ? rows * cols : 0;
+}
+
+function occupiedRangeEnd(sheet: WorkSheet, range: Range): { r: number; c: number } | null {
+	let maxRow = -1;
+	let maxCol = -1;
+	const data = (sheet as any)["!data"];
+	if (data != null) {
+		for (const rowKey of Object.keys(data)) {
+			const rowIdx = Number(rowKey);
+			if (!Number.isInteger(rowIdx) || rowIdx < range.s.r || rowIdx > range.e.r) {
+				continue;
+			}
+			const row = data[rowIdx];
+			if (!row) {
+				continue;
+			}
+			for (const colKey of Object.keys(row)) {
+				const colIdx = Number(colKey);
+				if (!Number.isInteger(colIdx) || colIdx < range.s.c || colIdx > range.e.c || row[colIdx] == null) {
+					continue;
+				}
+				if (rowIdx > maxRow) {
+					maxRow = rowIdx;
+				}
+				if (colIdx > maxCol) {
+					maxCol = colIdx;
+				}
+			}
+		}
+	} else {
+		for (const ref of Object.keys(sheet)) {
+			if (!CELL_REF_RE.test(ref) || (sheet as any)[ref] == null) {
+				continue;
+			}
+			const cell = decodeCell(ref);
+			if (cell.r < range.s.r || cell.r > range.e.r || cell.c < range.s.c || cell.c > range.e.c) {
+				continue;
+			}
+			if (cell.r > maxRow) {
+				maxRow = cell.r;
+			}
+			if (cell.c > maxCol) {
+				maxCol = cell.c;
+			}
+		}
+	}
+	return maxRow === -1 ? null : { r: maxRow, c: maxCol };
+}
+
+export function clampLargeExportRange(sheet: WorkSheet, range: Range): Range | null {
+	if (rangeCellCount(range) <= MAX_EXPORT_CELLS) {
+		return range;
+	}
+	const end = occupiedRangeEnd(sheet, range);
+	if (!end) {
+		return null;
+	}
+	return {
+		s: { r: range.s.r, c: range.s.c },
+		e: {
+			r: Math.max(range.s.r, Math.min(range.e.r, end.r)),
+			c: Math.max(range.s.c, Math.min(range.e.c, end.c)),
+		},
+	};
+}

--- a/src/xlsx/parse-zip.ts
+++ b/src/xlsx/parse-zip.ts
@@ -320,7 +320,7 @@ export function parseZip(zip: ZipArchive, opts?: ReadOptions): WorkBook {
 		}
 	}
 
-	const sheets: Record<string, WorkSheet> = {};
+	const sheets: Record<string, WorkSheet> = Object.create(null);
 
 	// Calculation chain (dependency order for formula recalc)
 	if (options.bookDeps && dir.calcchain) {
@@ -328,7 +328,7 @@ export function parseZip(zip: ZipArchive, opts?: ReadOptions): WorkBook {
 	}
 
 	// Build the sheet name list from the workbook
-	const sheetRels: Record<string, Relationships> = {};
+	const sheetRels: Record<string, Relationships> = Object.create(null);
 	const wbsheets = wb.Sheets;
 	props.Worksheets = wbsheets.length;
 	props.SheetNames = [];


### PR DESCRIPTION
## Summary
- guard sheetToJson rows and workbook sheet maps against prototype-pollution keys
- add opt-in CSV formula escaping and strengthen sanitized HTML hyperlink checks
- clamp oversized declared worksheet ranges for JSON, CSV, and HTML exporters
- add regression coverage for malicious headers, sheet names, formula-like CSV values, sanitized links, and huge !ref values

Closes #15
Closes #16
Closes #17

## Validation
- pnpm run check
- pnpm run lint
- pnpm run format:check
- pnpm exec vitest run src/security-export-guards.test.ts src/coverage-deep.test.ts src/coverage-integration.test.ts
- push hook: tsc, eslint src/, prettier --check src/