### PR TITLE
feat: secure export protections by default

### DIFF
--- a/docs/app/routes/guide/security.mdx
+++ b/docs/app/routes/guide/security.mdx
@@ -81,27 +81,22 @@ Stable error codes:
 
 CSV files opened in spreadsheet applications can interpret text that starts with characters such as `=`, `+`, `-`, `@`, tab, or carriage return as formulas. This is commonly called CSV injection or formula injection.
 
-If a CSV will be opened by a human in Excel, Google Sheets, or LibreOffice, neutralize user-controlled text fields before export. A common mitigation is prefixing formula-like text with a single quote.
+By default, `sheetToCsv()` and CSV output from `write()` prefix formula-like text with a single quote. Pass `escapeFormulae: false` only when you need exact text fidelity and the output will not be opened as an untrusted spreadsheet.
 
 ```typescript
-function safeCsvText(value: unknown): unknown {
-	if (typeof value !== "string") {
-		return value;
-	}
-	return /^[=+\-@\t\r]/.test(value) ? `'${value}` : value;
-}
+import { sheetToCsv } from "xlsx-format";
+
+const csv = sheetToCsv(sheet);
 ```
 
 ## Exporting HTML
 
-HTML export escapes cell text. Hyperlinks can still point to unsafe targets if you render exported HTML in a browser. Use `sanitizeLinks` when exporting HTML from user-controlled sheets to block script URLs such as `javascript:` targets. If your application accepts arbitrary hyperlinks, validate links against your own allowed URL schemes and domains before publishing or embedding the exported HTML.
+HTML export escapes cell text and, by default, drops hyperlink targets with unsafe schemes such as `javascript:`, `vbscript:`, and `data:`. Pass `sanitizeLinks: false` only when you need exact hyperlink fidelity and will not render the exported HTML in a browser. If your application accepts arbitrary hyperlinks, validate links against your own allowed URL schemes and domains before publishing or embedding the exported HTML.
 
 ```typescript
 import { sheetToHtml } from "xlsx-format";
 
-const html = sheetToHtml(sheet, {
-	sanitizeLinks: true,
-});
+const html = sheetToHtml(sheet);
 ```
 
 ## Object keys from workbook data

--- a/src/api/csv.test.ts
+++ b/src/api/csv.test.ts
@@ -84,7 +84,8 @@ describe("csv.ts: advanced CSV features", () => {
 	it("sheetToCsv formula with comma gets quoted", () => {
 		const ws: any = { A1: { t: "z", f: "IF(A2,B2,C2)" }, "!ref": "A1:A1" };
 		const csv = sheetToCsv(ws);
-		expect(csv).toContain('"=IF(A2,B2,C2)"');
+		expect(csv).toContain('"\'=IF(A2,B2,C2)"');
+		expect(sheetToCsv(ws, { escapeFormulae: false })).toContain('"=IF(A2,B2,C2)"');
 	});
 
 	it("sheetToTxt produces tab-separated output", () => {

--- a/src/api/csv.ts
+++ b/src/api/csv.ts
@@ -8,7 +8,7 @@ import { arrayToSheet } from "./aoa.js";
 const qreg = /"/g;
 
 function escapeFormulaText(txt: string, options: any): string {
-	if (!options.escapeFormulae || txt.length === 0) {
+	if (options.escapeFormulae === false || txt.length === 0) {
 		return txt;
 	}
 	switch (txt.charCodeAt(0)) {

--- a/src/api/html.ts
+++ b/src/api/html.ts
@@ -114,11 +114,11 @@ function buildHtmlRow(ws: WorkSheet, range: Range, rowIndex: number, options: Sh
 				cellAttrs["data-f"] = escapeHtml(cell.f);
 			}
 			// Wrap in an anchor tag if the cell has a non-internal hyperlink,
-			// filtering out unsafe URI schemes when sanitizeLinks is enabled
+			// filtering out unsafe URI schemes unless sanitization is disabled.
 			if (
 				cell.l &&
 				(cell.l.Target || "#").charAt(0) !== "#" &&
-				(!options.sanitizeLinks || isSanitizedLinkTarget(cell.l.Target || ""))
+				(options.sanitizeLinks === false || isSanitizedLinkTarget(cell.l.Target || ""))
 			) {
 				cellContent = '<a href="' + escapeHtml(cell.l.Target) + '">' + cellContent + "</a>";
 			}

--- a/src/security-export-guards.test.ts
+++ b/src/security-export-guards.test.ts
@@ -50,17 +50,18 @@ describe("export security guards", () => {
 		expect(Object.prototype).not.toHaveProperty("value");
 	});
 
-	it("escapes formula-like CSV fields when requested", () => {
+	it("escapes formula-like CSV fields by default", () => {
 		const ws = arrayToSheet([["=1+1", "+SUM(A1)", "-cmd", "@handle", "plain"]]);
 
-		expect(sheetToCsv(ws)).toBe("=1+1,+SUM(A1),-cmd,@handle,plain");
-		expect(sheetToCsv(ws, { escapeFormulae: true })).toBe("'=1+1,'+SUM(A1),'-cmd,'@handle,plain");
+		expect(sheetToCsv(ws)).toBe("'=1+1,'+SUM(A1),'-cmd,'@handle,plain");
+		expect(sheetToCsv(ws, { escapeFormulae: false })).toBe("=1+1,+SUM(A1),-cmd,@handle,plain");
 	});
 
-	it("escapes formula-only CSV cells when requested", () => {
+	it("escapes formula-only CSV cells by default", () => {
 		const ws = { A1: { t: "z", f: "SUM(B1:B10)" }, "!ref": "A1:A1" } as WorkSheet;
 
-		expect(sheetToCsv(ws, { escapeFormulae: true })).toBe("'=SUM(B1:B10)");
+		expect(sheetToCsv(ws)).toBe("'=SUM(B1:B10)");
+		expect(sheetToCsv(ws, { escapeFormulae: false })).toBe("=SUM(B1:B10)");
 	});
 
 	it("sanitizes javascript links with embedded whitespace", () => {
@@ -68,8 +69,13 @@ describe("export security guards", () => {
 			"!ref": "A1",
 			A1: { t: "s", v: "Bad", l: { Target: "java\nscript:alert(1)" } },
 		} as WorkSheet;
+		const unsafeOptOutWs = {
+			"!ref": "A1",
+			A1: { t: "s", v: "Bad", l: { Target: "javascript:alert(1)" } },
+		} as WorkSheet;
 
-		expect(sheetToHtml(ws, { sanitizeLinks: true })).not.toContain("href=");
+		expect(sheetToHtml(ws)).not.toContain("href=");
+		expect(sheetToHtml(unsafeOptOutWs, { sanitizeLinks: false })).toContain('href="javascript:alert(1)"');
 	});
 
 	it("sanitizes script links with invisible unicode characters", () => {
@@ -78,7 +84,7 @@ describe("export security guards", () => {
 			A1: { t: "s", v: "Bad", l: { Target: "java\u200bscript:alert(1)" } },
 		} as WorkSheet;
 
-		expect(sheetToHtml(ws, { sanitizeLinks: true })).not.toContain("href=");
+		expect(sheetToHtml(ws)).not.toContain("href=");
 	});
 
 	it("sanitizes data and vbscript links", () => {
@@ -88,7 +94,7 @@ describe("export security guards", () => {
 				A1: { t: "s", v: "Bad", l: { Target: target } },
 			} as WorkSheet;
 
-			expect(sheetToHtml(ws, { sanitizeLinks: true })).not.toContain("href=");
+			expect(sheetToHtml(ws)).not.toContain("href=");
 		}
 	});
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -136,7 +136,7 @@ export interface ReadOptions extends CommonOptions {
 }
 
 /** Options for writing/serializing workbook files */
-export interface WriteOptions extends CommonOptions {
+export interface WriteOptions extends CommonOptions, Sheet2CSVOpts, Sheet2HTMLOpts {
 	/** Output data type: "base64" for base64 string, "buffer" for Node Buffer, "array" for Uint8Array, "string" for plain text */
 	type?: "base64" | "buffer" | "array" | "string";
 	/** Output file format (default: "xlsx") */
@@ -522,7 +522,7 @@ export interface Sheet2CSVOpts {
 	forceQuotes?: boolean;
 	/** If true, emit raw numeric values instead of formatted text */
 	rawNumbers?: boolean;
-	/** If true, prefix formula-like text fields with a single quote */
+	/** If not false, prefix formula-like text fields with a single quote */
 	escapeFormulae?: boolean;
 	/** Override date format for date cells */
 	dateNF?: NumberFormat;
@@ -538,7 +538,7 @@ export interface Sheet2HTMLOpts {
 	header?: string;
 	/** HTML to append after the table */
 	footer?: string;
-	/** If true, sanitize hyperlink targets to prevent XSS */
+	/** If not false, sanitize hyperlink targets to prevent XSS */
 	sanitizeLinks?: boolean;
 }
 

--- a/src/write.test.ts
+++ b/src/write.test.ts
@@ -40,4 +40,22 @@ describe("write.ts — output types", () => {
 		const csv = await write(emptyWb, { bookType: "csv", type: "string" });
 		expect(csv).toBe("");
 	});
+
+	it("should pass CSV export options through write", async () => {
+		const wb = createWorkbook(arrayToSheet([["=1+1"]]), "Sheet1");
+
+		await expect(write(wb, { bookType: "csv", type: "string" })).resolves.toBe("'=1+1");
+		await expect(write(wb, { bookType: "csv", type: "string", escapeFormulae: false })).resolves.toBe("=1+1");
+	});
+
+	it("should pass HTML export options through write", async () => {
+		const ws = arrayToSheet([["Bad"]]);
+		ws.A1.l = { Target: "javascript:alert(1)" };
+		const wb = createWorkbook(ws, "Sheet1");
+
+		await expect(write(wb, { bookType: "html", type: "string" })).resolves.not.toContain("href=");
+		await expect(write(wb, { bookType: "html", type: "string", sanitizeLinks: false })).resolves.toContain(
+			'href="javascript:alert(1)"',
+		);
+	});
 });

--- a/src/write.ts
+++ b/src/write.ts
@@ -62,15 +62,15 @@ export async function write(wb: WorkBook, opts?: WriteOptions): Promise<any> {
 	switch (bookType) {
 		case "csv": {
 			const ws = firstSheet(wb);
-			return textOutput(ws ? sheetToCsv(ws) : "", options.type);
+			return textOutput(ws ? sheetToCsv(ws, options) : "", options.type);
 		}
 		case "tsv": {
 			const ws = firstSheet(wb);
-			return textOutput(ws ? sheetToTxt(ws) : "", options.type);
+			return textOutput(ws ? sheetToTxt(ws, options) : "", options.type);
 		}
 		case "html": {
 			const ws = firstSheet(wb);
-			return textOutput(ws ? sheetToHtml(ws) : "", options.type);
+			return textOutput(ws ? sheetToHtml(ws, options) : "", options.type);
 		}
 		default: {
 			const zip = writeZipXlsx(wb, options);


### PR DESCRIPTION
## Summary

- make CSV formula escaping and HTML unsafe-link sanitization enabled by default
- keep explicit fidelity opt-outs with `escapeFormulae: false` and `sanitizeLinks: false`
- pass CSV/TSV/HTML export options through `write()`
- update tests and security docs for the new defaults

## Why

Issue #41 identified that the export mitigations existed but were opt-in, so naive exports of attacker-controlled data could still emit live spreadsheet formulas or scriptable HTML links.

## Validation

- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run check`
- `pnpm test`
- `pnpm --filter docs build`

Fixes #41
