### PR TITLE
[codex] Add security policy and guidance

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are provided for the current major release line.
+
+| Version | Supported |
+| ------- | --------- |
+| 2.x     | Yes       |
+| < 2.0   | No        |
+
+## Reporting a Vulnerability
+
+Please do not open a public issue for an unpatched vulnerability.
+
+Use GitHub's private vulnerability reporting flow for this repository. If that flow is unavailable, contact the maintainer through GitHub and request a private reporting channel before sharing exploit details.
+
+Include enough detail to reproduce and assess the issue:
+
+- affected version or commit,
+- input file or minimal reproduction,
+- expected and actual behavior,
+- impact and any known exploitation requirements,
+- whether the report is already disclosed elsewhere.
+
+## Response Expectations
+
+The maintainers aim to acknowledge reports within 3 business days and provide an initial assessment or follow-up questions within 7 business days. Fix timelines depend on severity, reproducibility, and release risk.
+
+Coordinated disclosure is preferred. Please allow time for a fix and release before publishing details that would make exploitation straightforward.
+
+## Scope
+
+Reports are especially useful for:
+
+- parsing untrusted XLSX, XLSM, CSV, TSV, or HTML input,
+- ZIP, XML, shared-string, worksheet, and relationship parsing,
+- prototype-pollution or object-key handling bugs,
+- denial-of-service vectors such as excessive memory, CPU, or decompression work,
+- CSV/formula injection or unsafe HTML export behavior,
+- package export, type-resolution, or build-artifact integrity issues.
+
+xlsx-format does not execute workbook formulas, VBA macros, external entities, or embedded scripts. Bugs that require a separate spreadsheet application to execute generated output may still be security-relevant when xlsx-format is used to export user-controlled data.

--- a/docs/app/routes/guide/getting-started.mdx
+++ b/docs/app/routes/guide/getting-started.mdx
@@ -212,6 +212,7 @@ encodeRange(range); // "A1:C5"
 ## Next Steps
 
 - [Styled Workbooks](/guide/styled-workbooks) -- Build report exports that can replace ExcelJS styling flows
+- [Security Considerations](/guide/security) -- Safely parse untrusted files and export user-controlled data
 - [Why xlsx-format?](/guide/why-xlsx-format) -- See how xlsx-format compares to SheetJS and ExcelJS
 - [Migration Guide](/guide/migration) -- Step-by-step guide for switching from SheetJS
 - [API Reference](/api-reference) -- Full API documentation

--- a/docs/app/routes/guide/security.mdx
+++ b/docs/app/routes/guide/security.mdx
@@ -51,7 +51,7 @@ function safeCsvText(value: unknown): unknown {
 
 ## Exporting HTML
 
-HTML export escapes cell text. Hyperlinks can still point to unsafe targets if you render exported HTML in a browser. Use `sanitizeLinks` when exporting HTML from user-controlled sheets.
+HTML export escapes cell text. Hyperlinks can still point to unsafe targets if you render exported HTML in a browser. Use `sanitizeLinks` when exporting HTML from user-controlled sheets to block script URLs such as `javascript:` targets. If your application accepts arbitrary hyperlinks, validate links against your own allowed URL schemes and domains before publishing or embedding the exported HTML.
 
 ```typescript
 import { sheetToHtml } from "xlsx-format";

--- a/docs/app/routes/guide/security.mdx
+++ b/docs/app/routes/guide/security.mdx
@@ -1,0 +1,79 @@
+---
+title: Security Considerations
+---
+
+# Security Considerations
+
+xlsx-format is designed for modern XLSX reading and writing in Node.js and browsers. Spreadsheet files are still untrusted input: treat uploads, email attachments, partner feeds, and user-edited workbooks as data from an attacker-controlled boundary.
+
+## What xlsx-format does not execute
+
+xlsx-format parses workbook structures and cell data. It does not execute formulas, VBA macros, external entities, embedded scripts, or workbook event handlers.
+
+That avoids common execution classes such as XXE and macro execution, but it does not remove resource-exhaustion or unsafe-export risks. A malicious workbook can still try to consume excessive CPU or memory with large ZIP payloads, large XML parts, huge declared sheet ranges, or many repeated strings.
+
+## Reading untrusted files
+
+When reading files from users or external systems:
+
+- apply upload size limits before calling `read()`,
+- run parsing away from latency-sensitive request paths when possible,
+- use process, worker, or request timeouts in server environments,
+- prefer narrow conversion work instead of immediately materializing every sheet into JSON,
+- use `sheetRows` when only a preview or header sample is needed,
+- keep xlsx-format updated for ZIP, XML, and export hardening fixes.
+
+```typescript
+import { read, sheetToJson } from "xlsx-format";
+
+const workbook = await read(fileBytes, {
+	sheetRows: 1000,
+});
+
+const firstSheet = workbook.Sheets[workbook.SheetNames[0]];
+const previewRows = sheetToJson(firstSheet);
+```
+
+## Exporting CSV
+
+CSV files opened in spreadsheet applications can interpret text that starts with characters such as `=`, `+`, `-`, `@`, tab, or carriage return as formulas. This is commonly called CSV injection or formula injection.
+
+If a CSV will be opened by a human in Excel, Google Sheets, or LibreOffice, neutralize user-controlled text fields before export. A common mitigation is prefixing formula-like text with a single quote.
+
+```typescript
+function safeCsvText(value: unknown): unknown {
+	if (typeof value !== "string") {
+		return value;
+	}
+	return /^[=+\-@\t\r]/.test(value) ? `'${value}` : value;
+}
+```
+
+## Exporting HTML
+
+HTML export escapes cell text. Hyperlinks can still point to unsafe targets if you render exported HTML in a browser. Use `sanitizeLinks` when exporting HTML from user-controlled sheets.
+
+```typescript
+import { sheetToHtml } from "xlsx-format";
+
+const html = sheetToHtml(sheet, {
+	sanitizeLinks: true,
+});
+```
+
+## Object keys from workbook data
+
+Spreadsheet headers and sheet names can become object keys in APIs such as `sheetToJson()` and `workbook.Sheets`. Treat keys from untrusted files as untrusted data. Avoid merging parsed row objects directly into application configuration, prototypes, or privileged domain objects.
+
+```typescript
+const rows = sheetToJson<Record<string, unknown>>(sheet);
+
+for (const row of rows) {
+	const safeName = String(row["Name"] ?? "");
+	// Copy only the fields your application expects.
+}
+```
+
+## Reporting vulnerabilities
+
+See the [Security Policy](https://github.com/sebastian-software/xlsx-format/blob/main/SECURITY.md) for supported versions, private reporting guidance, and disclosure expectations.


### PR DESCRIPTION
## Summary
- add SECURITY.md with supported versions, private reporting guidance, response expectations, and vuln scope
- add a Security Considerations docs page for untrusted reads, CSV/HTML exports, and workbook-derived object keys
- link the security guide from Getting Started

Closes #24

## Validation
- pnpm exec prettier --check SECURITY.md docs/app/routes/guide/security.mdx docs/app/routes/guide/getting-started.mdx
- pnpm --filter docs build
- push hook: tsc, eslint src/, prettier --check src/