### PR TITLE
[codex] Harden ZIP parsing against malicious archives

### DIFF
--- a/src/read.ts
+++ b/src/read.ts
@@ -97,7 +97,7 @@ export async function read(data: any, opts?: ReadOptions): Promise<WorkBook> {
 
 	// 0x504B = "PK" -- ZIP file magic number (Phil Katz)
 	if (u8[0] === 0x50 && u8[1] === 0x4b) {
-		const zip = await zipRead(u8);
+		const zip = await zipRead(u8, options);
 		return parseZip(zip, options);
 	}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -111,6 +111,12 @@ export interface ReadOptions extends CommonOptions {
 	dense?: boolean;
 	/** If true, all dates are interpreted as UTC (no timezone adjustment) */
 	UTC?: boolean;
+	/** Maximum number of ZIP central-directory entries to parse */
+	maxZipEntries?: number;
+	/** Maximum total uncompressed ZIP payload size across file entries */
+	maxTotalUncompressedBytes?: number;
+	/** Maximum uncompressed ZIP payload size for a single file entry */
+	maxEntryUncompressedBytes?: number;
 }
 
 /** Options for writing/serializing workbook files */

--- a/src/zip/index.ts
+++ b/src/zip/index.ts
@@ -7,8 +7,22 @@ export interface ZipArchive {
 	files: Record<string, Uint8Array>;
 }
 
+/** Limits applied while reading untrusted ZIP archives. */
+export interface ZipReadOptions {
+	/** Maximum number of central-directory entries to parse. */
+	maxZipEntries?: number;
+	/** Maximum total uncompressed size across file entries. */
+	maxTotalUncompressedBytes?: number;
+	/** Maximum uncompressed size for a single file entry. */
+	maxEntryUncompressedBytes?: number;
+}
+
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
+
+const DEFAULT_MAX_ZIP_ENTRIES = 10000;
+const DEFAULT_MAX_TOTAL_UNCOMPRESSED_BYTES = 512 * 1024 * 1024;
+const DEFAULT_MAX_ENTRY_UNCOMPRESSED_BYTES = 256 * 1024 * 1024;
 
 // -- ZIP format signatures (little-endian magic numbers) --
 /** Local file header signature: "PK\x03\x04" */
@@ -17,6 +31,46 @@ const SIG_LOCAL = 0x04034b50;
 const SIG_CENTRAL = 0x02014b50;
 /** End of Central Directory record signature: "PK\x05\x06" */
 const SIG_EOCD = 0x06054b50;
+
+const ZIP64_U16 = 0xffff;
+const ZIP64_U32 = 0xffffffff;
+
+function optionLimit(value: number | undefined, fallback: number, name: string): number {
+	if (value == null) {
+		return fallback;
+	}
+	if (!Number.isFinite(value) || value < 0) {
+		throw new Error(`Invalid ZIP option: ${name} must be a non-negative finite number`);
+	}
+	return value;
+}
+
+function assertRange(data: Uint8Array, off: number, len: number, what: string): void {
+	if (!Number.isInteger(off) || !Number.isInteger(len) || off < 0 || len < 0 || off > data.length - len) {
+		throw new Error(`Invalid ZIP: ${what} out of bounds`);
+	}
+}
+
+function readU16At(buf: Uint8Array, off: number, what: string): number {
+	assertRange(buf, off, 2, what);
+	return readU16(buf, off);
+}
+
+function readU32At(buf: Uint8Array, off: number, what: string): number {
+	assertRange(buf, off, 4, what);
+	return readU32(buf, off);
+}
+
+function rejectZip64(): never {
+	throw new Error("Unsupported ZIP: Zip64 archives are not supported");
+}
+
+function assertCrc(name: string, data: Uint8Array, expected: number): void {
+	const actual = crc32(data);
+	if (actual !== expected) {
+		throw new Error(`Invalid ZIP: CRC mismatch for ${name}`);
+	}
+}
 
 /** Read an unsigned 16-bit little-endian integer from a buffer */
 function readU16(buf: Uint8Array, off: number): number {
@@ -53,23 +107,57 @@ function writeU32(buf: Uint8Array, off: number, val: number): void {
  * @returns Parsed archive with decompressed file contents
  * @throws Error if the ZIP structure is invalid or uses an unsupported compression method
  */
-export async function zipRead(data: Uint8Array): Promise<ZipArchive> {
+export async function zipRead(data: Uint8Array, opts?: ZipReadOptions): Promise<ZipArchive> {
+	const maxZipEntries = optionLimit(opts?.maxZipEntries, DEFAULT_MAX_ZIP_ENTRIES, "maxZipEntries");
+	const maxTotalUncompressedBytes = optionLimit(
+		opts?.maxTotalUncompressedBytes,
+		DEFAULT_MAX_TOTAL_UNCOMPRESSED_BYTES,
+		"maxTotalUncompressedBytes",
+	);
+	const maxEntryUncompressedBytes = optionLimit(
+		opts?.maxEntryUncompressedBytes,
+		DEFAULT_MAX_ENTRY_UNCOMPRESSED_BYTES,
+		"maxEntryUncompressedBytes",
+	);
+
 	// Scan backward for EOCD signature; EOCD is at least 22 bytes, max 65557 with comment
 	let eocdOffset = -1;
 	for (let i = data.length - 22; i >= 0 && i >= data.length - 65557; i--) {
 		if (readU32(data, i) === SIG_EOCD) {
-			eocdOffset = i;
-			break;
+			const commentLen = readU16(data, i + 20);
+			if (i + 22 + commentLen === data.length) {
+				eocdOffset = i;
+				break;
+			}
 		}
 	}
 	if (eocdOffset === -1) {
 		throw new Error("Invalid ZIP: EOCD not found");
 	}
 
-	// EOCD layout: +8 = total entries on disk, +10 = total entries, +12 = CD size, +16 = CD offset
-	const cdEntries = readU16(data, eocdOffset + 10);
-	const _cdSize = readU32(data, eocdOffset + 12);
-	const cdOffset = readU32(data, eocdOffset + 16);
+	assertRange(data, eocdOffset, 22, "EOCD");
+	const eocdCommentLen = readU16At(data, eocdOffset + 20, "EOCD comment length");
+	assertRange(data, eocdOffset, 22 + eocdCommentLen, "EOCD comment");
+
+	const diskNumber = readU16At(data, eocdOffset + 4, "EOCD disk number");
+	const cdDiskNumber = readU16At(data, eocdOffset + 6, "EOCD central directory disk number");
+	const cdEntriesOnDisk = readU16At(data, eocdOffset + 8, "EOCD disk entry count");
+	const cdEntries = readU16At(data, eocdOffset + 10, "EOCD entry count");
+	const cdSize = readU32At(data, eocdOffset + 12, "EOCD central directory size");
+	const cdOffset = readU32At(data, eocdOffset + 16, "EOCD central directory offset");
+	if (cdEntriesOnDisk === ZIP64_U16 || cdEntries === ZIP64_U16 || cdSize === ZIP64_U32 || cdOffset === ZIP64_U32) {
+		rejectZip64();
+	}
+	if (diskNumber !== 0 || cdDiskNumber !== 0 || cdEntriesOnDisk !== cdEntries) {
+		throw new Error("Unsupported ZIP: multi-disk archives are not supported");
+	}
+	if (cdEntries > maxZipEntries) {
+		throw new Error(`Invalid ZIP: entry count ${cdEntries} exceeds limit ${maxZipEntries}`);
+	}
+	assertRange(data, cdOffset, cdSize, "central directory");
+	if (cdOffset + cdSize > eocdOffset) {
+		throw new Error("Invalid ZIP: central directory overlaps EOCD");
+	}
 
 	// Parse central directory entries
 	interface CdEntry {
@@ -77,53 +165,114 @@ export async function zipRead(data: Uint8Array): Promise<ZipArchive> {
 		crc: number;
 		compSize: number;
 		uncompSize: number;
-		nameBytes: Uint8Array;
+		name: string;
 		localOffset: number;
 	}
 	const entries: CdEntry[] = [];
 	let pos = cdOffset;
+	const cdEnd = cdOffset + cdSize;
 	for (let i = 0; i < cdEntries; i++) {
-		if (readU32(data, pos) !== SIG_CENTRAL) {
+		assertRange(data, pos, 46, "central directory entry");
+		if (pos + 46 > cdEnd) {
+			throw new Error("Invalid ZIP: central directory entry exceeds declared size");
+		}
+		if (readU32At(data, pos, "central directory signature") !== SIG_CENTRAL) {
 			throw new Error("Invalid ZIP: bad central directory entry");
 		}
-		const method = readU16(data, pos + 10); // compression method (0=stored, 8=deflate)
-		const crcVal = readU32(data, pos + 16);
-		const compSize = readU32(data, pos + 20);
-		const uncompSize = readU32(data, pos + 24);
-		const nameLen = readU16(data, pos + 28);
-		const extraLen = readU16(data, pos + 30);
-		const commentLen = readU16(data, pos + 32);
-		const localOffset = readU32(data, pos + 42); // offset to local file header
+		const method = readU16At(data, pos + 10, "central directory compression method");
+		const crcVal = readU32At(data, pos + 16, "central directory CRC");
+		const compSize = readU32At(data, pos + 20, "central directory compressed size");
+		const uncompSize = readU32At(data, pos + 24, "central directory uncompressed size");
+		const nameLen = readU16At(data, pos + 28, "central directory file name length");
+		const extraLen = readU16At(data, pos + 30, "central directory extra length");
+		const commentLen = readU16At(data, pos + 32, "central directory comment length");
+		const diskStart = readU16At(data, pos + 34, "central directory disk start");
+		const localOffset = readU32At(data, pos + 42, "central directory local header offset");
+		if (
+			compSize === ZIP64_U32 ||
+			uncompSize === ZIP64_U32 ||
+			localOffset === ZIP64_U32 ||
+			diskStart === ZIP64_U16
+		) {
+			rejectZip64();
+		}
+		if (diskStart !== 0) {
+			throw new Error("Unsupported ZIP: multi-disk archives are not supported");
+		}
+		const entryEnd = pos + 46 + nameLen + extraLen + commentLen;
+		if (entryEnd > cdEnd) {
+			throw new Error("Invalid ZIP: central directory entry exceeds declared size");
+		}
 		const nameBytes = data.subarray(pos + 46, pos + 46 + nameLen);
-		entries.push({ method, crc: crcVal, compSize, uncompSize, nameBytes, localOffset });
-		pos += 46 + nameLen + extraLen + commentLen;
+		const name = decoder.decode(nameBytes);
+		entries.push({ method, crc: crcVal, compSize, uncompSize, name, localOffset });
+		pos = entryEnd;
 	}
 
 	// Read file data from local headers -- collect inflate promises for parallel decompression
-	const files: Record<string, Uint8Array> = {};
-	const inflateJobs: { name: string; compressed: Uint8Array }[] = [];
+	const files: Record<string, Uint8Array> = Object.create(null);
+	const seenNames = new Set<string>();
+	const inflateJobs: { name: string; compressed: Uint8Array; expectedSize: number; crc: number }[] = [];
+	let totalUncompressedBytes = 0;
 
 	for (const entry of entries) {
-		const loc = entry.localOffset;
-		if (readU32(data, loc) !== SIG_LOCAL) {
-			throw new Error("Invalid ZIP: bad local file header");
-		}
-		const localNameLen = readU16(data, loc + 26);
-		const localExtraLen = readU16(data, loc + 28);
-		const dataStart = loc + 30 + localNameLen + localExtraLen;
-		const name = decoder.decode(entry.nameBytes);
+		const name = entry.name;
 
 		// Skip directory entries (paths ending with "/")
 		if (name.endsWith("/")) {
 			continue;
 		}
+		if (seenNames.has(name)) {
+			throw new Error(`Invalid ZIP: duplicate entry ${name}`);
+		}
+		seenNames.add(name);
+
+		const loc = entry.localOffset;
+		assertRange(data, loc, 30, `local file header for ${entry.name}`);
+		if (readU32At(data, loc, "local file header signature") !== SIG_LOCAL) {
+			throw new Error("Invalid ZIP: bad local file header");
+		}
+		const localMethod = readU16At(data, loc + 8, "local file header compression method");
+		const localNameLen = readU16At(data, loc + 26, "local file header file name length");
+		const localExtraLen = readU16At(data, loc + 28, "local file header extra length");
+		const dataStart = loc + 30 + localNameLen + localExtraLen;
+		assertRange(data, dataStart, entry.compSize, `file data for ${entry.name}`);
+		const dataEnd = dataStart + entry.compSize;
+		if (localMethod !== entry.method) {
+			throw new Error(`Invalid ZIP: local header method mismatch for ${entry.name}`);
+		}
+		const localName = decoder.decode(data.subarray(loc + 30, loc + 30 + localNameLen));
+		if (localName !== name) {
+			throw new Error(`Invalid ZIP: local header file name mismatch for ${name}`);
+		}
+		if (entry.uncompSize > maxEntryUncompressedBytes) {
+			throw new Error(
+				`Invalid ZIP: entry ${name} uncompressed size ${entry.uncompSize} exceeds limit ${maxEntryUncompressedBytes}`,
+			);
+		}
+		totalUncompressedBytes += entry.uncompSize;
+		if (totalUncompressedBytes > maxTotalUncompressedBytes) {
+			throw new Error(
+				`Invalid ZIP: total uncompressed size ${totalUncompressedBytes} exceeds limit ${maxTotalUncompressedBytes}`,
+			);
+		}
 
 		if (entry.method === 0) {
+			if (entry.compSize !== entry.uncompSize) {
+				throw new Error(`Invalid ZIP: stored entry ${name} has mismatched compressed and uncompressed sizes`);
+			}
 			// Method 0: Stored (no compression)
-			files[name] = data.subarray(dataStart, dataStart + entry.uncompSize);
+			const fileData = data.subarray(dataStart, dataEnd);
+			assertCrc(name, fileData, entry.crc);
+			files[name] = fileData;
 		} else if (entry.method === 8) {
 			// Method 8: Deflated -- batch for parallel decompression
-			inflateJobs.push({ name, compressed: data.subarray(dataStart, dataStart + entry.compSize) });
+			inflateJobs.push({
+				name,
+				compressed: data.subarray(dataStart, dataEnd),
+				expectedSize: entry.uncompSize,
+				crc: entry.crc,
+			});
 		} else {
 			throw new Error(`Unsupported ZIP compression method: ${entry.method}`);
 		}
@@ -131,8 +280,14 @@ export async function zipRead(data: Uint8Array): Promise<ZipArchive> {
 
 	// Decompress all deflated entries in parallel
 	if (inflateJobs.length > 0) {
-		const results = await Promise.all(inflateJobs.map((j) => inflate(j.compressed)));
+		const results = await Promise.all(inflateJobs.map((j) => inflate(j.compressed, j.expectedSize)));
 		for (let i = 0; i < inflateJobs.length; i++) {
+			if (results[i].length !== inflateJobs[i].expectedSize) {
+				throw new Error(
+					`Invalid ZIP: entry ${inflateJobs[i].name} inflated to ${results[i].length} bytes, expected ${inflateJobs[i].expectedSize}`,
+				);
+			}
+			assertCrc(inflateJobs[i].name, results[i], inflateJobs[i].crc);
 			files[inflateJobs[i].name] = results[i];
 		}
 	}

--- a/src/zip/index.ts
+++ b/src/zip/index.ts
@@ -101,7 +101,7 @@ function writeU32(buf: Uint8Array, off: number, val: number): void {
  *
  * Locates the End of Central Directory (EOCD) record by scanning backward,
  * then reads the central directory to find all file entries. Deflated entries
- * are decompressed in parallel using {@link DecompressionStream}.
+ * are decompressed one at a time to keep peak memory bounded by entry limits.
  *
  * @param data - Raw ZIP file bytes
  * @returns Parsed archive with decompressed file contents
@@ -209,7 +209,7 @@ export async function zipRead(data: Uint8Array, opts?: ZipReadOptions): Promise<
 		pos = entryEnd;
 	}
 
-	// Read file data from local headers -- collect inflate promises for parallel decompression
+	// Read file data from local headers -- collect deflated entries for bounded decompression
 	const files: Record<string, Uint8Array> = Object.create(null);
 	const seenNames = new Set<string>();
 	const inflateJobs: { name: string; compressed: Uint8Array; expectedSize: number; crc: number }[] = [];
@@ -266,7 +266,7 @@ export async function zipRead(data: Uint8Array, opts?: ZipReadOptions): Promise<
 			assertCrc(name, fileData, entry.crc);
 			files[name] = fileData;
 		} else if (entry.method === 8) {
-			// Method 8: Deflated -- batch for parallel decompression
+			// Method 8: Deflated -- decompress after all structural checks pass
 			inflateJobs.push({
 				name,
 				compressed: data.subarray(dataStart, dataEnd),
@@ -278,18 +278,17 @@ export async function zipRead(data: Uint8Array, opts?: ZipReadOptions): Promise<
 		}
 	}
 
-	// Decompress all deflated entries in parallel
-	if (inflateJobs.length > 0) {
-		const results = await Promise.all(inflateJobs.map((j) => inflate(j.compressed, j.expectedSize)));
-		for (let i = 0; i < inflateJobs.length; i++) {
-			if (results[i].length !== inflateJobs[i].expectedSize) {
-				throw new Error(
-					`Invalid ZIP: entry ${inflateJobs[i].name} inflated to ${results[i].length} bytes, expected ${inflateJobs[i].expectedSize}`,
-				);
-			}
-			assertCrc(inflateJobs[i].name, results[i], inflateJobs[i].crc);
-			files[inflateJobs[i].name] = results[i];
+	// Decompress deflated entries sequentially so a failing archive cannot keep
+	// multiple max-sized decompressed buffers alive after the first rejection.
+	for (const job of inflateJobs) {
+		const result = await inflate(job.compressed, job.expectedSize);
+		if (result.length !== job.expectedSize) {
+			throw new Error(
+				`Invalid ZIP: entry ${job.name} inflated to ${result.length} bytes, expected ${job.expectedSize}`,
+			);
 		}
+		assertCrc(job.name, result, job.crc);
+		files[job.name] = result;
 	}
 
 	return { files };

--- a/src/zip/security.test.ts
+++ b/src/zip/security.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import { zipRead, zipWrite } from "./index.js";
+
+const encoder = new TextEncoder();
+
+function bytes(text: string): Uint8Array {
+	return encoder.encode(text);
+}
+
+function readU16(data: Uint8Array, off: number): number {
+	return data[off] | (data[off + 1] << 8);
+}
+
+function readU32(data: Uint8Array, off: number): number {
+	return (data[off] | (data[off + 1] << 8) | (data[off + 2] << 16) | (data[off + 3] << 24)) >>> 0;
+}
+
+function writeU16(data: Uint8Array, off: number, value: number): void {
+	data[off] = value & 0xff;
+	data[off + 1] = (value >> 8) & 0xff;
+}
+
+function writeU32(data: Uint8Array, off: number, value: number): void {
+	data[off] = value & 0xff;
+	data[off + 1] = (value >> 8) & 0xff;
+	data[off + 2] = (value >> 16) & 0xff;
+	data[off + 3] = (value >> 24) & 0xff;
+}
+
+function findEocd(data: Uint8Array): number {
+	for (let i = data.length - 22; i >= 0; --i) {
+		if (readU32(data, i) === 0x06054b50) {
+			return i;
+		}
+	}
+	throw new Error("EOCD not found in test archive");
+}
+
+function centralDirectoryEntryOffsets(data: Uint8Array): number[] {
+	const eocd = findEocd(data);
+	const entryCount = readU16(data, eocd + 10);
+	const offsets: number[] = [];
+	let pos = readU32(data, eocd + 16);
+	for (let i = 0; i < entryCount; ++i) {
+		offsets.push(pos);
+		const nameLen = readU16(data, pos + 28);
+		const extraLen = readU16(data, pos + 30);
+		const commentLen = readU16(data, pos + 32);
+		pos += 46 + nameLen + extraLen + commentLen;
+	}
+	return offsets;
+}
+
+describe("zipRead security guards", () => {
+	it("rejects archives without EOCD", async () => {
+		await expect(zipRead(new Uint8Array([0x50, 0x4b]))).rejects.toThrow(/EOCD not found/);
+	});
+
+	it("rejects central directories outside archive bounds", async () => {
+		const archive = await zipWrite({ files: { "a.txt": bytes("a") } });
+		const corrupted = archive.slice();
+		writeU32(corrupted, findEocd(corrupted) + 16, corrupted.length);
+
+		await expect(zipRead(corrupted)).rejects.toThrow(/central directory out of bounds/);
+	});
+
+	it("rejects Zip64 markers explicitly", async () => {
+		const archive = await zipWrite({ files: { "a.txt": bytes("a") } });
+		const corrupted = archive.slice();
+		writeU16(corrupted, findEocd(corrupted) + 10, 0xffff);
+
+		await expect(zipRead(corrupted)).rejects.toThrow(/Zip64 archives are not supported/);
+	});
+
+	it("enforces entry and uncompressed-size budgets", async () => {
+		const archive = await zipWrite({
+			files: {
+				"a.txt": bytes("abcd"),
+				"b.txt": bytes("efgh"),
+			},
+		});
+
+		await expect(zipRead(archive, { maxZipEntries: 1 })).rejects.toThrow(/entry count 2 exceeds limit 1/);
+		await expect(zipRead(archive, { maxEntryUncompressedBytes: 3 })).rejects.toThrow(
+			/a.txt uncompressed size 4 exceeds limit 3/,
+		);
+		await expect(zipRead(archive, { maxTotalUncompressedBytes: 7 })).rejects.toThrow(
+			/total uncompressed size 8 exceeds limit 7/,
+		);
+	});
+
+	it("rejects duplicate central-directory names", async () => {
+		const archive = await zipWrite({
+			files: {
+				"a.txt": bytes("a"),
+				"b.txt": bytes("b"),
+			},
+		});
+		const corrupted = archive.slice();
+		const [, secondEntry] = centralDirectoryEntryOffsets(corrupted);
+		corrupted.set(bytes("a.txt"), secondEntry + 46);
+
+		await expect(zipRead(corrupted)).rejects.toThrow(/duplicate entry a\.txt/);
+	});
+
+	it("rejects local-header file name mismatches", async () => {
+		const archive = await zipWrite({ files: { "a.txt": bytes("a") } });
+		const corrupted = archive.slice();
+		const [entry] = centralDirectoryEntryOffsets(corrupted);
+		corrupted.set(bytes("b.txt"), entry + 46);
+
+		await expect(zipRead(corrupted)).rejects.toThrow(/local header file name mismatch for b\.txt/);
+	});
+
+	it("rejects CRC mismatches", async () => {
+		const archive = await zipWrite({ files: { "a.txt": bytes("a") } });
+		const corrupted = archive.slice();
+		const [entry] = centralDirectoryEntryOffsets(corrupted);
+		writeU32(corrupted, entry + 16, 0);
+
+		await expect(zipRead(corrupted)).rejects.toThrow(/CRC mismatch for a\.txt/);
+	});
+
+	it("caps deflate output at the declared uncompressed size", async () => {
+		const archive = await zipWrite({ files: { "a.txt": bytes("hello") } }, true);
+		const corrupted = archive.slice();
+		const [entry] = centralDirectoryEntryOffsets(corrupted);
+		writeU32(corrupted, entry + 24, 1);
+
+		await expect(zipRead(corrupted)).rejects.toThrow(/decompressed data exceeds limit|inflated to/);
+	});
+});

--- a/src/zip/security.test.ts
+++ b/src/zip/security.test.ts
@@ -89,6 +89,23 @@ describe("zipRead security guards", () => {
 		);
 	});
 
+	it("rejects invalid budget options", async () => {
+		const archive = await zipWrite({ files: { "a.txt": bytes("a") } });
+
+		await expect(zipRead(archive, { maxZipEntries: -1 })).rejects.toThrow(/maxZipEntries/);
+		await expect(zipRead(archive, { maxTotalUncompressedBytes: Number.POSITIVE_INFINITY })).rejects.toThrow(
+			/maxTotalUncompressedBytes/,
+		);
+	});
+
+	it("rejects multi-disk archives", async () => {
+		const archive = await zipWrite({ files: { "a.txt": bytes("a") } });
+		const corrupted = archive.slice();
+		writeU16(corrupted, findEocd(corrupted) + 4, 1);
+
+		await expect(zipRead(corrupted)).rejects.toThrow(/multi-disk archives are not supported/);
+	});
+
 	it("rejects duplicate central-directory names", async () => {
 		const archive = await zipWrite({
 			files: {
@@ -110,6 +127,36 @@ describe("zipRead security guards", () => {
 		corrupted.set(bytes("b.txt"), entry + 46);
 
 		await expect(zipRead(corrupted)).rejects.toThrow(/local header file name mismatch for b\.txt/);
+	});
+
+	it("rejects local-header method mismatches", async () => {
+		const archive = await zipWrite({ files: { "a.txt": bytes("a") } });
+		const corrupted = archive.slice();
+		const [entry] = centralDirectoryEntryOffsets(corrupted);
+		const localOffset = readU32(corrupted, entry + 42);
+		writeU16(corrupted, localOffset + 8, 8);
+
+		await expect(zipRead(corrupted)).rejects.toThrow(/local header method mismatch for a\.txt/);
+	});
+
+	it("rejects unsupported compression methods", async () => {
+		const archive = await zipWrite({ files: { "a.txt": bytes("a") } });
+		const corrupted = archive.slice();
+		const [entry] = centralDirectoryEntryOffsets(corrupted);
+		const localOffset = readU32(corrupted, entry + 42);
+		writeU16(corrupted, entry + 10, 99);
+		writeU16(corrupted, localOffset + 8, 99);
+
+		await expect(zipRead(corrupted)).rejects.toThrow(/Unsupported ZIP compression method: 99/);
+	});
+
+	it("rejects stored entries with mismatched sizes", async () => {
+		const archive = await zipWrite({ files: { "a.txt": bytes("a") } });
+		const corrupted = archive.slice();
+		const [entry] = centralDirectoryEntryOffsets(corrupted);
+		writeU32(corrupted, entry + 20, 0);
+
+		await expect(zipRead(corrupted)).rejects.toThrow(/stored entry a\.txt has mismatched/);
 	});
 
 	it("rejects CRC mismatches", async () => {

--- a/src/zip/streams.ts
+++ b/src/zip/streams.ts
@@ -3,7 +3,7 @@
  *
  * Collects chunks incrementally, then copies them into a contiguous buffer.
  */
-async function collectStream(readable: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+async function collectStream(readable: ReadableStream<Uint8Array>, maxBytes = Infinity): Promise<Uint8Array> {
 	const reader = readable.getReader();
 	const chunks: Uint8Array[] = [];
 	let totalLength = 0;
@@ -14,6 +14,9 @@ async function collectStream(readable: ReadableStream<Uint8Array>): Promise<Uint
 		}
 		chunks.push(value);
 		totalLength += value.length;
+		if (totalLength > maxBytes) {
+			throw new Error(`Invalid ZIP: decompressed data exceeds limit (${maxBytes} bytes)`);
+		}
 	}
 	const result = new Uint8Array(totalLength);
 	let offset = 0;
@@ -31,14 +34,24 @@ async function collectStream(readable: ReadableStream<Uint8Array>): Promise<Uint
  * the compression used inside ZIP archives (method 8).
  *
  * @param data - Compressed bytes (raw deflate, no zlib/gzip wrapper)
+ * @param maxBytes - Maximum allowed decompressed size
  * @returns Decompressed bytes
  */
-export async function inflate(data: Uint8Array): Promise<Uint8Array> {
+export async function inflate(data: Uint8Array, maxBytes = Infinity): Promise<Uint8Array> {
 	const ds = new DecompressionStream("deflate-raw");
 	const writer = ds.writable.getWriter();
-	void writer.write(data as Uint8Array<ArrayBuffer>);
-	void writer.close();
-	return collectStream(ds.readable);
+	const writePromise = writer.write(data as Uint8Array<ArrayBuffer>).then(() => writer.close());
+	try {
+		const [result] = await Promise.all([collectStream(ds.readable, maxBytes), writePromise]);
+		return result;
+	} catch (err) {
+		try {
+			await writer.abort(err);
+		} catch {
+			/* ignore abort errors while preserving the original stream error */
+		}
+		throw err;
+	}
 }
 
 /**
@@ -53,7 +66,16 @@ export async function inflate(data: Uint8Array): Promise<Uint8Array> {
 export async function deflate(data: Uint8Array): Promise<Uint8Array> {
 	const cs = new CompressionStream("deflate-raw");
 	const writer = cs.writable.getWriter();
-	void writer.write(data as Uint8Array<ArrayBuffer>);
-	void writer.close();
-	return collectStream(cs.readable);
+	const writePromise = writer.write(data as Uint8Array<ArrayBuffer>).then(() => writer.close());
+	try {
+		const [result] = await Promise.all([collectStream(cs.readable), writePromise]);
+		return result;
+	} catch (err) {
+		try {
+			await writer.abort(err);
+		} catch {
+			/* ignore abort errors while preserving the original stream error */
+		}
+		throw err;
+	}
 }


### PR DESCRIPTION
## Summary
- add ZIP parsing bounds checks for EOCD, central directory entries, local headers, and file data
- expose ZIP entry and uncompressed-size budgets through ReadOptions
- cap deflate output, await stream writer failures, and reject Zip64/multi-disk archives explicitly
- reject duplicate entry names, local-header name mismatches, and CRC mismatches
- add regression tests for malformed archives and ZIP resource limits

Closes #14

## Validation
- pnpm run check
- pnpm run lint
- pnpm run format:check
- pnpm exec vitest run src/zip/security.test.ts src/zip/crc32.test.ts src/xlsx-integration.test.ts
- push hook: tsc, eslint src/, prettier --check src/