### PR TITLE
[codex] Tighten CI and local quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,3 +86,19 @@ jobs:
                   cache: pnpm
             - run: pnpm install --frozen-lockfile
             - run: pnpm run build
+            - run: pnpm dlx publint
+            - run: pnpm dlx @arethetypeswrong/cli --pack .
+            - run: pnpm run smoke:exports
+
+    docs:
+        name: Build Docs
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: pnpm/action-setup@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 24
+                  cache: pnpm
+            - run: pnpm install --frozen-lockfile
+            - run: pnpm --filter docs build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,7 @@ pnpm run format      # Prettier (auto-fix)
 pnpm test            # Run tests once
 pnpm run test:watch  # Run tests in watch mode
 pnpm run build       # Build ESM + CJS bundles
+pnpm run verify      # Run the full local quality gate
 ```
 
 ## Making Changes
@@ -26,7 +27,7 @@ pnpm run build       # Build ESM + CJS bundles
 1. Fork the repository and create a branch from `main`.
 2. Write your code. Follow the existing style -- Prettier and ESLint enforce most of it.
 3. Add or update tests for any changed behavior.
-4. Make sure all checks pass: `pnpm run check && pnpm run lint && pnpm test`
+4. Make sure all checks pass: `pnpm run verify`
 5. Use [Conventional Commits](https://www.conventionalcommits.org/) for your commit messages (e.g. `feat: add X`, `fix: handle Y`). Release Please uses these to generate the changelog.
 6. Open a pull request against `main`.
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
 		"test": "vitest run",
 		"test:watch": "vitest",
 		"test:coverage": "vitest run --coverage",
+		"verify": "pnpm run format:check && pnpm run lint && pnpm run check && pnpm run test:coverage && pnpm run package:check && pnpm --filter docs build",
+		"package:check": "pnpm run build && pnpm dlx publint && pnpm dlx @arethetypeswrong/cli --pack . && pnpm run smoke:exports",
+		"smoke:exports": "node scripts/smoke-exports.mjs",
 		"generate-fixtures": "tsx src/__fixtures__/generate.ts",
 		"lint": "eslint src/",
 		"lint:fix": "eslint --fix src/",
@@ -64,7 +67,12 @@
 	},
 	"packageManager": "pnpm@11.6.0+sha512.9a36518224080c6fe5165afdcfe79bfa118c29be703f3f462b1e32efe1e98e47e8750b148e08286250aad4113cc7993ca413c4e2cd447752708c2ee5751bc95f",
 	"lint-staged": {
-		"*.{ts,js}": "prettier --write",
+		"src/**/*.{ts,js}": [
+			"eslint --fix",
+			"prettier --write"
+		],
+		"*.{ts,js,mjs}": "prettier --write",
+		"scripts/**/*.{js,mjs}": "prettier --write",
 		"*.{json,md,yml,yaml}": "prettier --write"
 	},
 	"license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
 			"eslint --fix",
 			"prettier --write"
 		],
-		"*.{ts,js,mjs}": "prettier --write",
+		"*.{config,conf}.{ts,js,mjs}": "prettier --write",
 		"scripts/**/*.{js,mjs}": "prettier --write",
 		"*.{json,md,yml,yaml}": "prettier --write"
 	},

--- a/scripts/smoke-exports.mjs
+++ b/scripts/smoke-exports.mjs
@@ -14,3 +14,5 @@ for (const [kind, mod] of modules) {
 		}
 	}
 }
+
+console.log("smoke: all exports OK");

--- a/scripts/smoke-exports.mjs
+++ b/scripts/smoke-exports.mjs
@@ -1,0 +1,16 @@
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+const modules = [
+	["ESM", await import("../dist/index.js")],
+	["CJS", require("../dist/index.cjs")],
+];
+
+for (const [kind, mod] of modules) {
+	for (const name of ["read", "write", "createWorkbook", "appendSheet"]) {
+		if (typeof mod[name] !== "function") {
+			throw new Error(`${kind} export ${name} is not available`);
+		}
+	}
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,12 @@ export default defineConfig({
 			provider: "v8",
 			include: ["src/**"],
 			exclude: ["src/__fixtures__/**"],
+			thresholds: {
+				lines: 85,
+				statements: 85,
+				branches: 78,
+				functions: 85,
+			},
 		},
 	},
 });


### PR DESCRIPTION
## Summary
- add package validation to CI with publint, are-the-types-wrong, and ESM/CJS export smoke imports
- build the docs site in PR CI
- add a single pnpm run verify quality gate and document it in CONTRIBUTING.md
- run ESLint through lint-staged for source files and keep config/script files formatted
- enforce global coverage thresholds, including a branch floor set to the current 78% baseline

Closes #20
Closes #21
Closes #23

## Validation
- pnpm run verify
- push hook: tsc, eslint src/, prettier --check src/