### PR TITLE
feat(api): add typed error codes

### DIFF
--- a/docs/app/routes/guide/security.mdx
+++ b/docs/app/routes/guide/security.mdx
@@ -43,6 +43,40 @@ const previewRows = sheetToJson(firstSheet);
 
 The default ZIP and XML limits are intentionally high enough for ordinary workbooks. Lower them when a service receives arbitrary uploads and does not need to parse very large sheets.
 
+## Handling errors
+
+xlsx-format throws `XlsxError`, a subclass of `Error`, for deterministic library failures. Existing `catch` blocks keep working, but new integrations should branch on `error.code` instead of matching message text.
+
+```typescript
+import { read, XlsxError } from "xlsx-format";
+
+try {
+	const workbook = await read(fileBytes);
+} catch (error) {
+	if (error instanceof XlsxError) {
+		if (error.code === "MALFORMED" || error.code === "CRC_MISMATCH") {
+			// Reject corrupt uploads.
+		}
+		if (error.code === "LIMIT_EXCEEDED") {
+			// Keep public upload limits low, or retry trusted files with higher ReadOptions limits.
+		}
+	}
+	throw error;
+}
+```
+
+Stable error codes:
+
+| Code               | Meaning                                                          |
+| ------------------ | ---------------------------------------------------------------- |
+| `INVALID_ARGUMENT` | Caller-supplied options or API inputs are invalid.               |
+| `MALFORMED`        | The workbook, ZIP, XML, or format structure is corrupt.          |
+| `LIMIT_EXCEEDED`   | A configured ZIP, XML, worksheet, or shared-string limit failed. |
+| `UNSUPPORTED`      | The input uses a valid but unsupported format or feature.        |
+| `CRC_MISMATCH`     | ZIP entry data failed its CRC integrity check.                   |
+| `NOT_FOUND`        | A required workbook part or worksheet reference is missing.      |
+| `DUPLICATE`        | A workbook or archive structure contains a duplicate entry.      |
+
 ## Exporting CSV
 
 CSV files opened in spreadsheet applications can interpret text that starts with characters such as `=`, `+`, `-`, `@`, tab, or carriage return as formulas. This is commonly called CSV injection or formula injection.

--- a/src/api/aoa.ts
+++ b/src/api/aoa.ts
@@ -1,4 +1,5 @@
 import type { WorkSheet, AOA2SheetOpts, Range, Sheet2JSONOpts } from "../types.js";
+import { XlsxError } from "../errors.js";
 import { decodeCell, encodeRange, safeDecodeRange, getCell, setCell } from "../utils/cell.js";
 import { dateToSerialNumber, localToUtc } from "../utils/date.js";
 import { formatNumber } from "../ssf/format.js";
@@ -61,7 +62,7 @@ export function addArrayToSheet(worksheet: WorkSheet | null, data: any[][], opts
 			continue;
 		}
 		if (!Array.isArray(data[rowIdx])) {
-			throw new Error("arrayToSheet expects an array of arrays");
+			throw new XlsxError("INVALID_ARGUMENT", "arrayToSheet expects an array of arrays");
 		}
 		const targetRow = originRow + rowIdx;
 		const rowData = data[rowIdx];

--- a/src/api/book.ts
+++ b/src/api/book.ts
@@ -1,4 +1,5 @@
 import type { WorkBook, WorkSheet, CellObject, Hyperlink, CellStyle, Range } from "../types.js";
+import { XlsxError } from "../errors.js";
 import { validateSheetName } from "../xlsx/workbook.js";
 import {
 	encodeCol,
@@ -49,7 +50,7 @@ export function appendSheet(wb: WorkBook, ws: WorkSheet, name?: string, roll?: b
 		}
 	}
 	if (!name || wb.SheetNames.length >= 0xffff) {
-		throw new Error("Too many worksheets");
+		throw new XlsxError("LIMIT_EXCEEDED", "Too many worksheets");
 	}
 	// When rolling, strip any trailing digits and increment to find a unique name
 	if (roll && wb.SheetNames.indexOf(name) >= 0 && name.length < 32) {
@@ -64,7 +65,7 @@ export function appendSheet(wb: WorkBook, ws: WorkSheet, name?: string, roll?: b
 	}
 	validateSheetName(name);
 	if (wb.SheetNames.indexOf(name) >= 0) {
-		throw new Error("Worksheet with name |" + name + "| already exists!");
+		throw new XlsxError("DUPLICATE", "Worksheet with name |" + name + "| already exists!");
 	}
 
 	wb.SheetNames.push(name);
@@ -99,15 +100,15 @@ export function getSheetIndex(wb: WorkBook, sh: number | string): number {
 		if (sh >= 0 && wb.SheetNames.length > sh) {
 			return sh;
 		}
-		throw new Error("Cannot find sheet # " + sh);
+		throw new XlsxError("NOT_FOUND", "Cannot find sheet # " + sh);
 	} else if (typeof sh === "string") {
 		const idx = wb.SheetNames.indexOf(sh);
 		if (idx > -1) {
 			return idx;
 		}
-		throw new Error("Cannot find sheet name |" + sh + "|");
+		throw new XlsxError("NOT_FOUND", "Cannot find sheet name |" + sh + "|");
 	}
-	throw new Error("Cannot find sheet |" + sh + "|");
+	throw new XlsxError("NOT_FOUND", "Cannot find sheet |" + sh + "|");
 }
 
 /**
@@ -138,7 +139,7 @@ export function setSheetVisibility(wb: WorkBook, sh: number | string, vis: 0 | 1
 		case 2:
 			break;
 		default:
-			throw new Error("Bad sheet visibility setting " + vis);
+			throw new XlsxError("INVALID_ARGUMENT", "Bad sheet visibility setting " + vis);
 	}
 	wb.Workbook.Sheets[idx].Hidden = vis;
 }

--- a/src/api/json.ts
+++ b/src/api/json.ts
@@ -1,4 +1,5 @@
 import type { WorkSheet, Sheet2JSONOpts, JSON2SheetOpts, CellObject, Range } from "../types.js";
+import { XlsxError } from "../errors.js";
 import { decodeCell, encodeCol, encodeRow, encodeRange, safeDecodeRange, getCell } from "../utils/cell.js";
 import { dateToSerialNumber, serialNumberToDate, utcToLocal, localToUtc } from "../utils/date.js";
 import { clampLargeExportRange } from "../utils/export-range.js";
@@ -88,7 +89,7 @@ function buildJsonRow(
 				}
 				break;
 			default:
-				throw new Error("unrecognized type " + val.t);
+				throw new XlsxError("INVALID_ARGUMENT", "unrecognized type " + val.t);
 		}
 		if (headers[colIdx] != null) {
 			if (cellValue == null) {

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, it } from "vitest";
+import {
+	appendSheet,
+	createSheet,
+	createWorkbook,
+	getSheetIndex,
+	read,
+	setSheetVisibility,
+	sheetToJson,
+	XlsxError,
+} from "./index.js";
+import { parseContentTypes } from "./opc/content-types.js";
+import { formatNumber } from "./ssf/format.js";
+import type { CellStyle, WorkBook, WorkSheet } from "./types.js";
+import { parseZip } from "./xlsx/parse-zip.js";
+import { parseSstXml } from "./xlsx/shared-strings.js";
+import { buildStyleRegistry } from "./xlsx/styles.js";
+import { zipRead, zipWrite } from "./zip/index.js";
+
+const encoder = new TextEncoder();
+
+function bytes(text: string): Uint8Array {
+	return encoder.encode(text);
+}
+
+function readU16(data: Uint8Array, off: number): number {
+	return data[off] | (data[off + 1] << 8);
+}
+
+function readU32(data: Uint8Array, off: number): number {
+	return (data[off] | (data[off + 1] << 8) | (data[off + 2] << 16) | (data[off + 3] << 24)) >>> 0;
+}
+
+function writeU16(data: Uint8Array, off: number, value: number): void {
+	data[off] = value & 0xff;
+	data[off + 1] = (value >> 8) & 0xff;
+}
+
+function writeU32(data: Uint8Array, off: number, value: number): void {
+	data[off] = value & 0xff;
+	data[off + 1] = (value >> 8) & 0xff;
+	data[off + 2] = (value >> 16) & 0xff;
+	data[off + 3] = (value >> 24) & 0xff;
+}
+
+function findEocd(data: Uint8Array): number {
+	for (let i = data.length - 22; i >= 0; --i) {
+		if (readU32(data, i) === 0x06054b50) {
+			return i;
+		}
+	}
+	throw new Error("EOCD not found in test archive");
+}
+
+async function expectXlsxError(promise: Promise<unknown>, code: XlsxError["code"], message: RegExp): Promise<void> {
+	await expect(promise).rejects.toBeInstanceOf(XlsxError);
+	await expect(promise).rejects.toMatchObject({ code });
+	await expect(promise).rejects.toThrow(message);
+}
+
+function expectSyncXlsxError(action: () => unknown, code: XlsxError["code"], message: RegExp): void {
+	let error: unknown;
+	try {
+		action();
+	} catch (caught) {
+		error = caught;
+	}
+
+	expect(error).toBeInstanceOf(XlsxError);
+	expect(error).toMatchObject({ code });
+	expect((error as Error).message).toMatch(message);
+}
+
+function workbookWithStyle(style: CellStyle): WorkBook {
+	const ws: WorkSheet = {
+		"!ref": "A1",
+		A1: { t: "s", v: "styled", s: style },
+	};
+	return createWorkbook(ws, "Styles");
+}
+
+describe("XlsxError", () => {
+	it("exposes stable code metadata", () => {
+		const cause = new Error("source");
+		const error = new XlsxError("MALFORMED", "Invalid workbook", { cause });
+
+		expect(error).toBeInstanceOf(Error);
+		expect(error).toBeInstanceOf(XlsxError);
+		expect(error.name).toBe("XlsxError");
+		expect(error.code).toBe("MALFORMED");
+		expect(error.message).toBe("Invalid workbook");
+		expect(error.cause).toBe(cause);
+	});
+
+	it("classifies read() argument and file format failures", async () => {
+		await expectXlsxError(read(123), "INVALID_ARGUMENT", /Unsupported data type/);
+		await expectXlsxError(read(new Uint8Array([0x25, 0x50, 0x44, 0x46])), "UNSUPPORTED", /PDF/);
+	});
+
+	it("classifies malformed ZIP data and resource limits", async () => {
+		await expectXlsxError(zipRead(new Uint8Array([0x50, 0x4b])), "MALFORMED", /EOCD not found/);
+
+		const archive = await zipWrite({
+			files: {
+				"a.txt": bytes("a"),
+				"b.txt": bytes("b"),
+			},
+		});
+
+		await expectXlsxError(zipRead(archive, { maxZipEntries: 1 }), "LIMIT_EXCEEDED", /entry count 2/);
+	});
+
+	it("classifies ZIP CRC mismatches", async () => {
+		const archive = await zipWrite({ files: { "a.txt": bytes("a") } });
+		const corrupted = archive.slice();
+		const nameLength = readU16(corrupted, 26);
+		const extraLength = readU16(corrupted, 28);
+		corrupted[30 + nameLength + extraLength] ^= 0xff;
+
+		await expectXlsxError(zipRead(corrupted), "CRC_MISMATCH", /CRC mismatch/);
+	});
+
+	it("classifies additional ZIP structure failures", async () => {
+		const archive = await zipWrite({ files: { "a.txt": bytes("abcd") } });
+		const eocd = findEocd(archive);
+		const centralDirectoryOffset = readU32(archive, eocd + 16);
+
+		const overlappingCentralDirectory = archive.slice();
+		writeU32(overlappingCentralDirectory, eocd + 12, 1);
+		writeU32(overlappingCentralDirectory, eocd + 16, eocd);
+		await expectXlsxError(zipRead(overlappingCentralDirectory), "MALFORMED", /central directory overlaps EOCD/);
+
+		const truncatedCentralDirectoryHeader = archive.slice();
+		writeU32(truncatedCentralDirectoryHeader, eocd + 12, 1);
+		await expectXlsxError(
+			zipRead(truncatedCentralDirectoryHeader),
+			"MALFORMED",
+			/central directory entry exceeds declared size/,
+		);
+
+		const truncatedCentralDirectoryEntry = archive.slice();
+		writeU32(truncatedCentralDirectoryEntry, eocd + 12, 46);
+		await expectXlsxError(
+			zipRead(truncatedCentralDirectoryEntry),
+			"MALFORMED",
+			/central directory entry exceeds declared size/,
+		);
+
+		const badCentralDirectorySignature = archive.slice();
+		writeU32(badCentralDirectorySignature, centralDirectoryOffset, 0);
+		await expectXlsxError(zipRead(badCentralDirectorySignature), "MALFORMED", /bad central directory entry/);
+
+		const multiDiskCentralDirectoryEntry = archive.slice();
+		writeU16(multiDiskCentralDirectoryEntry, centralDirectoryOffset + 34, 1);
+		await expectXlsxError(zipRead(multiDiskCentralDirectoryEntry), "UNSUPPORTED", /multi-disk archives/);
+
+		const badLocalHeaderSignature = archive.slice();
+		writeU32(badLocalHeaderSignature, 0, 0);
+		await expectXlsxError(zipRead(badLocalHeaderSignature), "MALFORMED", /bad local file header/);
+
+		const deflated = await zipWrite({ files: { "a.txt": bytes("abcd") } }, true);
+		const deflatedEocd = findEocd(deflated);
+		const deflatedCentralDirectoryOffset = readU32(deflated, deflatedEocd + 16);
+		const mismatchedInflatedSize = deflated.slice();
+		writeU32(mismatchedInflatedSize, deflatedCentralDirectoryOffset + 24, 5);
+		await expectXlsxError(zipRead(mismatchedInflatedSize), "MALFORMED", /inflated to 4 bytes, expected 5/);
+	});
+
+	it("classifies workbook and sheet API failures", () => {
+		const fullWorkbook: WorkBook = {
+			SheetNames: Array.from({ length: 0xffff }, (_, index) => "Sheet" + index),
+			Sheets: {},
+		};
+		expectSyncXlsxError(
+			() => appendSheet(fullWorkbook, createSheet(), "Overflow"),
+			"LIMIT_EXCEEDED",
+			/Too many worksheets/,
+		);
+
+		const wb = createWorkbook(createSheet(), "A");
+		expectSyncXlsxError(() => appendSheet(wb, createSheet(), "A"), "DUPLICATE", /already exists/);
+		expectSyncXlsxError(() => getSheetIndex(wb, "missing"), "NOT_FOUND", /Cannot find sheet name \|missing\|/);
+		expectSyncXlsxError(() => getSheetIndex(wb, true as any), "NOT_FOUND", /Cannot find sheet \|true\|/);
+		expectSyncXlsxError(
+			() => {
+				setSheetVisibility(wb, "A", 3 as any);
+			},
+			"INVALID_ARGUMENT",
+			/Bad sheet visibility/,
+		);
+	});
+
+	it("classifies malformed worksheet and package metadata", () => {
+		expectSyncXlsxError(
+			() => sheetToJson({ "!ref": "A1", A1: { t: "x" as any, v: 1 } }, { header: 1 }),
+			"INVALID_ARGUMENT",
+			/unrecognized type x/,
+		);
+		expectSyncXlsxError(
+			() => parseContentTypes('<Types xmlns="urn:unknown"></Types>'),
+			"UNSUPPORTED",
+			/Unknown Namespace/,
+		);
+		expectSyncXlsxError(
+			() =>
+				parseSstXml(
+					'<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><si><r><rPr><foo/></rPr><t>x</t></r></si></sst>',
+				),
+			"UNSUPPORTED",
+			/Unrecognized rich format/,
+		);
+	});
+
+	it("classifies SSF format failures", () => {
+		expectSyncXlsxError(() => formatNumber("General", (() => 1) as any), "UNSUPPORTED", /unsupported value/);
+		expectSyncXlsxError(() => formatNumber("hhh AM/PM", 0.5), "MALFORMED", /bad hour format/);
+		expectSyncXlsxError(() => formatNumber("hhh", 0.5), "MALFORMED", /bad hour format/);
+		expectSyncXlsxError(() => formatNumber("h:mmm", 0.5), "MALFORMED", /bad minute format/);
+		expectSyncXlsxError(() => formatNumber("sss", 0.5), "MALFORMED", /bad second format/);
+		expectSyncXlsxError(() => formatNumber("[hhh]", 0.5), "MALFORMED", /bad abstime format/);
+		expectSyncXlsxError(() => formatNumber("0,0", 1), "UNSUPPORTED", /unsupported format \|0,0\|/);
+		expectSyncXlsxError(() => formatNumber("0,0", 1.5), "UNSUPPORTED", /unsupported format \|0,0\|/);
+		expectSyncXlsxError(() => formatNumber("Gx", 1), "MALFORMED", /unrecognized character G/);
+		expectSyncXlsxError(() => formatNumber("[Red", 1), "MALFORMED", /unterminated "\[" block/);
+		expectSyncXlsxError(() => formatNumber("0Q", 1), "MALFORMED", /unrecognized character Q/);
+		expectSyncXlsxError(() => formatNumber("0;0;0;@;0", 1), "MALFORMED", /cannot find right format/);
+	});
+
+	it("classifies XLSX package structure failures", () => {
+		expectSyncXlsxError(() => parseZip({ files: {} }), "UNSUPPORTED", /Unsupported ZIP file/);
+
+		const emptyContentTypes =
+			'<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"></Types>';
+		expectSyncXlsxError(
+			() => parseZip({ files: { "[Content_Types].xml": bytes(emptyContentTypes) } }),
+			"NOT_FOUND",
+			/Could not find workbook/,
+		);
+
+		const missingWorkbook =
+			'<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/></Types>';
+		expectSyncXlsxError(
+			() => parseZip({ files: { "[Content_Types].xml": bytes(missingWorkbook) } }),
+			"NOT_FOUND",
+			/Could not find xl\/workbook\.xml/,
+		);
+	});
+
+	it("classifies strict style serialization failures", () => {
+		expectSyncXlsxError(
+			() => buildStyleRegistry(workbookWithStyle({ font: { color: { argb: "not-a-color" } } }), { WTF: true }),
+			"UNSUPPORTED",
+			/Unsupported style color/,
+		);
+		expectSyncXlsxError(
+			() =>
+				buildStyleRegistry(
+					workbookWithStyle({ fill: { patternType: "darkGrid" as any, fgColor: { argb: "FFFFFFFF" } } }),
+					{ WTF: true },
+				),
+			"UNSUPPORTED",
+			/Unsupported fill pattern/,
+		);
+		expectSyncXlsxError(
+			() => buildStyleRegistry(workbookWithStyle({ border: { top: { style: "dashed" as any } } }), { WTF: true }),
+			"UNSUPPORTED",
+			/Unsupported border style/,
+		);
+		expectSyncXlsxError(
+			() => buildStyleRegistry(workbookWithStyle({ alignment: { horizontal: "justify" as any } }), { WTF: true }),
+			"UNSUPPORTED",
+			/Unsupported horizontal alignment/,
+		);
+		expectSyncXlsxError(
+			() => buildStyleRegistry(workbookWithStyle({ alignment: { vertical: "justify" as any } }), { WTF: true }),
+			"UNSUPPORTED",
+			/Unsupported vertical alignment/,
+		);
+	});
+});

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,26 @@
+/**
+ * Stable failure categories exposed by {@link XlsxError}.
+ *
+ * Codes are intentionally broader than individual messages so callers can
+ * handle failures without depending on human-readable text.
+ */
+export type XlsxErrorCode =
+	| "INVALID_ARGUMENT"
+	| "MALFORMED"
+	| "LIMIT_EXCEEDED"
+	| "UNSUPPORTED"
+	| "CRC_MISMATCH"
+	| "NOT_FOUND"
+	| "DUPLICATE";
+
+/** Error subclass thrown by xlsx-format for deterministic failure handling. */
+export class XlsxError extends Error {
+	readonly code: XlsxErrorCode;
+
+	constructor(code: XlsxErrorCode, message: string, options?: ErrorOptions) {
+		super(message, options);
+		this.name = "XlsxError";
+		this.code = code;
+		Object.setPrototypeOf(this, new.target.prototype);
+	}
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,8 @@ export type {
 	JSON2SheetOpts,
 	NumberFormat,
 } from "./types.js";
+export type { XlsxErrorCode } from "./errors.js";
+export { XlsxError } from "./errors.js";
 
 // Read / Write
 export { read } from "./read.js";

--- a/src/opc/content-types.ts
+++ b/src/opc/content-types.ts
@@ -1,3 +1,4 @@
+import { XlsxError } from "../errors.js";
 import { parseXmlTag, XML_HEADER, XML_TAG_REGEX } from "../xml/parser.js";
 import { writeXmlElement } from "../xml/writer.js";
 import { XMLNS } from "../xml/namespaces.js";
@@ -152,7 +153,7 @@ export function createContentTypes(): ContentTypes {
  * override into the appropriate category array.
  * @param data - raw XML string of the [Content_Types].xml file (may be null/undefined)
  * @returns a populated ContentTypes object
- * @throws if the root namespace is not the expected OPC content-types namespace
+ * @throws XlsxError if the root namespace is not the expected OPC content-types namespace
  */
 export function parseContentTypes(data: string | null | undefined, opts?: XmlLimitOptions): ContentTypes {
 	const ct = createContentTypes();
@@ -184,7 +185,7 @@ export function parseContentTypes(data: string | null | undefined, opts?: XmlLim
 		}
 	}
 	if (ct.xmlns !== XMLNS.CT) {
-		throw new Error("Unknown Namespace: " + ct.xmlns);
+		throw new XlsxError("UNSUPPORTED", "Unknown Namespace: " + ct.xmlns);
 	}
 	// Set convenience shortcuts to the first entry in commonly-used categories
 	ct.calcchain = ct.calcchains.length > 0 ? ct.calcchains[0] : "";

--- a/src/opc/relationships.ts
+++ b/src/opc/relationships.ts
@@ -1,3 +1,4 @@
+import { XlsxError } from "../errors.js";
 import { parseXmlTag, XML_HEADER, XML_TAG_REGEX } from "../xml/parser.js";
 import { unescapeXml } from "../xml/escape.js";
 import { writeXmlElement } from "../xml/writer.js";
@@ -135,7 +136,7 @@ export function writeRelationships(rels: Relationships): string {
  * @param type - the relationship type URI
  * @param targetmode - optional TargetMode ("External" for hyperlinks, etc.)
  * @returns the numeric rId that was assigned
- * @throws if the specified rId is already in use
+ * @throws XlsxError if the specified rId is already in use
  */
 export function addRelationship(
 	rels: Relationships,
@@ -169,7 +170,7 @@ export function addRelationship(
 		relobj.TargetMode = "External";
 	}
 	if (rels["!id"][relobj.Id]) {
-		throw new Error("Cannot rewrite rId " + rId);
+		throw new XlsxError("DUPLICATE", "Cannot rewrite rId " + rId);
 	}
 	rels["!id"][relobj.Id] = relobj;
 	// Store by normalized target path (ensure single leading slash)

--- a/src/read.ts
+++ b/src/read.ts
@@ -1,4 +1,5 @@
 import type { WorkBook, ReadOptions } from "./types.js";
+import { XlsxError } from "./errors.js";
 import { zipRead } from "./zip/index.js";
 import { parseZip } from "./xlsx/parse-zip.js";
 import { base64decode } from "./utils/base64.js";
@@ -36,7 +37,7 @@ function to_uint8array(data: any, opts: ReadOptions): Uint8Array {
 	if (Array.isArray(data)) {
 		return new Uint8Array(data);
 	}
-	throw new Error("Unsupported data type for read()");
+	throw new XlsxError("INVALID_ARGUMENT", "Unsupported data type for read()");
 }
 
 /**
@@ -75,7 +76,7 @@ function sheetToWorkBook(ws: any, name?: string): WorkBook {
  * @param data - File contents as Uint8Array, ArrayBuffer, Buffer, base64 string, binary string, or plain text string
  * @param opts - Read options controlling parsing behavior
  * @returns Promise resolving to a parsed WorkBook object
- * @throws Error if the input is a PDF, PNG, or other unsupported format
+ * @throws XlsxError if the input is a PDF, PNG, or other unsupported format
  */
 export async function read(data: any, opts?: ReadOptions): Promise<WorkBook> {
 	resetFormatTable();
@@ -103,13 +104,13 @@ export async function read(data: any, opts?: ReadOptions): Promise<WorkBook> {
 
 	// 0x25504446 = "%PDF" -- PDF file magic number
 	if (u8[0] === 0x25 && u8[1] === 0x50 && u8[2] === 0x44 && u8[3] === 0x46) {
-		throw new Error("PDF File is not a spreadsheet");
+		throw new XlsxError("UNSUPPORTED", "PDF File is not a spreadsheet");
 	}
 
 	// 0x89504E47 = "\x89PNG" -- PNG file magic number
 	if (u8[0] === 0x89 && u8[1] === 0x50 && u8[2] === 0x4e && u8[3] === 0x47) {
-		throw new Error("PNG Image File is not a spreadsheet");
+		throw new XlsxError("UNSUPPORTED", "PNG Image File is not a spreadsheet");
 	}
 
-	throw new Error("Unsupported file format. xlsx-format only supports XLSX files.");
+	throw new XlsxError("UNSUPPORTED", "Unsupported file format. xlsx-format only supports XLSX files.");
 }

--- a/src/ssf/format.ts
+++ b/src/ssf/format.ts
@@ -19,6 +19,7 @@
  * - The "General" format auto-selects integer, decimal, or scientific notation.
  */
 
+import { XlsxError } from "../errors.js";
 import { dateToSerialNumber } from "../utils/date.js";
 import { formatTable, DEFAULT_FORMAT_MAP, DEFAULT_FORMAT_STRINGS } from "./table.js";
 
@@ -297,7 +298,7 @@ function SSF_general(v: any, opts: any): string {
 				return formatNumber(14, dateToSerialNumber(v, opts && opts.date1904), opts);
 			}
 	}
-	throw new Error("unsupported value in General format: " + v);
+	throw new XlsxError("UNSUPPORTED", "unsupported value in General format: " + v);
 }
 
 /**
@@ -375,7 +376,7 @@ function SSF_write_date(type: number, fmt: string, val: SSFDateVal, ss0?: number
 					outputLength = fmt.length;
 					break;
 				default:
-					throw new Error("bad hour format: " + fmt);
+					throw new XlsxError("MALFORMED", "bad hour format: " + fmt);
 			}
 			break;
 		case 72 /* 'H' 24-hour clock */:
@@ -386,7 +387,7 @@ function SSF_write_date(type: number, fmt: string, val: SSFDateVal, ss0?: number
 					outputLength = fmt.length;
 					break;
 				default:
-					throw new Error("bad hour format: " + fmt);
+					throw new XlsxError("MALFORMED", "bad hour format: " + fmt);
 			}
 			break;
 		case 77 /* 'M' minutes */:
@@ -397,12 +398,12 @@ function SSF_write_date(type: number, fmt: string, val: SSFDateVal, ss0?: number
 					outputLength = fmt.length;
 					break;
 				default:
-					throw new Error("bad minute format: " + fmt);
+					throw new XlsxError("MALFORMED", "bad minute format: " + fmt);
 			}
 			break;
 		case 115 /* 's' seconds */:
 			if (fmt !== "s" && fmt !== "ss" && fmt !== ".0" && fmt !== ".00" && fmt !== ".000") {
-				throw new Error("bad second format: " + fmt);
+				throw new XlsxError("MALFORMED", "bad second format: " + fmt);
 			}
 			if (val.subSeconds === 0 && (fmt === "s" || fmt === "ss")) {
 				return padWithZeros(val.seconds, fmt.length);
@@ -446,7 +447,7 @@ function SSF_write_date(type: number, fmt: string, val: SSFDateVal, ss0?: number
 						(ss0 === 0 ? Math.round(val.seconds + val.subSeconds) : val.seconds);
 					break;
 				default:
-					throw new Error("bad abstime format: " + fmt);
+					throw new XlsxError("MALFORMED", "bad abstime format: " + fmt);
 			}
 			outputLength = fmt.length === 3 ? 1 : 2;
 			break;
@@ -850,7 +851,7 @@ function write_num_flt(type: string, fmt: string, val: number): string {
 		case "#,###.00":
 			return write_num_flt(type, "#,##0.00", val).replace(/^0\./, ".");
 	}
-	throw new Error("unsupported format |" + fmt + "|");
+	throw new XlsxError("UNSUPPORTED", "unsupported format |" + fmt + "|");
 }
 
 /**
@@ -1011,7 +1012,7 @@ function write_num_int(type: string, fmt: string, val: number): string {
 				);
 			}
 	}
-	throw new Error("unsupported format |" + fmt + "|");
+	throw new XlsxError("UNSUPPORTED", "unsupported format |" + fmt + "|");
 }
 
 /** Dispatch to integer or float formatter based on whether the value is an integer */
@@ -1051,7 +1052,7 @@ function SSF_split_fmt(fmt: string): string[] {
 	}
 	out[out.length] = fmt.substring(j);
 	if (in_str) {
-		throw new Error("Format |" + fmt + "| unterminated string ");
+		throw new XlsxError("MALFORMED", "Format |" + fmt + "| unterminated string ");
 	}
 	return out;
 }
@@ -1245,7 +1246,7 @@ function eval_fmt(fmt: string, value: any, opts: any, flen: number): string {
 		switch ((char = fmt.charAt(i))) {
 			case "G":
 				if (!isGeneralFormat(fmt, i)) {
-					throw new Error("unrecognized character " + char + " in " + fmt);
+					throw new XlsxError("MALFORMED", "unrecognized character " + char + " in " + fmt);
 				}
 				out[out.length] = { type: "G", value: "General" };
 				i += 7;
@@ -1382,7 +1383,7 @@ function eval_fmt(fmt: string, value: any, opts: any, flen: number): string {
 					tokenStr += fmt.charAt(i);
 				}
 				if (tokenStr.slice(-1) !== "]") {
-					throw new Error('unterminated "[" block: |' + tokenStr + "|");
+					throw new XlsxError("MALFORMED", 'unterminated "[" block: |' + tokenStr + "|");
 				}
 				if (tokenStr.match(SSF_abstime)) {
 					// Absolute/elapsed time token (e.g. [h], [mm], [ss])
@@ -1470,7 +1471,7 @@ function eval_fmt(fmt: string, value: any, opts: any, flen: number): string {
 			default:
 				// Characters known to be safe as text: currency, punctuation, misc letters
 				if (",$-+/():!^&'~{}<>=\u20ACacfijklopqrtuvwxzP".indexOf(char) === -1) {
-					throw new Error("unrecognized character " + char + " in " + fmt);
+					throw new XlsxError("MALFORMED", "unrecognized character " + char + " in " + fmt);
 				}
 				out[out.length] = { type: "t", value: char };
 				++i;
@@ -1888,7 +1889,7 @@ function choose_fmt(fmtStr: string, value: any): [number, string] {
 		--ll;
 	}
 	if (fmt.length > 4) {
-		throw new Error("cannot find right format for |" + fmt.join("|") + "|");
+		throw new XlsxError("MALFORMED", "cannot find right format for |" + fmt.join("|") + "|");
 	}
 	// Non-numeric values use the text section (section 4) or "@"
 	if (typeof value !== "number") {

--- a/src/utils/cell.ts
+++ b/src/utils/cell.ts
@@ -1,4 +1,5 @@
 import type { CellAddress, CellObject, Range, WorkSheet } from "../types.js";
+import { XlsxError } from "../errors.js";
 
 /**
  * Decode a row string (1-based) to a zero-based row index.
@@ -61,11 +62,11 @@ export function decodeCol(colstr: string): number {
  *
  * @param col - Zero-based column index
  * @returns Column label string
- * @throws Error if col is negative
+ * @throws XlsxError if col is negative
  */
 export function encodeCol(col: number): string {
 	if (col < 0) {
-		throw new Error("invalid column " + col);
+		throw new XlsxError("INVALID_ARGUMENT", "invalid column " + col);
 	}
 	let result = "";
 	// Convert to 1-based, then repeatedly extract bijective base-26 digits
@@ -281,11 +282,11 @@ export function getOrCreateCell(sheet: WorkSheet, row: number, col: number): Cel
  *
  * @param sname - Sheet name to quote
  * @returns Quoted sheet name safe for formula references
- * @throws Error if the sheet name is empty
+ * @throws XlsxError if the sheet name is empty
  */
 export function quoteSheetName(sname: string): string {
 	if (!sname) {
-		throw new Error("empty sheet name");
+		throw new XlsxError("INVALID_ARGUMENT", "empty sheet name");
 	}
 	// Match any character not in: word chars, CJK Unified Ideographs (4E00-9FFF), Hiragana/Katakana (3040-30FF)
 	if (/[^\w\u4E00-\u9FFF\u3040-\u30FF]/.test(sname)) {

--- a/src/xlsx/parse-zip.ts
+++ b/src/xlsx/parse-zip.ts
@@ -6,6 +6,7 @@ import type { SST } from "./shared-strings.js";
 import type { StylesData } from "./styles.js";
 import type { ThemeData } from "./theme.js";
 import type { WorkbookFile, SheetEntry } from "./workbook.js";
+import { XlsxError } from "../errors.js";
 import { zipReadString, zipHas } from "../zip/index.js";
 import { parseContentTypes } from "../opc/content-types.js";
 import { parseRelationships } from "../opc/relationships.js";
@@ -59,7 +60,7 @@ function resolve_path(target: string, basePath: string): string {
 function getZipString(zip: ZipArchive, path: string, safe?: boolean, opts?: ReadOptions): string | null {
 	const p = zipReadString(zip, path);
 	if (p == null && !safe) {
-		throw new Error("Could not find " + path);
+		throw new XlsxError("NOT_FOUND", "Could not find " + path);
 	}
 	if (p != null) {
 		assertXmlPartLimits(path, p, opts);
@@ -213,14 +214,14 @@ function safe_parse_sheet(
  * @param zip - ZipArchive containing the XLSX file parts
  * @param opts - Read options controlling parsing behavior
  * @returns Parsed WorkBook with sheets, properties, and metadata
- * @throws Error if the ZIP is not a valid XLSX file or the workbook is missing
+ * @throws XlsxError if the ZIP is not a valid XLSX file or the workbook is missing
  */
 export function parseZip(zip: ZipArchive, opts?: ReadOptions): WorkBook {
 	resetFormatTable();
 	const options: any = opts || {};
 
 	if (!zipHas(zip, "[Content_Types].xml")) {
-		throw new Error("Unsupported ZIP file");
+		throw new XlsxError("UNSUPPORTED", "Unsupported ZIP file");
 	}
 
 	const dir: ContentTypes = parseContentTypes(getZipString(zip, "[Content_Types].xml", false, options), options);
@@ -233,7 +234,7 @@ export function parseZip(zip: ZipArchive, opts?: ReadOptions): WorkBook {
 		}
 	}
 	if (dir.workbooks.length === 0) {
-		throw new Error("Could not find workbook");
+		throw new XlsxError("NOT_FOUND", "Could not find workbook");
 	}
 
 	const themes: ThemeData = { themeElements: { clrScheme: [] } };

--- a/src/xlsx/shared-strings.ts
+++ b/src/xlsx/shared-strings.ts
@@ -1,3 +1,4 @@
+import { XlsxError } from "../errors.js";
 import { parseXmlTag, XML_TAG_REGEX } from "../xml/parser.js";
 import { unescapeXml, escapeXml, escapeHtml } from "../xml/escape.js";
 import { writeXmlElement } from "../xml/writer.js";
@@ -149,7 +150,7 @@ function parseRunProperties(rpr: string, opts?: SstParseOptions): Record<string,
 				default:
 					// charCodeAt(1) !== 47 means it's not a closing tag (not '/')
 					if ((parsedTag[0] as string).charCodeAt(1) !== 47 && !pass) {
-						throw new Error("Unrecognized rich format " + parsedTag[0]);
+						throw new XlsxError("UNSUPPORTED", "Unrecognized rich format " + parsedTag[0]);
 					}
 			}
 		}

--- a/src/xlsx/styles.ts
+++ b/src/xlsx/styles.ts
@@ -10,6 +10,7 @@ import type {
 	CellBorderSide,
 	CellAlignment,
 } from "../types.js";
+import { XlsxError } from "../errors.js";
 import { parseXmlTag, XML_TAG_REGEX, XML_HEADER } from "../xml/parser.js";
 import { escapeXml, unescapeXml } from "../xml/escape.js";
 import { writeXmlElement } from "../xml/writer.js";
@@ -111,7 +112,7 @@ function normalizeColor(color?: StyleColor, opts?: any): StyleColor | undefined 
 		rgb = normalized;
 	} else {
 		if (opts?.WTF) {
-			throw new Error("Unsupported style color: " + raw);
+			throw new XlsxError("UNSUPPORTED", "Unsupported style color: " + raw);
 		}
 		return undefined;
 	}
@@ -145,7 +146,7 @@ function normalizeFill(fill?: CellFill, opts?: any): CellFill | undefined {
 	}
 	if (fill.patternType && fill.patternType !== "solid") {
 		if (opts?.WTF) {
-			throw new Error("Unsupported fill pattern: " + fill.patternType);
+			throw new XlsxError("UNSUPPORTED", "Unsupported fill pattern: " + fill.patternType);
 		}
 		return undefined;
 	}
@@ -168,7 +169,7 @@ function normalizeBorder(border?: CellBorder, opts?: any): CellBorder | undefine
 		}
 		if (input.style !== "thin" && input.style !== "medium") {
 			if (opts?.WTF) {
-				throw new Error("Unsupported border style: " + input.style);
+				throw new XlsxError("UNSUPPORTED", "Unsupported border style: " + input.style);
 			}
 			continue;
 		}
@@ -186,12 +187,12 @@ function normalizeAlignment(alignment?: CellAlignment, opts?: any): CellAlignmen
 	if (alignment.horizontal === "left" || alignment.horizontal === "center" || alignment.horizontal === "right") {
 		out.horizontal = alignment.horizontal;
 	} else if (alignment.horizontal && opts?.WTF) {
-		throw new Error("Unsupported horizontal alignment: " + alignment.horizontal);
+		throw new XlsxError("UNSUPPORTED", "Unsupported horizontal alignment: " + alignment.horizontal);
 	}
 	if (alignment.vertical === "top" || alignment.vertical === "middle" || alignment.vertical === "bottom") {
 		out.vertical = alignment.vertical;
 	} else if (alignment.vertical && opts?.WTF) {
-		throw new Error("Unsupported vertical alignment: " + alignment.vertical);
+		throw new XlsxError("UNSUPPORTED", "Unsupported vertical alignment: " + alignment.vertical);
 	}
 	if (alignment.wrapText) {
 		out.wrapText = true;

--- a/src/xlsx/workbook.ts
+++ b/src/xlsx/workbook.ts
@@ -1,3 +1,4 @@
+import { XlsxError } from "../errors.js";
 import { parseXmlTag, XML_TAG_REGEX, XML_HEADER, stripNamespace, parseXmlBoolean } from "../xml/parser.js";
 import { unescapeXml, escapeXml } from "../xml/escape.js";
 import { writeXmlElement } from "../xml/writer.js";
@@ -179,26 +180,26 @@ const badchars = ":][*?/\\".split("");
  * @param n - Sheet name to validate
  * @param safe - If true, return false on invalid names instead of throwing
  * @returns true if valid
- * @throws Error describing the validation failure (unless safe=true)
+ * @throws XlsxError describing the validation failure (unless safe=true)
  */
 export function validateSheetName(n: string, safe?: boolean): boolean {
 	try {
 		if (n === "") {
-			throw new Error("Sheet name cannot be blank");
+			throw new XlsxError("INVALID_ARGUMENT", "Sheet name cannot be blank");
 		}
 		if (n.length > 31) {
-			throw new Error("Sheet name cannot exceed 31 chars");
+			throw new XlsxError("INVALID_ARGUMENT", "Sheet name cannot exceed 31 chars");
 		}
 		// 0x27 = apostrophe (')
 		if (n.charCodeAt(0) === 0x27 || n.charCodeAt(n.length - 1) === 0x27) {
-			throw new Error("Sheet name cannot start or end with apostrophe (')");
+			throw new XlsxError("INVALID_ARGUMENT", "Sheet name cannot start or end with apostrophe (')");
 		}
 		if (n.toLowerCase() === "history") {
-			throw new Error("Sheet name cannot be 'History'");
+			throw new XlsxError("INVALID_ARGUMENT", "Sheet name cannot be 'History'");
 		}
 		for (const c of badchars) {
 			if (n.indexOf(c) !== -1) {
-				throw new Error("Sheet name cannot contain : \\ / ? * [ ]");
+				throw new XlsxError("INVALID_ARGUMENT", "Sheet name cannot contain : \\ / ? * [ ]");
 			}
 		}
 	} catch (e) {
@@ -215,14 +216,14 @@ export function validateSheetName(n: string, safe?: boolean): boolean {
  *
  * @param sheetNames - Array of sheet names to validate
  * @param sheetEntries - Optional sheet entry metadata (reserved for future use)
- * @throws Error if any name is invalid or duplicated
+ * @throws XlsxError if any name is invalid or duplicated
  */
 export function validateWorkbookNames(sheetNames: string[], _sheetEntries?: any[]): void {
 	for (let i = 0; i < sheetNames.length; ++i) {
 		validateSheetName(sheetNames[i]);
 		for (let j = 0; j < i; ++j) {
 			if (sheetNames[i] === sheetNames[j]) {
-				throw new Error("Duplicate Sheet Name: " + sheetNames[i]);
+				throw new XlsxError("DUPLICATE", "Duplicate Sheet Name: " + sheetNames[i]);
 			}
 		}
 	}
@@ -232,14 +233,14 @@ export function validateWorkbookNames(sheetNames: string[], _sheetEntries?: any[
  * Validate that a WorkBook object has the required structure.
  *
  * @param wb - WorkBook to validate
- * @throws Error if the workbook is missing required fields or has invalid sheet names
+ * @throws XlsxError if the workbook is missing required fields or has invalid sheet names
  */
 export function validateWorkbook(wb: WorkBook): void {
 	if (!wb || !wb.SheetNames || !wb.Sheets) {
-		throw new Error("Invalid Workbook");
+		throw new XlsxError("INVALID_ARGUMENT", "Invalid Workbook");
 	}
 	if (!wb.SheetNames.length) {
-		throw new Error("Workbook is empty");
+		throw new XlsxError("INVALID_ARGUMENT", "Workbook is empty");
 	}
 	const Sheets = (wb.Workbook && wb.Workbook.Sheets) || [];
 	validateWorkbookNames(wb.SheetNames, Sheets);
@@ -257,11 +258,11 @@ const wbnsregex = /<\w+:workbook/;
  * @param data - Raw XML string of workbook.xml
  * @param opts - Parsing options
  * @returns Parsed workbook file structure
- * @throws Error if data is empty or the namespace is unrecognized
+ * @throws XlsxError if data is empty or the namespace is unrecognized
  */
 export function parseWorkbookXml(data: string, _opts?: any): WorkbookFile {
 	if (!data) {
-		throw new Error("Could not find file");
+		throw new XlsxError("NOT_FOUND", "Could not find file");
 	}
 	const workbook: WorkbookFile = {
 		AppVersion: {},
@@ -444,7 +445,7 @@ export function parseWorkbookXml(data: string, _opts?: any): WorkbookFile {
 	});
 
 	if (XMLNS_main.indexOf(workbook.xmlns) === -1) {
-		throw new Error("Unknown Namespace: " + workbook.xmlns);
+		throw new XlsxError("UNSUPPORTED", "Unknown Namespace: " + workbook.xmlns);
 	}
 
 	parse_wb_defaults(workbook);

--- a/src/xml/limits.ts
+++ b/src/xml/limits.ts
@@ -1,3 +1,5 @@
+import { XlsxError } from "../errors.js";
+
 /** Limits applied while reading XML-based workbook parts. */
 export interface XmlLimitOptions {
 	/** Maximum decoded XML part size. */
@@ -32,21 +34,24 @@ export function xmlOptionLimit(value: number | undefined, fallback: number, name
 		return fallback;
 	}
 	if (!Number.isFinite(value) || value < 0) {
-		throw new Error(`Invalid XML option: ${name} must be a non-negative finite number`);
+		throw new XlsxError("INVALID_ARGUMENT", `Invalid XML option: ${name} must be a non-negative finite number`);
 	}
 	return value;
 }
 
 export function assertXmlCountWithinLimit(kind: string, count: number, limit: number): void {
 	if (count > limit) {
-		throw new Error(`Invalid XML: ${kind} count ${count} exceeds limit ${limit}`);
+		throw new XlsxError("LIMIT_EXCEEDED", `Invalid XML: ${kind} count ${count} exceeds limit ${limit}`);
 	}
 }
 
 export function assertXmlPartLimits(partName: string, data: string, opts?: XmlLimitOptions): void {
 	const maxXmlPartBytes = xmlOptionLimit(opts?.maxXmlPartBytes, DEFAULT_MAX_XML_PART_BYTES, "maxXmlPartBytes");
 	if (data.length > maxXmlPartBytes) {
-		throw new Error(`Invalid XML: ${partName} size ${data.length} exceeds limit ${maxXmlPartBytes}`);
+		throw new XlsxError(
+			"LIMIT_EXCEEDED",
+			`Invalid XML: ${partName} size ${data.length} exceeds limit ${maxXmlPartBytes}`,
+		);
 	}
 
 	const maxXmlTags = xmlOptionLimit(opts?.maxXmlTags, DEFAULT_MAX_XML_TAGS, "maxXmlTags");
@@ -64,7 +69,10 @@ export function assertXmlPartLimits(partName: string, data: string, opts?: XmlLi
 		const closeOffset = data.indexOf(">", offset + 1);
 		const tagLength = closeOffset === -1 ? data.length - offset : closeOffset - offset + 1;
 		if (tagLength > maxXmlTagLength) {
-			throw new Error(`Invalid XML: ${partName} tag length ${tagLength} exceeds limit ${maxXmlTagLength}`);
+			throw new XlsxError(
+				"LIMIT_EXCEEDED",
+				`Invalid XML: ${partName} tag length ${tagLength} exceeds limit ${maxXmlTagLength}`,
+			);
 		}
 		if (closeOffset === -1) {
 			break;
@@ -81,7 +89,10 @@ export function assertXmlPartLimits(partName: string, data: string, opts?: XmlLi
 			depth = Math.max(0, depth - 1);
 		} else if (!isProcessingOrDeclaration && !isSelfClosing) {
 			if (++depth > maxXmlNestingDepth) {
-				throw new Error(`Invalid XML: ${partName} nesting depth ${depth} exceeds limit ${maxXmlNestingDepth}`);
+				throw new XlsxError(
+					"LIMIT_EXCEEDED",
+					`Invalid XML: ${partName} nesting depth ${depth} exceeds limit ${maxXmlNestingDepth}`,
+				);
 			}
 		}
 		offset = closeOffset;

--- a/src/xml/writer.ts
+++ b/src/xml/writer.ts
@@ -1,3 +1,4 @@
+import { XlsxError } from "../errors.js";
 import { escapeXml } from "./escape.js";
 
 // Detects leading/trailing whitespace or embedded newlines that require xml:space="preserve"
@@ -83,7 +84,7 @@ export function writeW3cDatetime(date: Date, throwOnError?: boolean): string {
  * @param value - the value to serialize
  * @param xlsx - when true, escape double-quotes as _x0022_ (OOXML convention)
  * @returns an XML string containing the appropriate vt: element
- * @throws if value is an unsupported type
+ * @throws XlsxError if value is an unsupported type
  */
 export function writeVariantType(value: any, xlsx?: boolean): string {
 	switch (typeof value) {
@@ -104,5 +105,5 @@ export function writeVariantType(value: any, xlsx?: boolean): string {
 	if (value instanceof Date) {
 		return writeXmlElement("vt:filetime", writeW3cDatetime(value));
 	}
-	throw new Error("Unable to serialize " + value);
+	throw new XlsxError("INVALID_ARGUMENT", "Unable to serialize " + value);
 }

--- a/src/zip/index.ts
+++ b/src/zip/index.ts
@@ -1,3 +1,4 @@
+import { XlsxError } from "../errors.js";
 import { crc32 } from "./crc32.js";
 import { inflate, deflate } from "./streams.js";
 
@@ -40,14 +41,14 @@ function optionLimit(value: number | undefined, fallback: number, name: string):
 		return fallback;
 	}
 	if (!Number.isFinite(value) || value < 0) {
-		throw new Error(`Invalid ZIP option: ${name} must be a non-negative finite number`);
+		throw new XlsxError("INVALID_ARGUMENT", `Invalid ZIP option: ${name} must be a non-negative finite number`);
 	}
 	return value;
 }
 
 function assertRange(data: Uint8Array, off: number, len: number, what: string): void {
 	if (!Number.isInteger(off) || !Number.isInteger(len) || off < 0 || len < 0 || off > data.length - len) {
-		throw new Error(`Invalid ZIP: ${what} out of bounds`);
+		throw new XlsxError("MALFORMED", `Invalid ZIP: ${what} out of bounds`);
 	}
 }
 
@@ -62,13 +63,13 @@ function readU32At(buf: Uint8Array, off: number, what: string): number {
 }
 
 function rejectZip64(): never {
-	throw new Error("Unsupported ZIP: Zip64 archives are not supported");
+	throw new XlsxError("UNSUPPORTED", "Unsupported ZIP: Zip64 archives are not supported");
 }
 
 function assertCrc(name: string, data: Uint8Array, expected: number): void {
 	const actual = crc32(data);
 	if (actual !== expected) {
-		throw new Error(`Invalid ZIP: CRC mismatch for ${name}`);
+		throw new XlsxError("CRC_MISMATCH", `Invalid ZIP: CRC mismatch for ${name}`);
 	}
 }
 
@@ -105,7 +106,7 @@ function writeU32(buf: Uint8Array, off: number, val: number): void {
  *
  * @param data - Raw ZIP file bytes
  * @returns Parsed archive with decompressed file contents
- * @throws Error if the ZIP structure is invalid or uses an unsupported compression method
+ * @throws XlsxError if the ZIP structure is invalid or uses an unsupported compression method
  */
 export async function zipRead(data: Uint8Array, opts?: ZipReadOptions): Promise<ZipArchive> {
 	const maxZipEntries = optionLimit(opts?.maxZipEntries, DEFAULT_MAX_ZIP_ENTRIES, "maxZipEntries");
@@ -132,7 +133,7 @@ export async function zipRead(data: Uint8Array, opts?: ZipReadOptions): Promise<
 		}
 	}
 	if (eocdOffset === -1) {
-		throw new Error("Invalid ZIP: EOCD not found");
+		throw new XlsxError("MALFORMED", "Invalid ZIP: EOCD not found");
 	}
 
 	assertRange(data, eocdOffset, 22, "EOCD");
@@ -149,14 +150,14 @@ export async function zipRead(data: Uint8Array, opts?: ZipReadOptions): Promise<
 		rejectZip64();
 	}
 	if (diskNumber !== 0 || cdDiskNumber !== 0 || cdEntriesOnDisk !== cdEntries) {
-		throw new Error("Unsupported ZIP: multi-disk archives are not supported");
+		throw new XlsxError("UNSUPPORTED", "Unsupported ZIP: multi-disk archives are not supported");
 	}
 	if (cdEntries > maxZipEntries) {
-		throw new Error(`Invalid ZIP: entry count ${cdEntries} exceeds limit ${maxZipEntries}`);
+		throw new XlsxError("LIMIT_EXCEEDED", `Invalid ZIP: entry count ${cdEntries} exceeds limit ${maxZipEntries}`);
 	}
 	assertRange(data, cdOffset, cdSize, "central directory");
 	if (cdOffset + cdSize > eocdOffset) {
-		throw new Error("Invalid ZIP: central directory overlaps EOCD");
+		throw new XlsxError("MALFORMED", "Invalid ZIP: central directory overlaps EOCD");
 	}
 
 	// Parse central directory entries
@@ -174,10 +175,10 @@ export async function zipRead(data: Uint8Array, opts?: ZipReadOptions): Promise<
 	for (let i = 0; i < cdEntries; i++) {
 		assertRange(data, pos, 46, "central directory entry");
 		if (pos + 46 > cdEnd) {
-			throw new Error("Invalid ZIP: central directory entry exceeds declared size");
+			throw new XlsxError("MALFORMED", "Invalid ZIP: central directory entry exceeds declared size");
 		}
 		if (readU32At(data, pos, "central directory signature") !== SIG_CENTRAL) {
-			throw new Error("Invalid ZIP: bad central directory entry");
+			throw new XlsxError("MALFORMED", "Invalid ZIP: bad central directory entry");
 		}
 		const method = readU16At(data, pos + 10, "central directory compression method");
 		const crcVal = readU32At(data, pos + 16, "central directory CRC");
@@ -197,11 +198,11 @@ export async function zipRead(data: Uint8Array, opts?: ZipReadOptions): Promise<
 			rejectZip64();
 		}
 		if (diskStart !== 0) {
-			throw new Error("Unsupported ZIP: multi-disk archives are not supported");
+			throw new XlsxError("UNSUPPORTED", "Unsupported ZIP: multi-disk archives are not supported");
 		}
 		const entryEnd = pos + 46 + nameLen + extraLen + commentLen;
 		if (entryEnd > cdEnd) {
-			throw new Error("Invalid ZIP: central directory entry exceeds declared size");
+			throw new XlsxError("MALFORMED", "Invalid ZIP: central directory entry exceeds declared size");
 		}
 		const nameBytes = data.subarray(pos + 46, pos + 46 + nameLen);
 		const name = decoder.decode(nameBytes);
@@ -223,14 +224,14 @@ export async function zipRead(data: Uint8Array, opts?: ZipReadOptions): Promise<
 			continue;
 		}
 		if (seenNames.has(name)) {
-			throw new Error(`Invalid ZIP: duplicate entry ${name}`);
+			throw new XlsxError("DUPLICATE", `Invalid ZIP: duplicate entry ${name}`);
 		}
 		seenNames.add(name);
 
 		const loc = entry.localOffset;
 		assertRange(data, loc, 30, `local file header for ${entry.name}`);
 		if (readU32At(data, loc, "local file header signature") !== SIG_LOCAL) {
-			throw new Error("Invalid ZIP: bad local file header");
+			throw new XlsxError("MALFORMED", "Invalid ZIP: bad local file header");
 		}
 		const localMethod = readU16At(data, loc + 8, "local file header compression method");
 		const localNameLen = readU16At(data, loc + 26, "local file header file name length");
@@ -239,27 +240,32 @@ export async function zipRead(data: Uint8Array, opts?: ZipReadOptions): Promise<
 		assertRange(data, dataStart, entry.compSize, `file data for ${entry.name}`);
 		const dataEnd = dataStart + entry.compSize;
 		if (localMethod !== entry.method) {
-			throw new Error(`Invalid ZIP: local header method mismatch for ${entry.name}`);
+			throw new XlsxError("MALFORMED", `Invalid ZIP: local header method mismatch for ${entry.name}`);
 		}
 		const localName = decoder.decode(data.subarray(loc + 30, loc + 30 + localNameLen));
 		if (localName !== name) {
-			throw new Error(`Invalid ZIP: local header file name mismatch for ${name}`);
+			throw new XlsxError("MALFORMED", `Invalid ZIP: local header file name mismatch for ${name}`);
 		}
 		if (entry.uncompSize > maxEntryUncompressedBytes) {
-			throw new Error(
+			throw new XlsxError(
+				"LIMIT_EXCEEDED",
 				`Invalid ZIP: entry ${name} uncompressed size ${entry.uncompSize} exceeds limit ${maxEntryUncompressedBytes}`,
 			);
 		}
 		totalUncompressedBytes += entry.uncompSize;
 		if (totalUncompressedBytes > maxTotalUncompressedBytes) {
-			throw new Error(
+			throw new XlsxError(
+				"LIMIT_EXCEEDED",
 				`Invalid ZIP: total uncompressed size ${totalUncompressedBytes} exceeds limit ${maxTotalUncompressedBytes}`,
 			);
 		}
 
 		if (entry.method === 0) {
 			if (entry.compSize !== entry.uncompSize) {
-				throw new Error(`Invalid ZIP: stored entry ${name} has mismatched compressed and uncompressed sizes`);
+				throw new XlsxError(
+					"MALFORMED",
+					`Invalid ZIP: stored entry ${name} has mismatched compressed and uncompressed sizes`,
+				);
 			}
 			// Method 0: Stored (no compression)
 			const fileData = data.subarray(dataStart, dataEnd);
@@ -274,7 +280,7 @@ export async function zipRead(data: Uint8Array, opts?: ZipReadOptions): Promise<
 				crc: entry.crc,
 			});
 		} else {
-			throw new Error(`Unsupported ZIP compression method: ${entry.method}`);
+			throw new XlsxError("UNSUPPORTED", `Unsupported ZIP compression method: ${entry.method}`);
 		}
 	}
 
@@ -283,7 +289,8 @@ export async function zipRead(data: Uint8Array, opts?: ZipReadOptions): Promise<
 	for (const job of inflateJobs) {
 		const result = await inflate(job.compressed, job.expectedSize);
 		if (result.length !== job.expectedSize) {
-			throw new Error(
+			throw new XlsxError(
+				"MALFORMED",
 				`Invalid ZIP: entry ${job.name} inflated to ${result.length} bytes, expected ${job.expectedSize}`,
 			);
 		}

--- a/src/zip/streams.ts
+++ b/src/zip/streams.ts
@@ -1,3 +1,5 @@
+import { XlsxError } from "../errors.js";
+
 /**
  * Read all chunks from a {@link ReadableStream} and concatenate them into a single {@link Uint8Array}.
  *
@@ -15,7 +17,7 @@ async function collectStream(readable: ReadableStream<Uint8Array>, maxBytes = In
 		chunks.push(value);
 		totalLength += value.length;
 		if (totalLength > maxBytes) {
-			throw new Error(`Invalid ZIP: decompressed data exceeds limit (${maxBytes} bytes)`);
+			throw new XlsxError("LIMIT_EXCEEDED", `Invalid ZIP: decompressed data exceeds limit (${maxBytes} bytes)`);
 		}
 	}
 	const result = new Uint8Array(totalLength);


### PR DESCRIPTION
## What

- Add public `XlsxError` and `XlsxErrorCode` exports.
- Convert production `throw new Error(...)` sites to `XlsxError` with stable codes while preserving existing messages.
- Document error handling and stable codes in the security guide.
- Add focused tests for export shape and representative failure codes.

## Why

Closes #39.

## User-visible impact

Existing `catch (error)` / `error instanceof Error` handling continues to work because `XlsxError` extends `Error`. New callers can branch on `error.code` instead of matching message text.

## Validation

- `pnpm exec vitest run src/errors.test.ts src/read.test.ts src/zip/security.test.ts src/xml/xml.test.ts`
- `pnpm run check`
- `pnpm run verify`
- `rg -n "new Error\\(" src --glob "!*.test.ts"` returns no production matches
- Push hook: `tsc --noEmit`, `eslint src/`, `prettier --check src/`

## Checklist

- [x] Tests added or updated
- [x] `npm run check` passes (`pnpm run verify`)
- [x] `npm run lint` passes (`pnpm run verify`)
- [x] `npm test` passes (`pnpm run verify`)
- [x] Commit messages follow Conventional Commits