### PR TITLE
fix: add XML parser safety limits

### DIFF
--- a/docs/app/routes/guide/security.mdx
+++ b/docs/app/routes/guide/security.mdx
@@ -21,6 +21,7 @@ When reading files from users or external systems:
 - use process, worker, or request timeouts in server environments,
 - prefer narrow conversion work instead of immediately materializing every sheet into JSON,
 - use `sheetRows` when only a preview or header sample is needed,
+- tune ZIP and XML parser limits for public upload paths,
 - keep xlsx-format updated for ZIP, XML, and export hardening fixes.
 
 ```typescript
@@ -28,11 +29,19 @@ import { read, sheetToJson } from "xlsx-format";
 
 const workbook = await read(fileBytes, {
 	sheetRows: 1000,
+	maxXmlPartBytes: 32 * 1024 * 1024,
+	maxXmlTags: 500_000,
+	maxXmlNestingDepth: 128,
+	maxSharedStringItems: 100_000,
+	maxWorksheetRows: 100_000,
+	maxWorksheetCells: 1_000_000,
 });
 
 const firstSheet = workbook.Sheets[workbook.SheetNames[0]];
 const previewRows = sheetToJson(firstSheet);
 ```
+
+The default ZIP and XML limits are intentionally high enough for ordinary workbooks. Lower them when a service receives arbitrary uploads and does not need to parse very large sheets.
 
 ## Exporting CSV
 

--- a/src/opc/content-types.ts
+++ b/src/opc/content-types.ts
@@ -1,6 +1,7 @@
 import { parseXmlTag, XML_HEADER, XML_TAG_REGEX } from "../xml/parser.js";
 import { writeXmlElement } from "../xml/writer.js";
 import { XMLNS } from "../xml/namespaces.js";
+import type { XmlLimitOptions } from "../xml/limits.js";
 
 // Extracts the namespace prefix from the first tag in a string (e.g., "w" from "<w:Types>")
 const nsregex = /<(\w+):/;
@@ -153,7 +154,7 @@ export function createContentTypes(): ContentTypes {
  * @returns a populated ContentTypes object
  * @throws if the root namespace is not the expected OPC content-types namespace
  */
-export function parseContentTypes(data: string | null | undefined): ContentTypes {
+export function parseContentTypes(data: string | null | undefined, opts?: XmlLimitOptions): ContentTypes {
 	const ct = createContentTypes();
 	if (!data) {
 		return ct;
@@ -161,7 +162,7 @@ export function parseContentTypes(data: string | null | undefined): ContentTypes
 	const ctext: Record<string, string> = {};
 	const matches = data.match(XML_TAG_REGEX) || [];
 	for (const x of matches) {
-		const y = parseXmlTag(x);
+		const y = parseXmlTag(x, undefined, undefined, opts);
 		// Strip namespace prefix from tag name for uniform matching
 		switch ((y[0] as string).replace(nsregex, "<")) {
 			case "<?xml":

--- a/src/opc/relationships.ts
+++ b/src/opc/relationships.ts
@@ -2,6 +2,7 @@ import { parseXmlTag, XML_HEADER, XML_TAG_REGEX } from "../xml/parser.js";
 import { unescapeXml } from "../xml/escape.js";
 import { writeXmlElement } from "../xml/writer.js";
 import { XMLNS, RELS } from "../xml/namespaces.js";
+import type { XmlLimitOptions } from "../xml/limits.js";
 
 /** A single relationship entry from a .rels file */
 export interface RelEntry {
@@ -65,7 +66,11 @@ export function getRelsPath(file: string): string {
  * @param currentFilePath - the path of the file that owns this .rels (used for path resolution)
  * @returns the parsed Relationships object
  */
-export function parseRelationships(data: string | null | undefined, currentFilePath: string): Relationships {
+export function parseRelationships(
+	data: string | null | undefined,
+	currentFilePath: string,
+	opts?: XmlLimitOptions,
+): Relationships {
 	const rels = { "!id": {} } as any as Relationships;
 	if (!data) {
 		return rels;
@@ -77,7 +82,7 @@ export function parseRelationships(data: string | null | undefined, currentFileP
 
 	const matches = data.match(XML_TAG_REGEX) || [];
 	for (const x of matches) {
-		const y = parseXmlTag(x);
+		const y = parseXmlTag(x, undefined, undefined, opts);
 		if (y[0] === "<Relationship") {
 			const rel: RelEntry = {
 				Type: y.Type,

--- a/src/types.ts
+++ b/src/types.ts
@@ -117,6 +117,22 @@ export interface ReadOptions extends CommonOptions {
 	maxTotalUncompressedBytes?: number;
 	/** Maximum uncompressed ZIP payload size for a single file entry */
 	maxEntryUncompressedBytes?: number;
+	/** Maximum decoded XML part size */
+	maxXmlPartBytes?: number;
+	/** Maximum number of raw XML tags in a single XML part */
+	maxXmlTags?: number;
+	/** Maximum XML element nesting depth in a single XML part */
+	maxXmlNestingDepth?: number;
+	/** Maximum number of characters in a single XML tag */
+	maxXmlTagLength?: number;
+	/** Maximum number of attributes in a single XML tag */
+	maxXmlAttributesPerTag?: number;
+	/** Maximum number of shared string entries to parse */
+	maxSharedStringItems?: number;
+	/** Maximum number of worksheet row elements to scan */
+	maxWorksheetRows?: number;
+	/** Maximum number of worksheet cell elements to scan */
+	maxWorksheetCells?: number;
 }
 
 /** Options for writing/serializing workbook files */

--- a/src/xlsx/parse-zip.ts
+++ b/src/xlsx/parse-zip.ts
@@ -24,6 +24,7 @@ import { parseCalcChainXml } from "./calc-chain.js";
 import { resetFormatTable } from "../ssf/table.js";
 import { utf8read } from "../utils/buffer.js";
 import { RELS as RELTYPE } from "../xml/namespaces.js";
+import { assertXmlPartLimits } from "../xml/limits.js";
 
 /** Strip a leading "/" from a path (ZIP entries don't use leading slashes) */
 function stripLeadingSlash(x: string): string {
@@ -55,17 +56,20 @@ function resolve_path(target: string, basePath: string): string {
  * Read a file from the ZIP as a string.
  * Throws if the file is not found and safe is not set.
  */
-function getZipString(zip: ZipArchive, path: string, safe?: boolean): string | null {
+function getZipString(zip: ZipArchive, path: string, safe?: boolean, opts?: ReadOptions): string | null {
 	const p = zipReadString(zip, path);
 	if (p == null && !safe) {
 		throw new Error("Could not find " + path);
+	}
+	if (p != null) {
+		assertXmlPartLimits(path, p, opts);
 	}
 	return p;
 }
 
 /** Read ZIP entry data as string (alias for XML-based files) */
-function getZipData(zip: ZipArchive, path: string, safe?: boolean): string | null {
-	return getZipString(zip, path, safe);
+function getZipData(zip: ZipArchive, path: string, safe?: boolean, opts?: ReadOptions): string | null {
+	return getZipString(zip, path, safe, opts);
 }
 
 /** Recognized relationship types for worksheets (standard and transitional) */
@@ -122,8 +126,8 @@ function safe_parse_sheet(
 	strs: SST,
 ): void {
 	try {
-		sheetRels[sheetName] = parseRelationships(getZipString(zip, relsPath, true), path);
-		const data = getZipData(zip, path);
+		sheetRels[sheetName] = parseRelationships(getZipString(zip, relsPath, true, opts), path, opts);
+		const data = getZipData(zip, path, false, opts);
 		if (!data) {
 			return;
 		}
@@ -162,7 +166,7 @@ function safe_parse_sheet(
 				// Parse legacy comments (ECMA-376 18.7)
 				if (rel.Type === RELTYPE.CMNT) {
 					const dfile = resolve_path(rel.Target, path);
-					const cmntData = getZipData(zip, dfile, true);
+					const cmntData = getZipData(zip, dfile, true, opts);
 					if (cmntData) {
 						const parsedComments = parseCommentsXml(cmntData, opts);
 						if (parsedComments && parsedComments.length > 0) {
@@ -173,7 +177,7 @@ function safe_parse_sheet(
 				// Parse threaded comments (MS-XLSX extension)
 				if (rel.Type === RELTYPE.TCMNT) {
 					const dfile = resolve_path(rel.Target, path);
-					const tcData = getZipData(zip, dfile, true);
+					const tcData = getZipData(zip, dfile, true, opts);
 					if (tcData) {
 						tcomments = tcomments.concat(parseTcmntXml(tcData, opts));
 					}
@@ -187,7 +191,7 @@ function safe_parse_sheet(
 		// Parse legacy VML drawings (comment anchor shapes)
 		if ((_ws as any)["!legdrawel"] && sheetRels[sheetName]) {
 			const dfile = resolve_path((_ws as any)["!legdrawel"].Target, path);
-			const draw = getZipString(zip, dfile, true);
+			const draw = getZipString(zip, dfile, true, opts);
 			if (draw) {
 				parseVml(utf8read(draw), _ws, comments);
 			}
@@ -219,12 +223,12 @@ export function parseZip(zip: ZipArchive, opts?: ReadOptions): WorkBook {
 		throw new Error("Unsupported ZIP file");
 	}
 
-	const dir: ContentTypes = parseContentTypes(getZipString(zip, "[Content_Types].xml"));
+	const dir: ContentTypes = parseContentTypes(getZipString(zip, "[Content_Types].xml", false, options), options);
 
 	// Fallback: if no workbook found in content types, try the default path
 	if (dir.workbooks.length === 0) {
 		const binname = "xl/workbook.xml";
-		if (getZipData(zip, binname, true)) {
+		if (getZipData(zip, binname, true, options)) {
 			dir.workbooks.push(binname);
 		}
 	}
@@ -241,7 +245,7 @@ export function parseZip(zip: ZipArchive, opts?: ReadOptions): WorkBook {
 		// Shared String Table
 		if (dir.sst) {
 			try {
-				const sstData = getZipData(zip, stripLeadingSlash(dir.sst));
+				const sstData = getZipData(zip, stripLeadingSlash(dir.sst), false, options);
 				if (sstData) {
 					strs = parseSstXml(sstData, options);
 				}
@@ -254,7 +258,7 @@ export function parseZip(zip: ZipArchive, opts?: ReadOptions): WorkBook {
 
 		// Theme (color scheme for styled cells)
 		if (dir.themes.length) {
-			const themeData = getZipString(zip, dir.themes[0].replace(/^\//, ""), true);
+			const themeData = getZipString(zip, dir.themes[0].replace(/^\//, ""), true, options);
 			if (themeData) {
 				const parsed = parse_theme_xml(themeData);
 				Object.assign(themes, parsed);
@@ -263,7 +267,7 @@ export function parseZip(zip: ZipArchive, opts?: ReadOptions): WorkBook {
 
 		// Styles (number formats, cell xf entries)
 		if (dir.style) {
-			const styData = getZipData(zip, stripLeadingSlash(dir.style));
+			const styData = getZipData(zip, stripLeadingSlash(dir.style), false, options);
 			if (styData) {
 				styles = parseStylesXml(styData, themes, options);
 			}
@@ -271,17 +275,20 @@ export function parseZip(zip: ZipArchive, opts?: ReadOptions): WorkBook {
 	}
 
 	// Parse the workbook XML (sheet list, defined names, properties)
-	const wb: WorkbookFile = parseWorkbookXml(getZipData(zip, stripLeadingSlash(dir.workbooks[0]))!, options);
+	const wb: WorkbookFile = parseWorkbookXml(
+		getZipData(zip, stripLeadingSlash(dir.workbooks[0]), false, options)!,
+		options,
+	);
 
 	// Parse document properties
 	const props: any = {};
 	if (dir.coreprops.length) {
-		const propdata = getZipData(zip, stripLeadingSlash(dir.coreprops[0]), true);
+		const propdata = getZipData(zip, stripLeadingSlash(dir.coreprops[0]), true, options);
 		if (propdata) {
 			Object.assign(props, parseCoreProperties(propdata));
 		}
 		if (dir.extprops.length) {
-			const extdata = getZipData(zip, stripLeadingSlash(dir.extprops[0]), true);
+			const extdata = getZipData(zip, stripLeadingSlash(dir.extprops[0]), true, options);
 			if (extdata) {
 				parseExtendedProperties(extdata, props);
 			}
@@ -292,7 +299,7 @@ export function parseZip(zip: ZipArchive, opts?: ReadOptions): WorkBook {
 	let custprops: Record<string, any> = {};
 	if (!options.bookSheets || options.bookProps) {
 		if (dir.custprops.length) {
-			const custdata = getZipString(zip, stripLeadingSlash(dir.custprops[0]), true);
+			const custdata = getZipString(zip, stripLeadingSlash(dir.custprops[0]), true, options);
 			if (custdata) {
 				custprops = parseCustomProperties(custdata, options);
 			}
@@ -324,7 +331,7 @@ export function parseZip(zip: ZipArchive, opts?: ReadOptions): WorkBook {
 
 	// Calculation chain (dependency order for formula recalc)
 	if (options.bookDeps && dir.calcchain) {
-		parseCalcChainXml(getZipData(zip, stripLeadingSlash(dir.calcchain), true) || "");
+		parseCalcChainXml(getZipData(zip, stripLeadingSlash(dir.calcchain), true, options) || "");
 	}
 
 	// Build the sheet name list from the workbook
@@ -347,23 +354,30 @@ export function parseZip(zip: ZipArchive, opts?: ReadOptions): WorkBook {
 	if (!zipHas(zip, wbrelsfile)) {
 		wbrelsfile = "xl/_rels/workbook.xml.rels";
 	}
-	const wbrels = parseRelationships(getZipString(zip, wbrelsfile, true), wbrelsfile.replace(/_rels.*/, "s5s"));
+	const wbrels = parseRelationships(
+		getZipString(zip, wbrelsfile, true, options),
+		wbrelsfile.replace(/_rels.*/, "s5s"),
+		options,
+	);
 
 	// Parse cell metadata (for dynamic arrays, rich data, etc.)
 	if ((dir.metadata || []).length >= 1) {
-		options.xlmeta = parseMetadataXml(getZipData(zip, stripLeadingSlash(dir.metadata[0]), true) || "", options);
+		options.xlmeta = parseMetadataXml(
+			getZipData(zip, stripLeadingSlash(dir.metadata[0]), true, options) || "",
+			options,
+		);
 	}
 
 	// Parse people list (for threaded comment author resolution)
 	if ((dir.people || []).length >= 1) {
-		options.people = parsePeopleXml(getZipData(zip, stripLeadingSlash(dir.people[0]), true) || "");
+		options.people = parsePeopleXml(getZipData(zip, stripLeadingSlash(dir.people[0]), true, options) || "");
 	}
 
 	// Map sheet entries to their ZIP paths via workbook relationships
 	const wbrelsArr = wbrels ? safe_parse_wbrels(wbrels, wb.Sheets) : null;
 
 	// Detect legacy naming: some files use "sheet.xml" instead of "sheet1.xml"
-	const nmode = getZipData(zip, "xl/worksheets/sheet.xml", true) ? 1 : 0;
+	const nmode = getZipData(zip, "xl/worksheets/sheet.xml", true, options) ? 1 : 0;
 
 	for (let i = 0; i < props.Worksheets; ++i) {
 		let stype = "sheet";

--- a/src/xlsx/shared-strings.test.ts
+++ b/src/xlsx/shared-strings.test.ts
@@ -366,6 +366,17 @@ describe("xlsx/shared-strings", () => {
 		expect(parseSstXml("")).toHaveLength(0);
 	});
 
+	it("parseSstXml should enforce XML size and shared string count limits", () => {
+		const xml = `<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+			<si><t>Hello</t></si>
+			<si><t>World</t></si>
+		</sst>`;
+		expect(() => parseSstXml(xml, { maxXmlPartBytes: 8 })).toThrow(/sharedStrings\.xml size/);
+		expect(() => parseSstXml(xml, { maxSharedStringItems: 1 })).toThrow(
+			/shared string item count .* exceeds limit 1/,
+		);
+	});
+
 	it("writeSstXml should return empty when bookSST is false", () => {
 		expect(writeSstXml([] as any, { bookSST: false })).toBe("");
 	});

--- a/src/xlsx/shared-strings.ts
+++ b/src/xlsx/shared-strings.ts
@@ -4,6 +4,15 @@ import { writeXmlElement } from "../xml/writer.js";
 import { XML_HEADER } from "../xml/parser.js";
 import { XMLNS_main } from "../xml/namespaces.js";
 import { utf8read } from "../utils/buffer.js";
+import type { XmlLimitOptions } from "../xml/limits.js";
+import {
+	assertXmlCountWithinLimit,
+	assertXmlPartLimits,
+	DEFAULT_MAX_SHARED_STRING_ITEMS,
+	xmlOptionLimit,
+} from "../xml/limits.js";
+
+type SstParseOptions = XmlLimitOptions & { cellHTML?: boolean };
 
 /** A single string entry from the shared string table */
 export interface XLString {
@@ -24,13 +33,13 @@ export interface SST extends Array<XLString> {
 }
 
 /** Parse rich-text run properties (<rPr>) into a font descriptor object */
-function parseRunProperties(rpr: string): Record<string, any> {
+function parseRunProperties(rpr: string, opts?: SstParseOptions): Record<string, any> {
 	const font: Record<string, any> = {};
 	const matches = rpr.match(XML_TAG_REGEX);
 	let pass = false;
 	if (matches) {
 		for (let i = 0; i < matches.length; ++i) {
-			const parsedTag = parseXmlTag(matches[i]);
+			const parsedTag = parseXmlTag(matches[i], undefined, undefined, opts);
 			switch ((parsedTag[0] as string).replace(/<\w*:/g, "<")) {
 				case "<condense":
 				case "<extend":
@@ -202,7 +211,7 @@ function str_remove_xml_ns_g_local(str: string, tag: string): string {
 }
 
 /** Parse a single rich-text run (<r>) element, extracting text and optional style */
-function parseRichTextRun(r: string): { t: string; v: string; s?: any } {
+function parseRichTextRun(r: string, opts?: SstParseOptions): { t: string; v: string; s?: any } {
 	const textMatch = str_match_xml_ns_local(r, "t");
 	if (!textMatch) {
 		return { t: "s", v: "" };
@@ -211,17 +220,17 @@ function parseRichTextRun(r: string): { t: string; v: string; s?: any } {
 	// Parse run properties (font/style) if present
 	const rpr = str_match_xml_ns_local(r, "rPr");
 	if (rpr) {
-		runObj.s = parseRunProperties(rpr[1]);
+		runObj.s = parseRunProperties(rpr[1], opts);
 	}
 	return runObj;
 }
 
 /** Split rich-text XML into individual runs and parse each one */
-function parseRichTextRuns(rs: string): { t: string; v: string; s?: any }[] {
+function parseRichTextRuns(rs: string, opts?: SstParseOptions): { t: string; v: string; s?: any }[] {
 	return rs
 		.replace(rregex, "")
 		.split(rend)
-		.map(parseRichTextRun)
+		.map((r) => parseRichTextRun(r, opts))
 		.filter((r) => r.v);
 }
 
@@ -293,7 +302,7 @@ const sirregex = /<(?:\w+:)?r\b[^<>]*>/;
  * Parse a single string item (<si>) from the shared string table.
  * Handles both plain text (<t>) and rich text (<r>) formats.
  */
-function parseStringItem(x: string, opts?: { cellHTML?: boolean }): XLString {
+function parseStringItem(x: string, opts?: SstParseOptions): XLString {
 	const html = opts ? opts.cellHTML !== false : true;
 	const result: any = {};
 	if (!x) {
@@ -317,7 +326,7 @@ function parseStringItem(x: string, opts?: { cellHTML?: boolean }): XLString {
 		// Join all <t> content and strip tags to get plain text
 		result.t = unescapeXml(utf8read(matches.join("").replace(XML_TAG_REGEX, "")), true);
 		if (html) {
-			result.h = richTextToHtml(parseRichTextRuns(result.r));
+			result.h = richTextToHtml(parseRichTextRuns(result.r, opts));
 		}
 	}
 	return result;
@@ -338,16 +347,23 @@ const sstr2 = /<\/(?:\w+:)?(?:si|sstItem)>/;
  * @param opts - Options controlling HTML generation (cellHTML)
  * @returns Array of parsed string entries with Count and Unique metadata
  */
-export function parseSstXml(data: string, opts?: { cellHTML?: boolean }): SST {
+export function parseSstXml(data: string, opts?: SstParseOptions): SST {
 	const strings: SST = [] as any;
 	if (!data) {
 		return strings;
 	}
+	assertXmlPartLimits("sharedStrings.xml", data, opts);
 
 	const sst = str_match_xml_ns_local(data, "sst");
 	if (sst) {
 		// Split the SST content by </si> boundaries to get individual string items
 		const stringItems = sst[1].replace(sstr1, "").split(sstr2);
+		const maxSharedStringItems = xmlOptionLimit(
+			opts?.maxSharedStringItems,
+			DEFAULT_MAX_SHARED_STRING_ITEMS,
+			"maxSharedStringItems",
+		);
+		assertXmlCountWithinLimit("shared string item", stringItems.length, maxSharedStringItems);
 		for (let i = 0; i < stringItems.length; ++i) {
 			const parsedItem = parseStringItem(stringItems[i].trim(), opts);
 			if (parsedItem != null) {
@@ -355,7 +371,7 @@ export function parseSstXml(data: string, opts?: { cellHTML?: boolean }): SST {
 			}
 		}
 		// Extract count/uniqueCount attributes from the <sst> opening tag
-		const tag = parseXmlTag(sst[0].slice(0, sst[0].indexOf(">")));
+		const tag = parseXmlTag(sst[0].slice(0, sst[0].indexOf(">")), undefined, undefined, opts);
 		strings.Count = tag.count;
 		strings.Unique = tag.uniquecount;
 	}

--- a/src/xlsx/worksheet.test.ts
+++ b/src/xlsx/worksheet.test.ts
@@ -193,6 +193,28 @@ describe("parseWorksheetXml: direct XML parsing", () => {
 		expect(ws["!autofilter"]).toBeDefined();
 	});
 
+	it("enforces worksheet row and cell scan limits", () => {
+		const rowsXml = `<?xml version="1.0"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+<sheetData>
+<row r="1"><c r="A1"><v>1</v></c></row>
+<row r="2"><c r="A2"><v>2</v></c></row>
+</sheetData>
+</worksheet>`;
+		const cellsXml = `<?xml version="1.0"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+<sheetData>
+<row r="1"><c r="A1"><v>1</v></c><c r="B1"><v>2</v></c></row>
+</sheetData>
+</worksheet>`;
+		expect(() => parseWorksheetXml(rowsXml, { maxWorksheetRows: 1 })).toThrow(
+			/worksheet row count 2 exceeds limit 1/,
+		);
+		expect(() => parseWorksheetXml(cellsXml, { maxWorksheetCells: 1 })).toThrow(
+			/worksheet cell count 2 exceeds limit 1/,
+		);
+	});
+
 	it("parses worksheet with cols (cellStyles)", () => {
 		const xml = `<?xml version="1.0"?>
 <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">

--- a/src/xlsx/worksheet.ts
+++ b/src/xlsx/worksheet.ts
@@ -3,6 +3,13 @@ import { parseXmlTag, XML_HEADER } from "../xml/parser.js";
 import { unescapeXml, escapeXml } from "../xml/escape.js";
 import { writeXmlElement } from "../xml/writer.js";
 import { XMLNS_main } from "../xml/namespaces.js";
+import {
+	assertXmlCountWithinLimit,
+	assertXmlPartLimits,
+	DEFAULT_MAX_WORKSHEET_CELLS,
+	DEFAULT_MAX_WORKSHEET_ROWS,
+	xmlOptionLimit,
+} from "../xml/limits.js";
 import { safeDecodeRange, encodeRange, encodeCell } from "../utils/cell.js";
 import { formatNumber, isDateFormat } from "../ssf/format.js";
 import { formatTable } from "../ssf/table.js";
@@ -42,15 +49,15 @@ function parseWorksheetXml_margins(tag: Record<string, any>): MarginInfo {
 }
 
 /** Parse <autoFilter> element extracting the filter reference range */
-function parseWorksheetXml_autofilter(data: string): { ref: string } {
-	const tag = parseXmlTag(data.match(/<[^>]*>/)?.[0] || "");
+function parseWorksheetXml_autofilter(data: string, opts?: any): { ref: string } {
+	const tag = parseXmlTag(data.match(/<[^>]*>/)?.[0] || "", undefined, undefined, opts);
 	return { ref: tag.ref || "" };
 }
 
 /** Parse <col> elements to populate column width and hidden state */
-function parseWorksheetXml_cols(columns: ColInfo[], cols: string[]): void {
+function parseWorksheetXml_cols(columns: ColInfo[], cols: string[], opts?: any): void {
 	for (let i = 0; i < cols.length; ++i) {
-		const tag = parseXmlTag(cols[i]);
+		const tag = parseXmlTag(cols[i], undefined, undefined, opts);
 		if (!tag.min || !tag.max) {
 			continue;
 		}
@@ -73,7 +80,7 @@ function parseWorksheetXml_cols(columns: ColInfo[], cols: string[]): void {
 	}
 }
 
-function parseWorksheetXml_views(data: string): SheetView[] | undefined {
+function parseWorksheetXml_views(data: string, opts?: any): SheetView[] | undefined {
 	const match = data.match(sheetViewRegex);
 	if (!match) {
 		return undefined;
@@ -82,7 +89,7 @@ function parseWorksheetXml_views(data: string): SheetView[] | undefined {
 	if (!pane) {
 		return undefined;
 	}
-	const tag = parseXmlTag(pane[0]);
+	const tag = parseXmlTag(pane[0], undefined, undefined, opts);
 	if (tag.state !== "frozen") {
 		return undefined;
 	}
@@ -103,9 +110,9 @@ function parseWorksheetXml_views(data: string): SheetView[] | undefined {
 }
 
 /** Parse <hyperlink> elements and attach link objects to the corresponding cells */
-function parseWorksheetXml_hlinks(s: WorkSheet, hlinks: string[], rels: Relationships): void {
+function parseWorksheetXml_hlinks(s: WorkSheet, hlinks: string[], rels: Relationships, opts?: any): void {
 	for (let i = 0; i < hlinks.length; ++i) {
-		const tag = parseXmlTag(hlinks[i]);
+		const tag = parseXmlTag(hlinks[i], undefined, undefined, opts);
 		if (!tag.ref) {
 			continue;
 		}
@@ -170,6 +177,10 @@ function parseSheetData(
 ): void {
 	const dense = s["!data"] != null;
 	const date1904 = wb?.WBProps?.date1904;
+	const maxWorksheetRows = xmlOptionLimit(opts.maxWorksheetRows, DEFAULT_MAX_WORKSHEET_ROWS, "maxWorksheetRows");
+	const maxWorksheetCells = xmlOptionLimit(opts.maxWorksheetCells, DEFAULT_MAX_WORKSHEET_CELLS, "maxWorksheetCells");
+	let rowCount = 0;
+	let cellCount = 0;
 
 	// Split by </row> boundaries to isolate each row's content
 	const rows = sdata.split(/<\/(?:\w+:)?row>/);
@@ -185,7 +196,8 @@ function parseSheetData(
 		if (!rowTagMatch) {
 			continue;
 		}
-		const rowTag = parseXmlTag(rowTagMatch[0]);
+		assertXmlCountWithinLimit("worksheet row", ++rowCount, maxWorksheetRows);
+		const rowTag = parseXmlTag(rowTagMatch[0], undefined, undefined, opts);
 		// Row numbers in XML are 1-based
 		const R = parseInt(rowTag.r, 10) - 1;
 		if (isNaN(R)) {
@@ -217,7 +229,13 @@ function parseSheetData(
 		cellregex.lastIndex = 0;
 		let cellMatch;
 		while ((cellMatch = cellregex.exec(rowStr))) {
-			const cellTag = parseXmlTag(cellMatch[0].match(/<(?:\w+:)?c\b[^>]*/)?.[0] + ">" || "");
+			assertXmlCountWithinLimit("worksheet cell", ++cellCount, maxWorksheetCells);
+			const cellTag = parseXmlTag(
+				cellMatch[0].match(/<(?:\w+:)?c\b[^>]*/)?.[0] + ">" || "",
+				undefined,
+				undefined,
+				opts,
+			);
 			const ref = cellTag.r;
 			if (!ref) {
 				continue;
@@ -336,7 +354,12 @@ function parseSheetData(
 			// Extract formula
 			if (fMatch && opts.cellFormula !== false) {
 				cell.f = unescapeXml(fMatch[1]);
-				const fTag = parseXmlTag(cellValue.match(/<(?:\w+:)?f[^>]*/)?.[0] + ">" || "");
+				const fTag = parseXmlTag(
+					cellValue.match(/<(?:\w+:)?f[^>]*/)?.[0] + ">" || "",
+					undefined,
+					undefined,
+					opts,
+				);
 				if (fTag.t === "shared" && fTag.si != null) {
 					// Shared formula (master or reference)
 				}
@@ -471,6 +494,7 @@ export function parseWorksheetXml(
 	if (!opts) {
 		opts = {};
 	}
+	assertXmlPartLimits("worksheet.xml", data, opts);
 	if (!rels) {
 		rels = { "!id": {} } as any;
 	}
@@ -504,9 +528,9 @@ export function parseWorksheetXml(
 	if (opts.cellStyles) {
 		const cols = data1.match(colregex);
 		if (cols) {
-			parseWorksheetXml_cols(columns, cols);
+			parseWorksheetXml_cols(columns, cols, opts);
 		}
-		const views = parseWorksheetXml_views(data1);
+		const views = parseWorksheetXml_views(data1, opts);
 		if (views) {
 			s["!views"] = views;
 		}
@@ -520,7 +544,7 @@ export function parseWorksheetXml(
 	// AutoFilter
 	const afilter = data2.match(afregex);
 	if (afilter) {
-		s["!autofilter"] = parseWorksheetXml_autofilter(afilter[0]);
+		s["!autofilter"] = parseWorksheetXml_autofilter(afilter[0], opts);
 	}
 
 	// Merged cells
@@ -536,13 +560,13 @@ export function parseWorksheetXml(
 	// Hyperlinks
 	const hlink = data2.match(hlinkregex);
 	if (hlink) {
-		parseWorksheetXml_hlinks(s, hlink, rels!);
+		parseWorksheetXml_hlinks(s, hlink, rels!, opts);
 	}
 
 	// Page margins
 	const margins = data2.match(marginregex);
 	if (margins) {
-		s["!margins"] = parseWorksheetXml_margins(parseXmlTag(margins[0]));
+		s["!margins"] = parseWorksheetXml_margins(parseXmlTag(margins[0], undefined, undefined, opts));
 	}
 
 	// Legacy drawing reference (for VML comment shapes)

--- a/src/xml/limits.ts
+++ b/src/xml/limits.ts
@@ -1,0 +1,89 @@
+/** Limits applied while reading XML-based workbook parts. */
+export interface XmlLimitOptions {
+	/** Maximum decoded XML part size. */
+	maxXmlPartBytes?: number;
+	/** Maximum number of raw XML tags in a single part. */
+	maxXmlTags?: number;
+	/** Maximum nesting depth for XML elements in a single part. */
+	maxXmlNestingDepth?: number;
+	/** Maximum number of characters in a single XML tag. */
+	maxXmlTagLength?: number;
+	/** Maximum number of attributes in a single XML tag. */
+	maxXmlAttributesPerTag?: number;
+	/** Maximum number of shared string items to parse. */
+	maxSharedStringItems?: number;
+	/** Maximum number of worksheet row elements to scan. */
+	maxWorksheetRows?: number;
+	/** Maximum number of worksheet cell elements to scan. */
+	maxWorksheetCells?: number;
+}
+
+export const DEFAULT_MAX_XML_PART_BYTES = 128 * 1024 * 1024;
+export const DEFAULT_MAX_XML_TAGS = 5_000_000;
+export const DEFAULT_MAX_XML_NESTING_DEPTH = 256;
+export const DEFAULT_MAX_XML_TAG_LENGTH = 1024 * 1024;
+export const DEFAULT_MAX_XML_ATTRIBUTES_PER_TAG = 10_000;
+export const DEFAULT_MAX_SHARED_STRING_ITEMS = 1_000_000;
+export const DEFAULT_MAX_WORKSHEET_ROWS = 1_048_576;
+export const DEFAULT_MAX_WORKSHEET_CELLS = 10_000_000;
+
+export function xmlOptionLimit(value: number | undefined, fallback: number, name: string): number {
+	if (value == null) {
+		return fallback;
+	}
+	if (!Number.isFinite(value) || value < 0) {
+		throw new Error(`Invalid XML option: ${name} must be a non-negative finite number`);
+	}
+	return value;
+}
+
+export function assertXmlCountWithinLimit(kind: string, count: number, limit: number): void {
+	if (count > limit) {
+		throw new Error(`Invalid XML: ${kind} count ${count} exceeds limit ${limit}`);
+	}
+}
+
+export function assertXmlPartLimits(partName: string, data: string, opts?: XmlLimitOptions): void {
+	const maxXmlPartBytes = xmlOptionLimit(opts?.maxXmlPartBytes, DEFAULT_MAX_XML_PART_BYTES, "maxXmlPartBytes");
+	if (data.length > maxXmlPartBytes) {
+		throw new Error(`Invalid XML: ${partName} size ${data.length} exceeds limit ${maxXmlPartBytes}`);
+	}
+
+	const maxXmlTags = xmlOptionLimit(opts?.maxXmlTags, DEFAULT_MAX_XML_TAGS, "maxXmlTags");
+	const maxXmlNestingDepth = xmlOptionLimit(
+		opts?.maxXmlNestingDepth,
+		DEFAULT_MAX_XML_NESTING_DEPTH,
+		"maxXmlNestingDepth",
+	);
+	const maxXmlTagLength = xmlOptionLimit(opts?.maxXmlTagLength, DEFAULT_MAX_XML_TAG_LENGTH, "maxXmlTagLength");
+	let tagCount = 0;
+	let depth = 0;
+	let offset = -1;
+	while ((offset = data.indexOf("<", offset + 1)) !== -1) {
+		assertXmlCountWithinLimit(`${partName} tag`, ++tagCount, maxXmlTags);
+		const closeOffset = data.indexOf(">", offset + 1);
+		const tagLength = closeOffset === -1 ? data.length - offset : closeOffset - offset + 1;
+		if (tagLength > maxXmlTagLength) {
+			throw new Error(`Invalid XML: ${partName} tag length ${tagLength} exceeds limit ${maxXmlTagLength}`);
+		}
+		if (closeOffset === -1) {
+			break;
+		}
+		let tagStart = offset + 1;
+		while (tagStart < closeOffset && data.charCodeAt(tagStart) <= 32) {
+			++tagStart;
+		}
+		const first = data.charCodeAt(tagStart);
+		const isClosingTag = first === 47;
+		const isProcessingOrDeclaration = first === 33 || first === 63;
+		const isSelfClosing = data.charCodeAt(closeOffset - 1) === 47;
+		if (isClosingTag) {
+			depth = Math.max(0, depth - 1);
+		} else if (!isProcessingOrDeclaration && !isSelfClosing) {
+			if (++depth > maxXmlNestingDepth) {
+				throw new Error(`Invalid XML: ${partName} nesting depth ${depth} exceeds limit ${maxXmlNestingDepth}`);
+			}
+		}
+		offset = closeOffset;
+	}
+}

--- a/src/xml/parser.ts
+++ b/src/xml/parser.ts
@@ -1,3 +1,6 @@
+import type { XmlLimitOptions } from "./limits.js";
+import { assertXmlCountWithinLimit, DEFAULT_MAX_XML_ATTRIBUTES_PER_TAG, xmlOptionLimit } from "./limits.js";
+
 // Matches attribute key="value" pairs within an XML tag. Captures the attribute
 // name, then handles double-quoted, single-quoted, or unquoted values.
 const attregexg = /\s([^"\s?>/]+)\s*=\s*((?:")([^"]*)(?:")|(?:')([^']*)(?:')|([^'">\s]+))/g;
@@ -26,9 +29,15 @@ const nsregex2 = /<(\/?)\w+:/;
  * @param tag - the raw XML tag string (e.g., `<Relationship Id="rId1" Target="..."/>`)
  * @param skip_root - if true, do not store the tag name under key `0`
  * @param skip_LC - if true, do not store lowercase copies of attribute names
+ * @param opts - XML parsing limits
  * @returns a record mapping attribute names to their values
  */
-export function parseXmlTag(tag: string, skip_root?: boolean, skip_LC?: boolean): Record<string, any> {
+export function parseXmlTag(
+	tag: string,
+	skip_root?: boolean,
+	skip_LC?: boolean,
+	opts?: XmlLimitOptions,
+): Record<string, any> {
 	const attrs: Record<string, any> = {};
 	let scanPos = 0;
 	let charCode = 0;
@@ -44,56 +53,62 @@ export function parseXmlTag(tag: string, skip_root?: boolean, skip_LC?: boolean)
 	if (scanPos === tag.length) {
 		return attrs;
 	}
-	const matches = tag.match(attregexg);
-	if (matches) {
-		for (let i = 0; i < matches.length; ++i) {
-			// Strip the leading whitespace character captured by the regex
-			const attrStr = matches[i].slice(1);
-			let eqPos = 0;
-			// Find the '=' separator (charCode 61)
-			for (eqPos = 0; eqPos < attrStr.length; ++eqPos) {
-				if (attrStr.charCodeAt(eqPos) === 61) {
-					break;
-				}
+	const maxXmlAttributesPerTag = xmlOptionLimit(
+		opts?.maxXmlAttributesPerTag,
+		DEFAULT_MAX_XML_ATTRIBUTES_PER_TAG,
+		"maxXmlAttributesPerTag",
+	);
+	attregexg.lastIndex = 0;
+	let attrMatch: RegExpExecArray | null;
+	let attrCount = 0;
+	while ((attrMatch = attregexg.exec(tag))) {
+		assertXmlCountWithinLimit("XML attribute", ++attrCount, maxXmlAttributesPerTag);
+		// Strip the leading whitespace character captured by the regex
+		const attrStr = attrMatch[0].slice(1);
+		let eqPos = 0;
+		// Find the '=' separator (charCode 61)
+		for (eqPos = 0; eqPos < attrStr.length; ++eqPos) {
+			if (attrStr.charCodeAt(eqPos) === 61) {
+				break;
 			}
-			let attrName = attrStr.slice(0, eqPos).trim();
-			// Skip any spaces between '=' and the value
-			while (attrStr.charCodeAt(eqPos + 1) === 32) {
-				++eqPos;
-			}
-			// Detect and skip surrounding quotes (charCode 34=" or 39=')
-			const quoteOffset = (scanPos = attrStr.charCodeAt(eqPos + 1)) === 34 || scanPos === 39 ? 1 : 0;
-			const attrValue = attrStr.slice(eqPos + 1 + quoteOffset, attrStr.length - quoteOffset);
+		}
+		let attrName = attrStr.slice(0, eqPos).trim();
+		// Skip any spaces between '=' and the value
+		while (attrStr.charCodeAt(eqPos + 1) === 32) {
+			++eqPos;
+		}
+		// Detect and skip surrounding quotes (charCode 34=" or 39=')
+		const quoteOffset = (scanPos = attrStr.charCodeAt(eqPos + 1)) === 34 || scanPos === 39 ? 1 : 0;
+		const attrValue = attrStr.slice(eqPos + 1 + quoteOffset, attrStr.length - quoteOffset);
 
-			// Check for namespace prefix by finding ':' (charCode 58)
-			let colonPos = 0;
-			for (colonPos = 0; colonPos < attrName.length; ++colonPos) {
-				if (attrName.charCodeAt(colonPos) === 58) {
-					break;
-				}
+		// Check for namespace prefix by finding ':' (charCode 58)
+		let colonPos = 0;
+		for (colonPos = 0; colonPos < attrName.length; ++colonPos) {
+			if (attrName.charCodeAt(colonPos) === 58) {
+				break;
 			}
-			if (colonPos === attrName.length) {
-				// No namespace prefix -- truncate at underscore if present (handles extended names)
-				if (attrName.indexOf("_") > 0) {
-					attrName = attrName.slice(0, attrName.indexOf("_"));
-				}
-				attrs[attrName] = attrValue;
-				if (!skip_LC) {
-					attrs[attrName.toLowerCase()] = attrValue;
-				}
-			} else {
-				// Has namespace prefix -- extract the local name.
-				// Special case: "xmlns:foo" keeps "xmlns" prefix for the local name.
-				const localName =
-					(colonPos === 5 && attrName.slice(0, 5) === "xmlns" ? "xmlns" : "") + attrName.slice(colonPos + 1);
-				// Skip "ext" namespace attributes if a non-ext value already exists
-				if (attrs[localName] && attrName.slice(colonPos - 3, colonPos) === "ext") {
-					continue;
-				}
-				attrs[localName] = attrValue;
-				if (!skip_LC) {
-					attrs[localName.toLowerCase()] = attrValue;
-				}
+		}
+		if (colonPos === attrName.length) {
+			// No namespace prefix -- truncate at underscore if present (handles extended names)
+			if (attrName.indexOf("_") > 0) {
+				attrName = attrName.slice(0, attrName.indexOf("_"));
+			}
+			attrs[attrName] = attrValue;
+			if (!skip_LC) {
+				attrs[attrName.toLowerCase()] = attrValue;
+			}
+		} else {
+			// Has namespace prefix -- extract the local name.
+			// Special case: "xmlns:foo" keeps "xmlns" prefix for the local name.
+			const localName =
+				(colonPos === 5 && attrName.slice(0, 5) === "xmlns" ? "xmlns" : "") + attrName.slice(colonPos + 1);
+			// Skip "ext" namespace attributes if a non-ext value already exists
+			if (attrs[localName] && attrName.slice(colonPos - 3, colonPos) === "ext") {
+				continue;
+			}
+			attrs[localName] = attrValue;
+			if (!skip_LC) {
+				attrs[localName.toLowerCase()] = attrValue;
 			}
 		}
 	}

--- a/src/xml/xml.test.ts
+++ b/src/xml/xml.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { escapeXml, unescapeXml, escapeHtml, htmlDecode, escapeXmlTag } from "./escape.js";
 import { parseXmlTag, parseXmlBoolean, stripNamespace } from "./parser.js";
+import { assertXmlPartLimits } from "./limits.js";
 
 describe("escapeXml", () => {
 	it("should escape ampersand", () => {
@@ -127,6 +128,44 @@ describe("parseXmlTag", () => {
 	it("should strip namespace prefixes from attributes", () => {
 		const result = parseXmlTag('tag r:id="rId1"');
 		expect(result["id"]).toBe("rId1");
+	});
+
+	it("should enforce the configured attribute limit", () => {
+		expect(() =>
+			parseXmlTag('tag first="1" second="2"', undefined, undefined, { maxXmlAttributesPerTag: 1 }),
+		).toThrow(/XML attribute count 2 exceeds limit 1/);
+	});
+
+	it("should reject invalid XML limit options", () => {
+		expect(() => parseXmlTag('tag id="1"', undefined, undefined, { maxXmlAttributesPerTag: -1 })).toThrow(
+			/maxXmlAttributesPerTag/,
+		);
+	});
+});
+
+describe("assertXmlPartLimits", () => {
+	it("should enforce decoded XML part size", () => {
+		expect(() => {
+			assertXmlPartLimits("sheet.xml", "<a/>", { maxXmlPartBytes: 3 });
+		}).toThrow(/sheet\.xml size 4 exceeds limit 3/);
+	});
+
+	it("should enforce XML tag count", () => {
+		expect(() => {
+			assertXmlPartLimits("sheet.xml", "<a/><b/>", { maxXmlTags: 1 });
+		}).toThrow(/sheet\.xml tag count 2 exceeds limit 1/);
+	});
+
+	it("should enforce XML nesting depth", () => {
+		expect(() => {
+			assertXmlPartLimits("sheet.xml", "<a><b></b></a>", { maxXmlNestingDepth: 1 });
+		}).toThrow(/sheet\.xml nesting depth 2 exceeds limit 1/);
+	});
+
+	it("should enforce XML tag length", () => {
+		expect(() => {
+			assertXmlPartLimits("sheet.xml", `<${"a".repeat(8)}>`, { maxXmlTagLength: 4 });
+		}).toThrow(/sheet\.xml tag length 10 exceeds limit 4/);
 	});
 });
 


### PR DESCRIPTION
## Summary
- add configurable XML parser limits for part size, tag count, nesting depth, tag length, attributes, shared strings, worksheet rows, and worksheet cells
- enforce XML part limits at ZIP read boundaries and in direct worksheet/shared-string parsing paths
- add adversarial parser tests and document recommended limit tuning for untrusted uploads

Closes #25

## Verification
- pnpm run verify