### PR TITLE
fix(pkg): expose package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
 				"types": "./dist/index.d.cts",
 				"default": "./dist/index.cjs"
 			}
-		}
+		},
+		"./package.json": "./package.json"
 	},
 	"files": [
 		"dist",
@@ -83,5 +84,6 @@
 	"bugs": {
 		"url": "https://github.com/sebastian-software/xlsx-format/issues"
 	},
-	"homepage": "https://github.com/sebastian-software/xlsx-format"
+	"homepage": "https://github.com/sebastian-software/xlsx-format",
+	"funding": "https://github.com/sebastian-software/xlsx-format"
 }


### PR DESCRIPTION
## What

- Add the `./package.json` subpath export so tooling can resolve package metadata when `exports` is present.
- Add a `funding` field for npm and `npm fund` discovery.

## Why

Closes #42.

## Validation

- `pnpm run package:check`
- `pnpm run verify`
- Push hook: `tsc --noEmit`, `eslint src/`, `prettier --check src/`

## Checklist

- [x] Tests added or updated (metadata-only change; existing package checks cover it)
- [x] `npm run check` passes (`pnpm run verify`)
- [x] `npm run lint` passes (`pnpm run verify`)
- [x] `npm test` passes (`pnpm run verify`)
- [x] Commit messages follow Conventional Commits