### PR TITLE
[codex] chore(deps): update toolchain and docs dependencies

### DIFF
--- a/docs/app/root.tsx
+++ b/docs/app/root.tsx
@@ -1,16 +1,16 @@
-import { RootLayout, ArdoRoot } from "ardo/ui"
-import config from "virtual:ardo/config"
-import sidebar from "virtual:ardo/sidebar"
-import type { MetaFunction } from "react-router"
-import "ardo/ui/styles.css"
-import "./custom.css"
+import { ArdoRootLayout, ArdoRoot } from "ardo/ui";
+import config from "virtual:ardo/config";
+import sidebar from "virtual:ardo/sidebar";
+import type { MetaFunction } from "react-router";
+import "ardo/ui/styles.css";
+import "./custom.css";
 
-export const meta: MetaFunction = () => [{ title: config.title }]
+export const meta: MetaFunction = () => [{ title: config.title }];
 
 export function Layout({ children }: { children: React.ReactNode }) {
-  return <RootLayout>{children}</RootLayout>
+	return <ArdoRootLayout>{children}</ArdoRootLayout>;
 }
 
 export default function Root() {
-  return <ArdoRoot config={config} sidebar={sidebar} />
+	return <ArdoRoot config={config} sidebar={sidebar} />;
 }

--- a/docs/app/routes/home.tsx
+++ b/docs/app/routes/home.tsx
@@ -1,54 +1,68 @@
-import { Hero, Features } from "ardo/ui"
-import { Package, Zap, ShieldCheck, Globe, Paintbrush, ArrowLeftRight, ArrowRight, Github } from "lucide-react"
-import config from "virtual:ardo/config"
+import { ArdoHero, ArdoFeatures } from "ardo/ui";
+import { Package, Zap, ShieldCheck, Globe, Paintbrush, ArrowLeftRight, ArrowRight, ExternalLink } from "lucide-react";
+import config from "virtual:ardo/config";
 
 export default function HomePage() {
-  return (
-    <>
-      <Hero
-        name="xlsx-format"
-        text="The XLSX library your bundler will thank you for."
-        tagline={`v${config.project?.version ?? "0.0.0"} · Zero dependencies. Fully async. TypeScript-first.`}
-        actions={[
-          { text: "Get Started", link: "/guide/getting-started", theme: "brand", icon: <ArrowRight size={16} /> },
-          { text: "GitHub", link: "https://github.com/sebastian-software/xlsx-format", theme: "alt", icon: <Github size={16} /> },
-        ]}
-      />
-      <Features
-        items={[
-          {
-            title: "Zero Dependencies",
-            icon: <Package size={28} strokeWidth={1.5} />,
-            details: "No runtime dependencies. No supply chain risk. Nothing to audit, nothing to break.",
-          },
-          {
-            title: "Fully Async",
-            icon: <Zap size={28} strokeWidth={1.5} />,
-            details: "Streaming ZIP under the hood. Your event loop stays free while Excel files are read and written.",
-          },
-          {
-            title: "TypeScript-First",
-            icon: <ShieldCheck size={28} strokeWidth={1.5} />,
-            details: "Written in strict TypeScript from day one. Every export is fully typed — no .d.ts bolted on after the fact.",
-          },
-          {
-            title: "Browser-Ready",
-            icon: <Globe size={28} strokeWidth={1.5} />,
-            details: "Works with Uint8Array and ArrayBuffer. No Node.js APIs needed, no separate browser bundle required.",
-          },
-          {
-            title: "Styled XLSX Reports",
-            icon: <Paintbrush size={28} strokeWidth={1.5} />,
-            details:
-              "Write branded report exports with table headers, totals, merged titles, column widths, row heights, and frozen panes — without carrying ExcelJS just for styling.",
-          },
-          {
-            title: "Drop-In Migration",
-            icon: <ArrowLeftRight size={28} strokeWidth={1.5} />,
-            details: "API close to SheetJS by design. Add `await`, switch to named imports, and you're done.",
-          },
-        ]}
-      />
-    </>
-  )
+	return (
+		<>
+			<ArdoHero
+				name="xlsx-format"
+				text="The XLSX library your bundler will thank you for."
+				tagline={`v${config.project?.version ?? "0.0.0"} · Zero dependencies. Fully async. TypeScript-first.`}
+				actions={[
+					{
+						text: "Get Started",
+						link: "/guide/getting-started",
+						theme: "brand",
+						icon: <ArrowRight size={16} />,
+					},
+					{
+						text: "GitHub",
+						link: "https://github.com/sebastian-software/xlsx-format",
+						theme: "alt",
+						icon: <ExternalLink size={16} />,
+					},
+				]}
+			/>
+			<ArdoFeatures
+				items={[
+					{
+						title: "Zero Dependencies",
+						icon: <Package size={28} strokeWidth={1.5} />,
+						details: "No runtime dependencies. No supply chain risk. Nothing to audit, nothing to break.",
+					},
+					{
+						title: "Fully Async",
+						icon: <Zap size={28} strokeWidth={1.5} />,
+						details:
+							"Streaming ZIP under the hood. Your event loop stays free while Excel files are read and written.",
+					},
+					{
+						title: "TypeScript-First",
+						icon: <ShieldCheck size={28} strokeWidth={1.5} />,
+						details:
+							"Written in strict TypeScript from day one. Every export is fully typed — no .d.ts bolted on after the fact.",
+					},
+					{
+						title: "Browser-Ready",
+						icon: <Globe size={28} strokeWidth={1.5} />,
+						details:
+							"Works with Uint8Array and ArrayBuffer. No Node.js APIs needed, no separate browser bundle required.",
+					},
+					{
+						title: "Styled XLSX Reports",
+						icon: <Paintbrush size={28} strokeWidth={1.5} />,
+						details:
+							"Write branded report exports with table headers, totals, merged titles, column widths, row heights, and frozen panes — without carrying ExcelJS just for styling.",
+					},
+					{
+						title: "Drop-In Migration",
+						icon: <ArrowLeftRight size={28} strokeWidth={1.5} />,
+						details:
+							"API close to SheetJS by design. Add `await`, switch to named imports, and you're done.",
+					},
+				]}
+			/>
+		</>
+	);
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,18 +9,18 @@
 		"preview": "vite preview"
 	},
 	"dependencies": {
-		"ardo": "^2.7.0",
-		"isbot": "*",
-		"lucide-react": "^0.564.0",
-		"react": "*",
-		"react-dom": "*",
-		"react-router": "*"
+		"ardo": "^3.5.0",
+		"isbot": "^5.1.43",
+		"lucide-react": "^1.20.0",
+		"react": "^19.2.7",
+		"react-dom": "^19.2.7",
+		"react-router": "^7.18.0"
 	},
 	"devDependencies": {
-		"@react-router/dev": "*",
-		"@types/react": "^19.2.13",
+		"@react-router/dev": "^7.18.0",
+		"@types/react": "^19.2.17",
 		"@types/react-dom": "^19.2.3",
 		"typescript": "^5.9.3",
-		"vite": "^8.0.0-beta.0"
+		"vite": "^8.0.16"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -50,18 +50,18 @@
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.39.2",
-		"@types/node": "^25.2.3",
-		"@vitest/coverage-v8": "^4.0.18",
+		"@types/node": "^25.9.3",
+		"@vitest/coverage-v8": "^4.1.9",
 		"eslint": "^9.39.2",
 		"eslint-config-prettier": "^10.1.8",
 		"husky": "^9.1.7",
 		"lint-staged": "^16.2.7",
-		"prettier": "^3.8.1",
-		"tsdown": "^0.22.2",
-		"tsx": "^4.21.0",
+		"prettier": "^3.8.4",
+		"tsdown": "^0.22.3",
+		"tsx": "^4.22.4",
 		"typescript": "^5.9.3",
-		"typescript-eslint": "^8.55.0",
-		"vitest": "^4.0.18"
+		"typescript-eslint": "^8.61.1",
+		"vitest": "^4.1.9"
 	},
 	"engines": {
 		"node": ">=22"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,11 +11,11 @@ importers:
                 specifier: ^9.39.2
                 version: 9.39.2
             "@types/node":
-                specifier: ^25.2.3
-                version: 25.2.3
+                specifier: ^25.9.3
+                version: 25.9.3
             "@vitest/coverage-v8":
-                specifier: ^4.0.18
-                version: 4.0.18(vitest@4.0.18(@types/node@25.2.3)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+                specifier: ^4.1.9
+                version: 4.1.9(vitest@4.1.9)
             eslint:
                 specifier: ^9.39.2
                 version: 9.39.2
@@ -29,326 +29,315 @@ importers:
                 specifier: ^16.2.7
                 version: 16.2.7
             prettier:
-                specifier: ^3.8.1
-                version: 3.8.1
+                specifier: ^3.8.4
+                version: 3.8.4
             tsdown:
-                specifier: ^0.22.2
-                version: 0.22.2(tsx@4.21.0)(typescript@5.9.3)
+                specifier: ^0.22.3
+                version: 0.22.3(tsx@4.22.4)(typescript@5.9.3)
             tsx:
-                specifier: ^4.21.0
-                version: 4.21.0
+                specifier: ^4.22.4
+                version: 4.22.4
             typescript:
                 specifier: ^5.9.3
                 version: 5.9.3
             typescript-eslint:
-                specifier: ^8.55.0
-                version: 8.55.0(eslint@9.39.2)(typescript@5.9.3)
+                specifier: ^8.61.1
+                version: 8.61.1(eslint@9.39.2)(typescript@5.9.3)
             vitest:
-                specifier: ^4.0.18
-                version: 4.0.18(@types/node@25.2.3)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+                specifier: ^4.1.9
+                version: 4.1.9(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))
 
     docs:
         dependencies:
             ardo:
-                specifier: ^2.7.0
-                version: 2.7.0(@types/node@25.2.3)(lightningcss@1.31.1)(lucide-react@0.564.0(react@19.2.4))(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.0-beta.13(@types/node@25.2.3)(esbuild@0.27.3)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)
+                specifier: ^3.5.0
+                version: 3.5.0(@types/node@25.9.3)(esbuild@0.28.1)(lightningcss@1.32.0)(lucide-react@1.20.0(react@19.2.7))(rollup@4.62.0)(tsx@4.22.4)(typescript@5.9.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.2))(yaml@2.9.0)
             isbot:
-                specifier: "*"
-                version: 5.1.35
+                specifier: ^5.1.43
+                version: 5.1.43
             lucide-react:
-                specifier: ^0.564.0
-                version: 0.564.0(react@19.2.4)
+                specifier: ^1.20.0
+                version: 1.20.0(react@19.2.7)
             react:
-                specifier: "*"
-                version: 19.2.4
+                specifier: ^19.2.7
+                version: 19.2.7
             react-dom:
-                specifier: "*"
-                version: 19.2.4(react@19.2.4)
+                specifier: ^19.2.7
+                version: 19.2.7(react@19.2.7)
             react-router:
-                specifier: "*"
-                version: 7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+                specifier: ^7.18.0
+                version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
         devDependencies:
             "@react-router/dev":
-                specifier: "*"
-                version: 7.13.0(@types/node@25.2.3)(lightningcss@1.31.1)(react-router@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.0-beta.13(@types/node@25.2.3)(esbuild@0.27.3)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)
+                specifier: ^7.18.0
+                version: 7.18.0(@types/node@25.9.3)(lightningcss@1.32.0)(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(tsx@4.22.4)(typescript@5.9.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.2))(yaml@2.9.0)
             "@types/react":
-                specifier: ^19.2.13
-                version: 19.2.14
+                specifier: ^19.2.17
+                version: 19.2.17
             "@types/react-dom":
                 specifier: ^19.2.3
-                version: 19.2.3(@types/react@19.2.14)
+                version: 19.2.3(@types/react@19.2.17)
             typescript:
                 specifier: ^5.9.3
                 version: 5.9.3
             vite:
-                specifier: ^8.0.0-beta.0
-                version: 8.0.0-beta.13(@types/node@25.2.3)(esbuild@0.27.3)(tsx@4.21.0)(yaml@2.8.2)
+                specifier: ^8.0.16
+                version: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.2)
 
 packages:
-    "@babel/code-frame@7.29.0":
+    "@babel/code-frame@7.29.7":
         resolution:
             {
-                integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==,
+                integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==,
             }
         engines: { node: ">=6.9.0" }
 
-    "@babel/compat-data@7.29.0":
+    "@babel/compat-data@7.29.7":
         resolution:
             {
-                integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==,
+                integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==,
             }
         engines: { node: ">=6.9.0" }
 
-    "@babel/core@7.29.0":
+    "@babel/core@7.29.7":
         resolution:
             {
-                integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==,
+                integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==,
             }
         engines: { node: ">=6.9.0" }
 
-    "@babel/generator@7.29.1":
+    "@babel/generator@7.29.7":
         resolution:
             {
-                integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==,
+                integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==,
             }
         engines: { node: ">=6.9.0" }
 
-    "@babel/generator@8.0.0-rc.6":
+    "@babel/generator@8.0.0":
         resolution:
             {
-                integrity: sha512-6mIzgVK8DgEzvIapoQwhXTMnnkuE4STQmVv9H03i/tZ2ml8oev3TRvZJgTenK2Bsq0YWNtzOrFdTyNzCMFtjJQ==,
+                integrity: sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==,
             }
         engines: { node: ^22.18.0 || >=24.11.0 }
 
-    "@babel/helper-annotate-as-pure@7.27.3":
+    "@babel/helper-annotate-as-pure@7.29.7":
         resolution:
             {
-                integrity: sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==,
+                integrity: sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==,
             }
         engines: { node: ">=6.9.0" }
 
-    "@babel/helper-compilation-targets@7.28.6":
+    "@babel/helper-compilation-targets@7.29.7":
         resolution:
             {
-                integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==,
+                integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==,
             }
         engines: { node: ">=6.9.0" }
 
-    "@babel/helper-create-class-features-plugin@7.28.6":
+    "@babel/helper-create-class-features-plugin@7.29.7":
         resolution:
             {
-                integrity: sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==,
+                integrity: sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==,
             }
         engines: { node: ">=6.9.0" }
         peerDependencies:
             "@babel/core": ^7.0.0
 
-    "@babel/helper-globals@7.28.0":
+    "@babel/helper-globals@7.29.7":
         resolution:
             {
-                integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==,
+                integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==,
             }
         engines: { node: ">=6.9.0" }
 
-    "@babel/helper-member-expression-to-functions@7.28.5":
+    "@babel/helper-member-expression-to-functions@7.29.7":
         resolution:
             {
-                integrity: sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==,
+                integrity: sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==,
             }
         engines: { node: ">=6.9.0" }
 
-    "@babel/helper-module-imports@7.28.6":
+    "@babel/helper-module-imports@7.29.7":
         resolution:
             {
-                integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==,
+                integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==,
             }
         engines: { node: ">=6.9.0" }
 
-    "@babel/helper-module-transforms@7.28.6":
+    "@babel/helper-module-transforms@7.29.7":
         resolution:
             {
-                integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==,
-            }
-        engines: { node: ">=6.9.0" }
-        peerDependencies:
-            "@babel/core": ^7.0.0
-
-    "@babel/helper-optimise-call-expression@7.27.1":
-        resolution:
-            {
-                integrity: sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==,
-            }
-        engines: { node: ">=6.9.0" }
-
-    "@babel/helper-plugin-utils@7.28.6":
-        resolution:
-            {
-                integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==,
-            }
-        engines: { node: ">=6.9.0" }
-
-    "@babel/helper-replace-supers@7.28.6":
-        resolution:
-            {
-                integrity: sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==,
+                integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==,
             }
         engines: { node: ">=6.9.0" }
         peerDependencies:
             "@babel/core": ^7.0.0
 
-    "@babel/helper-skip-transparent-expression-wrappers@7.27.1":
+    "@babel/helper-optimise-call-expression@7.29.7":
         resolution:
             {
-                integrity: sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==,
+                integrity: sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==,
             }
         engines: { node: ">=6.9.0" }
 
-    "@babel/helper-string-parser@7.27.1":
+    "@babel/helper-plugin-utils@7.29.7":
         resolution:
             {
-                integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==,
+                integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==,
             }
         engines: { node: ">=6.9.0" }
 
-    "@babel/helper-string-parser@8.0.0-rc.6":
+    "@babel/helper-replace-supers@7.29.7":
         resolution:
             {
-                integrity: sha512-BCkFy+zN6kXQed3YOT7aJl93NfDSzQc3pBfsvTVPs9gU9X3V0aefEF5kwBT0E+mDWH9QgKaZstYUQN9VdQZT4g==,
+                integrity: sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==,
+            }
+        engines: { node: ">=6.9.0" }
+        peerDependencies:
+            "@babel/core": ^7.0.0
+
+    "@babel/helper-skip-transparent-expression-wrappers@7.29.7":
+        resolution:
+            {
+                integrity: sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==,
+            }
+        engines: { node: ">=6.9.0" }
+
+    "@babel/helper-string-parser@7.29.7":
+        resolution:
+            {
+                integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==,
+            }
+        engines: { node: ">=6.9.0" }
+
+    "@babel/helper-string-parser@8.0.0":
+        resolution:
+            {
+                integrity: sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==,
             }
         engines: { node: ^22.18.0 || >=24.11.0 }
 
-    "@babel/helper-validator-identifier@7.28.5":
+    "@babel/helper-validator-identifier@7.29.7":
         resolution:
             {
-                integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==,
+                integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==,
             }
         engines: { node: ">=6.9.0" }
 
-    "@babel/helper-validator-identifier@8.0.0-rc.6":
+    "@babel/helper-validator-identifier@8.0.0":
         resolution:
             {
-                integrity: sha512-nVJ+1JcCgntv8d78rRo++o2wuODT0Irknx2BF8Np4Ft2CRgjLqIs4qzSZ8b66yGbBdMWGmZBO9WEZv1hhNiSpg==,
+                integrity: sha512-kXxQVZHNOctSJJsqzmcbPSCEkM6oHNnDIkua7g9RCO9xRHj2eCiKvRx2KPdfWR9QxcGWnK/oArrtunmie3rL9g==,
             }
         engines: { node: ^22.18.0 || >=24.11.0 }
 
-    "@babel/helper-validator-option@7.27.1":
+    "@babel/helper-validator-option@7.29.7":
         resolution:
             {
-                integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==,
+                integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==,
             }
         engines: { node: ">=6.9.0" }
 
-    "@babel/helpers@7.28.6":
+    "@babel/helpers@7.29.7":
         resolution:
             {
-                integrity: sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==,
+                integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==,
             }
         engines: { node: ">=6.9.0" }
 
-    "@babel/parser@7.29.0":
+    "@babel/parser@7.29.7":
         resolution:
             {
-                integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==,
+                integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==,
             }
         engines: { node: ">=6.0.0" }
         hasBin: true
 
-    "@babel/parser@8.0.0-rc.6":
+    "@babel/parser@8.0.0":
         resolution:
             {
-                integrity: sha512-rOS8IpdO7mQELkTPlCsTgPejO0bFuZdEDCGQJouYbYf9e1FLTym7Fei2pEjq8q7MWbX0ravcd7QQYKs1TxOuog==,
+                integrity: sha512-aLxAE+imI9bCcyaPrUDjBv3uSkWieifjLe0kuFOZF0zli0L6GCsTmsePnTr55adbIAgYz2zhN1vnFimCBUYcRQ==,
             }
         engines: { node: ^22.18.0 || >=24.11.0 }
         hasBin: true
 
-    "@babel/plugin-syntax-jsx@7.28.6":
+    "@babel/plugin-syntax-jsx@7.29.7":
         resolution:
             {
-                integrity: sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==,
+                integrity: sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==,
             }
         engines: { node: ">=6.9.0" }
         peerDependencies:
             "@babel/core": ^7.0.0-0
 
-    "@babel/plugin-syntax-typescript@7.28.6":
+    "@babel/plugin-syntax-typescript@7.29.7":
         resolution:
             {
-                integrity: sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==,
+                integrity: sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==,
             }
         engines: { node: ">=6.9.0" }
         peerDependencies:
             "@babel/core": ^7.0.0-0
 
-    "@babel/plugin-transform-modules-commonjs@7.28.6":
+    "@babel/plugin-transform-modules-commonjs@7.29.7":
         resolution:
             {
-                integrity: sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==,
+                integrity: sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==,
             }
         engines: { node: ">=6.9.0" }
         peerDependencies:
             "@babel/core": ^7.0.0-0
 
-    "@babel/plugin-transform-react-jsx-self@7.27.1":
+    "@babel/plugin-transform-typescript@7.29.7":
         resolution:
             {
-                integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==,
+                integrity: sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==,
             }
         engines: { node: ">=6.9.0" }
         peerDependencies:
             "@babel/core": ^7.0.0-0
 
-    "@babel/plugin-transform-react-jsx-source@7.27.1":
+    "@babel/preset-typescript@7.29.7":
         resolution:
             {
-                integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==,
+                integrity: sha512-/Foi8vKY2EVbed/1eZx0gJEEwHAIxogrySI7rULcRIvhZzbvoE/b5qG5Ghc0WKAFKOHA9SD1x7RsFlOYdutIiQ==,
             }
         engines: { node: ">=6.9.0" }
         peerDependencies:
             "@babel/core": ^7.0.0-0
 
-    "@babel/plugin-transform-typescript@7.28.6":
+    "@babel/runtime@7.29.7":
         resolution:
             {
-                integrity: sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw==,
-            }
-        engines: { node: ">=6.9.0" }
-        peerDependencies:
-            "@babel/core": ^7.0.0-0
-
-    "@babel/preset-typescript@7.28.5":
-        resolution:
-            {
-                integrity: sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==,
-            }
-        engines: { node: ">=6.9.0" }
-        peerDependencies:
-            "@babel/core": ^7.0.0-0
-
-    "@babel/template@7.28.6":
-        resolution:
-            {
-                integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==,
+                integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==,
             }
         engines: { node: ">=6.9.0" }
 
-    "@babel/traverse@7.29.0":
+    "@babel/template@7.29.7":
         resolution:
             {
-                integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==,
+                integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==,
             }
         engines: { node: ">=6.9.0" }
 
-    "@babel/types@7.29.0":
+    "@babel/traverse@7.29.7":
         resolution:
             {
-                integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==,
+                integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==,
             }
         engines: { node: ">=6.9.0" }
 
-    "@babel/types@8.0.0-rc.6":
+    "@babel/types@7.29.7":
         resolution:
             {
-                integrity: sha512-p7/ABylAYlexb31wtRdIfH9L9A0Z2T/9H6zAqzqndkY2PLkvNNc580wGhp/gGKN4Sp9sQvSkhc6Oga8/O+wTyw==,
+                integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==,
+            }
+        engines: { node: ">=6.9.0" }
+
+    "@babel/types@8.0.0":
+        resolution:
+            {
+                integrity: sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==,
             }
         engines: { node: ^22.18.0 || >=24.11.0 }
 
@@ -359,16 +348,22 @@ packages:
             }
         engines: { node: ">=18" }
 
+    "@emnapi/core@1.10.0":
+        resolution:
+            {
+                integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==,
+            }
+
     "@emnapi/core@1.11.0":
         resolution:
             {
                 integrity: sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==,
             }
 
-    "@emnapi/core@1.8.1":
+    "@emnapi/runtime@1.10.0":
         resolution:
             {
-                integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==,
+                integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==,
             }
 
     "@emnapi/runtime@1.11.0":
@@ -377,16 +372,10 @@ packages:
                 integrity: sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==,
             }
 
-    "@emnapi/runtime@1.8.1":
+    "@emnapi/wasi-threads@1.2.1":
         resolution:
             {
-                integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==,
-            }
-
-    "@emnapi/wasi-threads@1.1.0":
-        resolution:
-            {
-                integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==,
+                integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==,
             }
 
     "@emnapi/wasi-threads@1.2.2":
@@ -395,235 +384,475 @@ packages:
                 integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==,
             }
 
-    "@esbuild/aix-ppc64@0.27.3":
+    "@emotion/hash@0.9.2":
         resolution:
             {
-                integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==,
+                integrity: sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==,
+            }
+
+    "@esbuild/aix-ppc64@0.27.7":
+        resolution:
+            {
+                integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==,
             }
         engines: { node: ">=18" }
         cpu: [ppc64]
         os: [aix]
 
-    "@esbuild/android-arm64@0.27.3":
+    "@esbuild/aix-ppc64@0.28.1":
         resolution:
             {
-                integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==,
+                integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==,
+            }
+        engines: { node: ">=18" }
+        cpu: [ppc64]
+        os: [aix]
+
+    "@esbuild/android-arm64@0.27.7":
+        resolution:
+            {
+                integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==,
             }
         engines: { node: ">=18" }
         cpu: [arm64]
         os: [android]
 
-    "@esbuild/android-arm@0.27.3":
+    "@esbuild/android-arm64@0.28.1":
         resolution:
             {
-                integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==,
+                integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==,
+            }
+        engines: { node: ">=18" }
+        cpu: [arm64]
+        os: [android]
+
+    "@esbuild/android-arm@0.27.7":
+        resolution:
+            {
+                integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==,
             }
         engines: { node: ">=18" }
         cpu: [arm]
         os: [android]
 
-    "@esbuild/android-x64@0.27.3":
+    "@esbuild/android-arm@0.28.1":
         resolution:
             {
-                integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==,
+                integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==,
+            }
+        engines: { node: ">=18" }
+        cpu: [arm]
+        os: [android]
+
+    "@esbuild/android-x64@0.27.7":
+        resolution:
+            {
+                integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==,
             }
         engines: { node: ">=18" }
         cpu: [x64]
         os: [android]
 
-    "@esbuild/darwin-arm64@0.27.3":
+    "@esbuild/android-x64@0.28.1":
         resolution:
             {
-                integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==,
+                integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==,
+            }
+        engines: { node: ">=18" }
+        cpu: [x64]
+        os: [android]
+
+    "@esbuild/darwin-arm64@0.27.7":
+        resolution:
+            {
+                integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==,
             }
         engines: { node: ">=18" }
         cpu: [arm64]
         os: [darwin]
 
-    "@esbuild/darwin-x64@0.27.3":
+    "@esbuild/darwin-arm64@0.28.1":
         resolution:
             {
-                integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==,
+                integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==,
+            }
+        engines: { node: ">=18" }
+        cpu: [arm64]
+        os: [darwin]
+
+    "@esbuild/darwin-x64@0.27.7":
+        resolution:
+            {
+                integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==,
             }
         engines: { node: ">=18" }
         cpu: [x64]
         os: [darwin]
 
-    "@esbuild/freebsd-arm64@0.27.3":
+    "@esbuild/darwin-x64@0.28.1":
         resolution:
             {
-                integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==,
+                integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==,
+            }
+        engines: { node: ">=18" }
+        cpu: [x64]
+        os: [darwin]
+
+    "@esbuild/freebsd-arm64@0.27.7":
+        resolution:
+            {
+                integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==,
             }
         engines: { node: ">=18" }
         cpu: [arm64]
         os: [freebsd]
 
-    "@esbuild/freebsd-x64@0.27.3":
+    "@esbuild/freebsd-arm64@0.28.1":
         resolution:
             {
-                integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==,
+                integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==,
+            }
+        engines: { node: ">=18" }
+        cpu: [arm64]
+        os: [freebsd]
+
+    "@esbuild/freebsd-x64@0.27.7":
+        resolution:
+            {
+                integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==,
             }
         engines: { node: ">=18" }
         cpu: [x64]
         os: [freebsd]
 
-    "@esbuild/linux-arm64@0.27.3":
+    "@esbuild/freebsd-x64@0.28.1":
         resolution:
             {
-                integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==,
+                integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==,
+            }
+        engines: { node: ">=18" }
+        cpu: [x64]
+        os: [freebsd]
+
+    "@esbuild/linux-arm64@0.27.7":
+        resolution:
+            {
+                integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==,
             }
         engines: { node: ">=18" }
         cpu: [arm64]
         os: [linux]
 
-    "@esbuild/linux-arm@0.27.3":
+    "@esbuild/linux-arm64@0.28.1":
         resolution:
             {
-                integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==,
+                integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==,
+            }
+        engines: { node: ">=18" }
+        cpu: [arm64]
+        os: [linux]
+
+    "@esbuild/linux-arm@0.27.7":
+        resolution:
+            {
+                integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==,
             }
         engines: { node: ">=18" }
         cpu: [arm]
         os: [linux]
 
-    "@esbuild/linux-ia32@0.27.3":
+    "@esbuild/linux-arm@0.28.1":
         resolution:
             {
-                integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==,
+                integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==,
+            }
+        engines: { node: ">=18" }
+        cpu: [arm]
+        os: [linux]
+
+    "@esbuild/linux-ia32@0.27.7":
+        resolution:
+            {
+                integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==,
             }
         engines: { node: ">=18" }
         cpu: [ia32]
         os: [linux]
 
-    "@esbuild/linux-loong64@0.27.3":
+    "@esbuild/linux-ia32@0.28.1":
         resolution:
             {
-                integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==,
+                integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==,
+            }
+        engines: { node: ">=18" }
+        cpu: [ia32]
+        os: [linux]
+
+    "@esbuild/linux-loong64@0.27.7":
+        resolution:
+            {
+                integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==,
             }
         engines: { node: ">=18" }
         cpu: [loong64]
         os: [linux]
 
-    "@esbuild/linux-mips64el@0.27.3":
+    "@esbuild/linux-loong64@0.28.1":
         resolution:
             {
-                integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==,
+                integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==,
+            }
+        engines: { node: ">=18" }
+        cpu: [loong64]
+        os: [linux]
+
+    "@esbuild/linux-mips64el@0.27.7":
+        resolution:
+            {
+                integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==,
             }
         engines: { node: ">=18" }
         cpu: [mips64el]
         os: [linux]
 
-    "@esbuild/linux-ppc64@0.27.3":
+    "@esbuild/linux-mips64el@0.28.1":
         resolution:
             {
-                integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==,
+                integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==,
+            }
+        engines: { node: ">=18" }
+        cpu: [mips64el]
+        os: [linux]
+
+    "@esbuild/linux-ppc64@0.27.7":
+        resolution:
+            {
+                integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==,
             }
         engines: { node: ">=18" }
         cpu: [ppc64]
         os: [linux]
 
-    "@esbuild/linux-riscv64@0.27.3":
+    "@esbuild/linux-ppc64@0.28.1":
         resolution:
             {
-                integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==,
+                integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==,
+            }
+        engines: { node: ">=18" }
+        cpu: [ppc64]
+        os: [linux]
+
+    "@esbuild/linux-riscv64@0.27.7":
+        resolution:
+            {
+                integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==,
             }
         engines: { node: ">=18" }
         cpu: [riscv64]
         os: [linux]
 
-    "@esbuild/linux-s390x@0.27.3":
+    "@esbuild/linux-riscv64@0.28.1":
         resolution:
             {
-                integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==,
+                integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==,
+            }
+        engines: { node: ">=18" }
+        cpu: [riscv64]
+        os: [linux]
+
+    "@esbuild/linux-s390x@0.27.7":
+        resolution:
+            {
+                integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==,
             }
         engines: { node: ">=18" }
         cpu: [s390x]
         os: [linux]
 
-    "@esbuild/linux-x64@0.27.3":
+    "@esbuild/linux-s390x@0.28.1":
         resolution:
             {
-                integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==,
+                integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==,
+            }
+        engines: { node: ">=18" }
+        cpu: [s390x]
+        os: [linux]
+
+    "@esbuild/linux-x64@0.27.7":
+        resolution:
+            {
+                integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==,
             }
         engines: { node: ">=18" }
         cpu: [x64]
         os: [linux]
 
-    "@esbuild/netbsd-arm64@0.27.3":
+    "@esbuild/linux-x64@0.28.1":
         resolution:
             {
-                integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==,
+                integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==,
+            }
+        engines: { node: ">=18" }
+        cpu: [x64]
+        os: [linux]
+
+    "@esbuild/netbsd-arm64@0.27.7":
+        resolution:
+            {
+                integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==,
             }
         engines: { node: ">=18" }
         cpu: [arm64]
         os: [netbsd]
 
-    "@esbuild/netbsd-x64@0.27.3":
+    "@esbuild/netbsd-arm64@0.28.1":
         resolution:
             {
-                integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==,
+                integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==,
+            }
+        engines: { node: ">=18" }
+        cpu: [arm64]
+        os: [netbsd]
+
+    "@esbuild/netbsd-x64@0.27.7":
+        resolution:
+            {
+                integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==,
             }
         engines: { node: ">=18" }
         cpu: [x64]
         os: [netbsd]
 
-    "@esbuild/openbsd-arm64@0.27.3":
+    "@esbuild/netbsd-x64@0.28.1":
         resolution:
             {
-                integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==,
+                integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==,
+            }
+        engines: { node: ">=18" }
+        cpu: [x64]
+        os: [netbsd]
+
+    "@esbuild/openbsd-arm64@0.27.7":
+        resolution:
+            {
+                integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==,
             }
         engines: { node: ">=18" }
         cpu: [arm64]
         os: [openbsd]
 
-    "@esbuild/openbsd-x64@0.27.3":
+    "@esbuild/openbsd-arm64@0.28.1":
         resolution:
             {
-                integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==,
+                integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==,
+            }
+        engines: { node: ">=18" }
+        cpu: [arm64]
+        os: [openbsd]
+
+    "@esbuild/openbsd-x64@0.27.7":
+        resolution:
+            {
+                integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==,
             }
         engines: { node: ">=18" }
         cpu: [x64]
         os: [openbsd]
 
-    "@esbuild/openharmony-arm64@0.27.3":
+    "@esbuild/openbsd-x64@0.28.1":
         resolution:
             {
-                integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==,
+                integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==,
+            }
+        engines: { node: ">=18" }
+        cpu: [x64]
+        os: [openbsd]
+
+    "@esbuild/openharmony-arm64@0.27.7":
+        resolution:
+            {
+                integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==,
             }
         engines: { node: ">=18" }
         cpu: [arm64]
         os: [openharmony]
 
-    "@esbuild/sunos-x64@0.27.3":
+    "@esbuild/openharmony-arm64@0.28.1":
         resolution:
             {
-                integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==,
+                integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==,
+            }
+        engines: { node: ">=18" }
+        cpu: [arm64]
+        os: [openharmony]
+
+    "@esbuild/sunos-x64@0.27.7":
+        resolution:
+            {
+                integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==,
             }
         engines: { node: ">=18" }
         cpu: [x64]
         os: [sunos]
 
-    "@esbuild/win32-arm64@0.27.3":
+    "@esbuild/sunos-x64@0.28.1":
         resolution:
             {
-                integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==,
+                integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==,
+            }
+        engines: { node: ">=18" }
+        cpu: [x64]
+        os: [sunos]
+
+    "@esbuild/win32-arm64@0.27.7":
+        resolution:
+            {
+                integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==,
             }
         engines: { node: ">=18" }
         cpu: [arm64]
         os: [win32]
 
-    "@esbuild/win32-ia32@0.27.3":
+    "@esbuild/win32-arm64@0.28.1":
         resolution:
             {
-                integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==,
+                integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==,
+            }
+        engines: { node: ">=18" }
+        cpu: [arm64]
+        os: [win32]
+
+    "@esbuild/win32-ia32@0.27.7":
+        resolution:
+            {
+                integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==,
             }
         engines: { node: ">=18" }
         cpu: [ia32]
         os: [win32]
 
-    "@esbuild/win32-x64@0.27.3":
+    "@esbuild/win32-ia32@0.28.1":
         resolution:
             {
-                integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==,
+                integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==,
+            }
+        engines: { node: ">=18" }
+        cpu: [ia32]
+        os: [win32]
+
+    "@esbuild/win32-x64@0.27.7":
+        resolution:
+            {
+                integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==,
+            }
+        engines: { node: ">=18" }
+        cpu: [x64]
+        os: [win32]
+
+    "@esbuild/win32-x64@0.28.1":
+        resolution:
+            {
+                integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==,
             }
         engines: { node: ">=18" }
         cpu: [x64]
@@ -694,10 +923,10 @@ packages:
             }
         engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
-    "@gerrit0/mini-shiki@3.22.0":
+    "@gerrit0/mini-shiki@3.23.0":
         resolution:
             {
-                integrity: sha512-jMpciqEVUBKE1QwU64S4saNMzpsSza6diNCk4MWAeCxO2+LFi2FIFmL2S0VDLzEJCxuvCbU783xi8Hp/gkM5CQ==,
+                integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==,
             }
 
     "@humanfs/core@0.19.1":
@@ -779,12 +1008,6 @@ packages:
                 integrity: sha512-EMlH1e30yzmTpGLQjlFmaDAjyOeZhng1/XCd7DExR8PNAnG/G1tyruZxEoUe11ClnwGhGrtsdnyyUx1frSzjng==,
             }
 
-    "@napi-rs/wasm-runtime@1.1.1":
-        resolution:
-            {
-                integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==,
-            }
-
     "@napi-rs/wasm-runtime@1.1.5":
         resolution:
             {
@@ -794,17 +1017,10 @@ packages:
             "@emnapi/core": ^1.7.1
             "@emnapi/runtime": ^1.7.1
 
-    "@oxc-project/runtime@0.112.0":
+    "@oxc-project/types@0.133.0":
         resolution:
             {
-                integrity: sha512-4vYtWXMnXM6EaweCxbJ6bISAhkNHeN33SihvuX3wrpqaSJA4ZEoW35i9mSvE74+GDf1yTeVE+aEHA+WBpjDk/g==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-
-    "@oxc-project/types@0.112.0":
-        resolution:
-            {
-                integrity: sha512-m6RebKHIRsax2iCwVpYW2ErQwa4ywHJrE4sCK3/8JK8ZZAWOKXaRJFl/uP51gaVyyXlaS4+chU1nSCdzYf6QqQ==,
+                integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==,
             }
 
     "@oxc-project/types@0.135.0":
@@ -819,20 +1035,20 @@ packages:
                 integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==,
             }
 
-    "@react-router/dev@7.13.0":
+    "@react-router/dev@7.18.0":
         resolution:
             {
-                integrity: sha512-0vRfTrS6wIXr9j0STu614Cv2ytMr21evnv1r+DXPv5cJ4q0V2x2kBAXC8TAqEXkpN5vdhbXBlbGQ821zwOfhvg==,
+                integrity: sha512-GVTFvul0xlZHZyVXyRpiJv54Xfyj4eDOAlGYrzi7kDmN7n40rsrUqX+hvU0fy/41SCDMtckht59R3iGR94703g==,
             }
         engines: { node: ">=20.0.0" }
         hasBin: true
         peerDependencies:
-            "@react-router/serve": ^7.13.0
-            "@vitejs/plugin-rsc": ~0.5.7
-            react-router: ^7.13.0
+            "@react-router/serve": ^7.18.0
+            "@vitejs/plugin-rsc": ~0.5.21
+            react-router: ^7.18.0
             react-server-dom-webpack: ^19.2.3
-            typescript: ^5.1.0
-            vite: ^5.1.0 || ^6.0.0 || ^7.0.0
+            typescript: ^5.1.0 || ^6.0.0
+            vite: ^5.1.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
             wrangler: ^3.28.2 || ^4.0.0
         peerDependenciesMeta:
             "@react-router/serve":
@@ -846,29 +1062,148 @@ packages:
             wrangler:
                 optional: true
 
-    "@react-router/node@7.13.0":
+    "@react-router/node@7.18.0":
         resolution:
             {
-                integrity: sha512-Mhr3fAou19oc/S93tKMIBHwCPfqLpWyWM/m0NWd3pJh/wZin8/9KhAdjwxhYbXw1TrTBZBLDENa35uZ+Y7oh3A==,
+                integrity: sha512-pRXJahLrdVfuVbaTpWsZ89mBuGiYH3Z4y+y1UidwxmJFKk6NjMyUvkJl3FjDWdD+nSlgFPSESUZS0hF560MUUQ==,
             }
         engines: { node: ">=20.0.0" }
         peerDependencies:
-            react-router: 7.13.0
-            typescript: ^5.1.0
+            react-router: 7.18.0
+            typescript: ^5.1.0 || ^6.0.0
         peerDependenciesMeta:
             typescript:
                 optional: true
 
-    "@remix-run/node-fetch-server@0.13.0":
+    "@remix-run/node-fetch-server@0.13.3":
         resolution:
             {
-                integrity: sha512-1EsNo0ZpgXu/90AWoRZf/oE3RVTUS80tiTUpt+hv5pjtAkw7icN4WskDwz/KdAw5ARbJLMhZBrO1NqThmy/McA==,
+                integrity: sha512-UfjOXed/DQteaM5VyTfqTeGpHwyL2J5aoRGY6cydip4tt1ehNNeSwuXCC7AEGE0RWBs/7bgKxYkL/B/+UDe4AA==,
             }
 
-    "@rolldown/binding-android-arm64@1.0.0-rc.3":
+    "@resvg/resvg-js-android-arm-eabi@2.6.2":
         resolution:
             {
-                integrity: sha512-0T1k9FinuBZ/t7rZ8jN6OpUKPnUjNdYHoj/cESWrQ3ZraAJ4OMm6z7QjSfCxqj8mOp9kTKc1zHK3kGz5vMu+nQ==,
+                integrity: sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==,
+            }
+        engines: { node: ">= 10" }
+        cpu: [arm]
+        os: [android]
+
+    "@resvg/resvg-js-android-arm64@2.6.2":
+        resolution:
+            {
+                integrity: sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==,
+            }
+        engines: { node: ">= 10" }
+        cpu: [arm64]
+        os: [android]
+
+    "@resvg/resvg-js-darwin-arm64@2.6.2":
+        resolution:
+            {
+                integrity: sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==,
+            }
+        engines: { node: ">= 10" }
+        cpu: [arm64]
+        os: [darwin]
+
+    "@resvg/resvg-js-darwin-x64@2.6.2":
+        resolution:
+            {
+                integrity: sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==,
+            }
+        engines: { node: ">= 10" }
+        cpu: [x64]
+        os: [darwin]
+
+    "@resvg/resvg-js-linux-arm-gnueabihf@2.6.2":
+        resolution:
+            {
+                integrity: sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==,
+            }
+        engines: { node: ">= 10" }
+        cpu: [arm]
+        os: [linux]
+
+    "@resvg/resvg-js-linux-arm64-gnu@2.6.2":
+        resolution:
+            {
+                integrity: sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==,
+            }
+        engines: { node: ">= 10" }
+        cpu: [arm64]
+        os: [linux]
+        libc: [glibc]
+
+    "@resvg/resvg-js-linux-arm64-musl@2.6.2":
+        resolution:
+            {
+                integrity: sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==,
+            }
+        engines: { node: ">= 10" }
+        cpu: [arm64]
+        os: [linux]
+        libc: [musl]
+
+    "@resvg/resvg-js-linux-x64-gnu@2.6.2":
+        resolution:
+            {
+                integrity: sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==,
+            }
+        engines: { node: ">= 10" }
+        cpu: [x64]
+        os: [linux]
+        libc: [glibc]
+
+    "@resvg/resvg-js-linux-x64-musl@2.6.2":
+        resolution:
+            {
+                integrity: sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==,
+            }
+        engines: { node: ">= 10" }
+        cpu: [x64]
+        os: [linux]
+        libc: [musl]
+
+    "@resvg/resvg-js-win32-arm64-msvc@2.6.2":
+        resolution:
+            {
+                integrity: sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==,
+            }
+        engines: { node: ">= 10" }
+        cpu: [arm64]
+        os: [win32]
+
+    "@resvg/resvg-js-win32-ia32-msvc@2.6.2":
+        resolution:
+            {
+                integrity: sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==,
+            }
+        engines: { node: ">= 10" }
+        cpu: [ia32]
+        os: [win32]
+
+    "@resvg/resvg-js-win32-x64-msvc@2.6.2":
+        resolution:
+            {
+                integrity: sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==,
+            }
+        engines: { node: ">= 10" }
+        cpu: [x64]
+        os: [win32]
+
+    "@resvg/resvg-js@2.6.2":
+        resolution:
+            {
+                integrity: sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==,
+            }
+        engines: { node: ">= 10" }
+
+    "@rolldown/binding-android-arm64@1.0.3":
+        resolution:
+            {
+                integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==,
             }
         engines: { node: ^20.19.0 || >=22.12.0 }
         cpu: [arm64]
@@ -883,10 +1218,10 @@ packages:
         cpu: [arm64]
         os: [android]
 
-    "@rolldown/binding-darwin-arm64@1.0.0-rc.3":
+    "@rolldown/binding-darwin-arm64@1.0.3":
         resolution:
             {
-                integrity: sha512-JWWLzvcmc/3pe7qdJqPpuPk91SoE/N+f3PcWx/6ZwuyDVyungAEJPvKm/eEldiDdwTmaEzWfIR+HORxYWrCi1A==,
+                integrity: sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==,
             }
         engines: { node: ^20.19.0 || >=22.12.0 }
         cpu: [arm64]
@@ -901,10 +1236,10 @@ packages:
         cpu: [arm64]
         os: [darwin]
 
-    "@rolldown/binding-darwin-x64@1.0.0-rc.3":
+    "@rolldown/binding-darwin-x64@1.0.3":
         resolution:
             {
-                integrity: sha512-MTakBxfx3tde5WSmbHxuqlDsIW0EzQym+PJYGF4P6lG2NmKzi128OGynoFUqoD5ryCySEY85dug4v+LWGBElIw==,
+                integrity: sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==,
             }
         engines: { node: ^20.19.0 || >=22.12.0 }
         cpu: [x64]
@@ -919,10 +1254,10 @@ packages:
         cpu: [x64]
         os: [darwin]
 
-    "@rolldown/binding-freebsd-x64@1.0.0-rc.3":
+    "@rolldown/binding-freebsd-x64@1.0.3":
         resolution:
             {
-                integrity: sha512-jje3oopyOLs7IwfvXoS6Lxnmie5JJO7vW29fdGFu5YGY1EDbVDhD+P9vDihqS5X6fFiqL3ZQZCMBg6jyHkSVww==,
+                integrity: sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==,
             }
         engines: { node: ^20.19.0 || >=22.12.0 }
         cpu: [x64]
@@ -937,10 +1272,10 @@ packages:
         cpu: [x64]
         os: [freebsd]
 
-    "@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.3":
+    "@rolldown/binding-linux-arm-gnueabihf@1.0.3":
         resolution:
             {
-                integrity: sha512-A0n8P3hdLAaqzSFrQoA42p23ZKBYQOw+8EH5r15Sa9X1kD9/JXe0YT2gph2QTWvdr0CVK2BOXiK6ENfy6DXOag==,
+                integrity: sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==,
             }
         engines: { node: ^20.19.0 || >=22.12.0 }
         cpu: [arm]
@@ -955,10 +1290,10 @@ packages:
         cpu: [arm]
         os: [linux]
 
-    "@rolldown/binding-linux-arm64-gnu@1.0.0-rc.3":
+    "@rolldown/binding-linux-arm64-gnu@1.0.3":
         resolution:
             {
-                integrity: sha512-kWXkoxxarYISBJ4bLNf5vFkEbb4JvccOwxWDxuK9yee8lg5XA7OpvlTptfRuwEvYcOZf+7VS69Uenpmpyo5Bjw==,
+                integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==,
             }
         engines: { node: ^20.19.0 || >=22.12.0 }
         cpu: [arm64]
@@ -975,10 +1310,10 @@ packages:
         os: [linux]
         libc: [glibc]
 
-    "@rolldown/binding-linux-arm64-musl@1.0.0-rc.3":
+    "@rolldown/binding-linux-arm64-musl@1.0.3":
         resolution:
             {
-                integrity: sha512-Z03/wrqau9Bicfgb3Dbs6SYTHliELk2PM2LpG2nFd+cGupTMF5kanLEcj2vuuJLLhptNyS61rtk7SOZ+lPsTUA==,
+                integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==,
             }
         engines: { node: ^20.19.0 || >=22.12.0 }
         cpu: [arm64]
@@ -995,6 +1330,16 @@ packages:
         os: [linux]
         libc: [musl]
 
+    "@rolldown/binding-linux-ppc64-gnu@1.0.3":
+        resolution:
+            {
+                integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        cpu: [ppc64]
+        os: [linux]
+        libc: [glibc]
+
     "@rolldown/binding-linux-ppc64-gnu@1.1.1":
         resolution:
             {
@@ -1002,6 +1347,16 @@ packages:
             }
         engines: { node: ^20.19.0 || >=22.12.0 }
         cpu: [ppc64]
+        os: [linux]
+        libc: [glibc]
+
+    "@rolldown/binding-linux-s390x-gnu@1.0.3":
+        resolution:
+            {
+                integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        cpu: [s390x]
         os: [linux]
         libc: [glibc]
 
@@ -1015,10 +1370,10 @@ packages:
         os: [linux]
         libc: [glibc]
 
-    "@rolldown/binding-linux-x64-gnu@1.0.0-rc.3":
+    "@rolldown/binding-linux-x64-gnu@1.0.3":
         resolution:
             {
-                integrity: sha512-iSXXZsQp08CSilff/DCTFZHSVEpEwdicV3W8idHyrByrcsRDVh9sGC3sev6d8BygSGj3vt8GvUKBPCoyMA4tgQ==,
+                integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==,
             }
         engines: { node: ^20.19.0 || >=22.12.0 }
         cpu: [x64]
@@ -1035,10 +1390,10 @@ packages:
         os: [linux]
         libc: [glibc]
 
-    "@rolldown/binding-linux-x64-musl@1.0.0-rc.3":
+    "@rolldown/binding-linux-x64-musl@1.0.3":
         resolution:
             {
-                integrity: sha512-qaj+MFudtdCv9xZo9znFvkgoajLdc+vwf0Kz5N44g+LU5XMe+IsACgn3UG7uTRlCCvhMAGXm1XlpEA5bZBrOcw==,
+                integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==,
             }
         engines: { node: ^20.19.0 || >=22.12.0 }
         cpu: [x64]
@@ -1055,10 +1410,10 @@ packages:
         os: [linux]
         libc: [musl]
 
-    "@rolldown/binding-openharmony-arm64@1.0.0-rc.3":
+    "@rolldown/binding-openharmony-arm64@1.0.3":
         resolution:
             {
-                integrity: sha512-U662UnMETyjT65gFmG9ma+XziENrs7BBnENi/27swZPYagubfHRirXHG2oMl+pEax2WvO7Kb9gHZmMakpYqBHQ==,
+                integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==,
             }
         engines: { node: ^20.19.0 || >=22.12.0 }
         cpu: [arm64]
@@ -1073,12 +1428,12 @@ packages:
         cpu: [arm64]
         os: [openharmony]
 
-    "@rolldown/binding-wasm32-wasi@1.0.0-rc.3":
+    "@rolldown/binding-wasm32-wasi@1.0.3":
         resolution:
             {
-                integrity: sha512-gekrQ3Q2HiC1T5njGyuUJoGpK/l6B/TNXKed3fZXNf9YRTJn3L5MOZsFBn4bN2+UX+8+7hgdlTcEsexX988G4g==,
+                integrity: sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==,
             }
-        engines: { node: ">=14.0.0" }
+        engines: { node: ^20.19.0 || >=22.12.0 }
         cpu: [wasm32]
 
     "@rolldown/binding-wasm32-wasi@1.1.1":
@@ -1089,10 +1444,10 @@ packages:
         engines: { node: ^20.19.0 || >=22.12.0 }
         cpu: [wasm32]
 
-    "@rolldown/binding-win32-arm64-msvc@1.0.0-rc.3":
+    "@rolldown/binding-win32-arm64-msvc@1.0.3":
         resolution:
             {
-                integrity: sha512-85y5JifyMgs8m5K2XzR/VDsapKbiFiohl7s5lEj7nmNGO0pkTXE7q6TQScei96BNAsoK7JC3pA7ukA8WRHVJpg==,
+                integrity: sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==,
             }
         engines: { node: ^20.19.0 || >=22.12.0 }
         cpu: [arm64]
@@ -1107,10 +1462,10 @@ packages:
         cpu: [arm64]
         os: [win32]
 
-    "@rolldown/binding-win32-x64-msvc@1.0.0-rc.3":
+    "@rolldown/binding-win32-x64-msvc@1.0.3":
         resolution:
             {
-                integrity: sha512-a4VUQZH7LxGbUJ3qJ/TzQG8HxdHvf+jOnqf7B7oFx1TEBm+j2KNL2zr5SQ7wHkNAcaPevF6gf9tQnVBnC4mD+A==,
+                integrity: sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==,
             }
         engines: { node: ^20.19.0 || >=22.12.0 }
         cpu: [x64]
@@ -1125,22 +1480,16 @@ packages:
         cpu: [x64]
         os: [win32]
 
-    "@rolldown/pluginutils@1.0.0-rc.3":
-        resolution:
-            {
-                integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==,
-            }
-
     "@rolldown/pluginutils@1.0.1":
         resolution:
             {
                 integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==,
             }
 
-    "@rollup/pluginutils@5.3.0":
+    "@rollup/pluginutils@5.4.0":
         resolution:
             {
-                integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==,
+                integrity: sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==,
             }
         engines: { node: ">=14.0.0" }
         peerDependencies:
@@ -1149,260 +1498,298 @@ packages:
             rollup:
                 optional: true
 
-    "@rollup/rollup-android-arm-eabi@4.57.1":
+    "@rollup/rollup-android-arm-eabi@4.62.0":
         resolution:
             {
-                integrity: sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==,
+                integrity: sha512-IPIQ55ythEHkfEd9jMEi32OQ7SxURsGA43JI22lj01OLZNt2NUbJX8YUHxkVWyQ6daHPNn0truF5nSj3DQp6YQ==,
             }
         cpu: [arm]
         os: [android]
 
-    "@rollup/rollup-android-arm64@4.57.1":
+    "@rollup/rollup-android-arm64@4.62.0":
         resolution:
             {
-                integrity: sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==,
+                integrity: sha512-M6s9cr10MibETyo8JsOkq+Lo1+lU6hcvb1MApnUql5qte/5hMEgzlN8/ReIKNfRV8rrqX50W1BX9zoUhC192RA==,
             }
         cpu: [arm64]
         os: [android]
 
-    "@rollup/rollup-darwin-arm64@4.57.1":
+    "@rollup/rollup-darwin-arm64@4.62.0":
         resolution:
             {
-                integrity: sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==,
+                integrity: sha512-BqCoMoIbn0keKys+dEAdBa70EtOwV1bEsQCUgU9FdiZmmMge/Zk7LlkYGqbrdHR+Frnt0E1FOanly+rlwvvQzw==,
             }
         cpu: [arm64]
         os: [darwin]
 
-    "@rollup/rollup-darwin-x64@4.57.1":
+    "@rollup/rollup-darwin-x64@4.62.0":
         resolution:
             {
-                integrity: sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==,
+                integrity: sha512-SIMzST3VFNXDAbeIWDWiFCNM5qncUBDWaEV7NfE7oZbDt2mgfW4MvbKdbYiGOLoM32gbTv608UMd0XktEYSD7w==,
             }
         cpu: [x64]
         os: [darwin]
 
-    "@rollup/rollup-freebsd-arm64@4.57.1":
+    "@rollup/rollup-freebsd-arm64@4.62.0":
         resolution:
             {
-                integrity: sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==,
+                integrity: sha512-ezjfSQMP7ArdUsbBwbQIfwAlhE84I2iVnzQNCFSveqV42q+BmKlzVpf7mxv5EchLcoWU4y6/heFzVg1F+hodUQ==,
             }
         cpu: [arm64]
         os: [freebsd]
 
-    "@rollup/rollup-freebsd-x64@4.57.1":
+    "@rollup/rollup-freebsd-x64@4.62.0":
         resolution:
             {
-                integrity: sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==,
+                integrity: sha512-9+qTWGW9AZRhnUgwtTwzNwcPlL87ngkeN0LA+q1bADvmY9aNvWaF2TFW8BZgnQPYxpDI7+rMVLivcd4V737TAQ==,
             }
         cpu: [x64]
         os: [freebsd]
 
-    "@rollup/rollup-linux-arm-gnueabihf@4.57.1":
+    "@rollup/rollup-linux-arm-gnueabihf@4.62.0":
         resolution:
             {
-                integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==,
+                integrity: sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ==,
             }
         cpu: [arm]
         os: [linux]
         libc: [glibc]
 
-    "@rollup/rollup-linux-arm-musleabihf@4.57.1":
+    "@rollup/rollup-linux-arm-musleabihf@4.62.0":
         resolution:
             {
-                integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==,
+                integrity: sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==,
             }
         cpu: [arm]
         os: [linux]
         libc: [musl]
 
-    "@rollup/rollup-linux-arm64-gnu@4.57.1":
+    "@rollup/rollup-linux-arm64-gnu@4.62.0":
         resolution:
             {
-                integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==,
+                integrity: sha512-bVURMg+6eNN9C/yc0aVjooZcwTTtYF4YW3xta5pP0//r3o1V8gXEHXWCndj47w/HhwsFroZrFhR+6uQP5T0n0g==,
             }
         cpu: [arm64]
         os: [linux]
         libc: [glibc]
 
-    "@rollup/rollup-linux-arm64-musl@4.57.1":
+    "@rollup/rollup-linux-arm64-musl@4.62.0":
         resolution:
             {
-                integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==,
+                integrity: sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==,
             }
         cpu: [arm64]
         os: [linux]
         libc: [musl]
 
-    "@rollup/rollup-linux-loong64-gnu@4.57.1":
+    "@rollup/rollup-linux-loong64-gnu@4.62.0":
         resolution:
             {
-                integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==,
+                integrity: sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg==,
             }
         cpu: [loong64]
         os: [linux]
         libc: [glibc]
 
-    "@rollup/rollup-linux-loong64-musl@4.57.1":
+    "@rollup/rollup-linux-loong64-musl@4.62.0":
         resolution:
             {
-                integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==,
+                integrity: sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==,
             }
         cpu: [loong64]
         os: [linux]
         libc: [musl]
 
-    "@rollup/rollup-linux-ppc64-gnu@4.57.1":
+    "@rollup/rollup-linux-ppc64-gnu@4.62.0":
         resolution:
             {
-                integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==,
+                integrity: sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w==,
             }
         cpu: [ppc64]
         os: [linux]
         libc: [glibc]
 
-    "@rollup/rollup-linux-ppc64-musl@4.57.1":
+    "@rollup/rollup-linux-ppc64-musl@4.62.0":
         resolution:
             {
-                integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==,
+                integrity: sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==,
             }
         cpu: [ppc64]
         os: [linux]
         libc: [musl]
 
-    "@rollup/rollup-linux-riscv64-gnu@4.57.1":
+    "@rollup/rollup-linux-riscv64-gnu@4.62.0":
         resolution:
             {
-                integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==,
+                integrity: sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg==,
             }
         cpu: [riscv64]
         os: [linux]
         libc: [glibc]
 
-    "@rollup/rollup-linux-riscv64-musl@4.57.1":
+    "@rollup/rollup-linux-riscv64-musl@4.62.0":
         resolution:
             {
-                integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==,
+                integrity: sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==,
             }
         cpu: [riscv64]
         os: [linux]
         libc: [musl]
 
-    "@rollup/rollup-linux-s390x-gnu@4.57.1":
+    "@rollup/rollup-linux-s390x-gnu@4.62.0":
         resolution:
             {
-                integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==,
+                integrity: sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA==,
             }
         cpu: [s390x]
         os: [linux]
         libc: [glibc]
 
-    "@rollup/rollup-linux-x64-gnu@4.57.1":
+    "@rollup/rollup-linux-x64-gnu@4.62.0":
         resolution:
             {
-                integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==,
+                integrity: sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg==,
             }
         cpu: [x64]
         os: [linux]
         libc: [glibc]
 
-    "@rollup/rollup-linux-x64-musl@4.57.1":
+    "@rollup/rollup-linux-x64-musl@4.62.0":
         resolution:
             {
-                integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==,
+                integrity: sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==,
             }
         cpu: [x64]
         os: [linux]
         libc: [musl]
 
-    "@rollup/rollup-openbsd-x64@4.57.1":
+    "@rollup/rollup-openbsd-x64@4.62.0":
         resolution:
             {
-                integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==,
+                integrity: sha512-3oVS7FLGa4U1qcvao9ylGxrjXZyUQqR8UwxEcnUEyPX53O/C/mKDZegNXTdHCP+h3e6ta/f1EN38Yif1mmZHYg==,
             }
         cpu: [x64]
         os: [openbsd]
 
-    "@rollup/rollup-openharmony-arm64@4.57.1":
+    "@rollup/rollup-openharmony-arm64@4.62.0":
         resolution:
             {
-                integrity: sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==,
+                integrity: sha512-yTB9TgfWj5wHe5QgktAgXTLLot1gvEjl1NiPPAUiCs4oPrIWFl5V4nC3GrkNdj9LaAU4s94nVrGbGOCqUpyWsg==,
             }
         cpu: [arm64]
         os: [openharmony]
 
-    "@rollup/rollup-win32-arm64-msvc@4.57.1":
+    "@rollup/rollup-win32-arm64-msvc@4.62.0":
         resolution:
             {
-                integrity: sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==,
+                integrity: sha512-5LOhoaesY3doG1c+ac/2JtgREpKoJr5bUHH8tKY0V8di7+uSV6BwLs2PlR0/yzefGOkR+wE7ZolZphHCsyG5Rw==,
             }
         cpu: [arm64]
         os: [win32]
 
-    "@rollup/rollup-win32-ia32-msvc@4.57.1":
+    "@rollup/rollup-win32-ia32-msvc@4.62.0":
         resolution:
             {
-                integrity: sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==,
+                integrity: sha512-yYkWHhmbhRTWTnWos5HC4GcPQfjlzzCNbM9e/+GXrLuaBXYA3qSDR9f0Vgufd5S8yX81U8jPKp7ZnAjZFMtRnw==,
             }
         cpu: [ia32]
         os: [win32]
 
-    "@rollup/rollup-win32-x64-gnu@4.57.1":
+    "@rollup/rollup-win32-x64-gnu@4.62.0":
         resolution:
             {
-                integrity: sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==,
+                integrity: sha512-SoTb6lPg25xZlA2ibwQ++ahCCnH+FP0qmEuafMJ4gznZKOlXioKEAeJLgCrqjM98ACziXM9V1amFjICVL4IFoA==,
             }
         cpu: [x64]
         os: [win32]
 
-    "@rollup/rollup-win32-x64-msvc@4.57.1":
+    "@rollup/rollup-win32-x64-msvc@4.62.0":
         resolution:
             {
-                integrity: sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==,
+                integrity: sha512-5L+T1fMX4RIEBoZzT0+sQ0PhTS36NULFmMXtl1TZo44TMAROIMHbZufSOjVWt/Y622BtxgxtaNOokbTDvfsrZA==,
             }
         cpu: [x64]
         os: [win32]
 
-    "@shikijs/core@3.22.0":
+    "@shikijs/core@4.2.0":
         resolution:
             {
-                integrity: sha512-iAlTtSDDbJiRpvgL5ugKEATDtHdUVkqgHDm/gbD2ZS9c88mx7G1zSYjjOxp5Qa0eaW0MAQosFRmJSk354PRoQA==,
+                integrity: sha512-Hc87Ab1Ld/vEbZRCbwx344I5v+4RU8CVToUTRkqXL1+TjbuOp9U5Xa0M23V4GEWHxVn+yO5otb+HkQVm3ptWQQ==,
+            }
+        engines: { node: ">=20" }
+
+    "@shikijs/engine-javascript@4.2.0":
+        resolution:
+            {
+                integrity: sha512-fjETeq1k5ffyXqRgS6+3hpvqseLalp1kjNfRbXpUgWR8FpZ1CmQfiNHovc5lncYjt/Vg5JK/WJEmLahjwMa0og==,
+            }
+        engines: { node: ">=20" }
+
+    "@shikijs/engine-oniguruma@3.23.0":
+        resolution:
+            {
+                integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==,
             }
 
-    "@shikijs/engine-javascript@3.22.0":
+    "@shikijs/engine-oniguruma@4.2.0":
         resolution:
             {
-                integrity: sha512-jdKhfgW9CRtj3Tor0L7+yPwdG3CgP7W+ZEqSsojrMzCjD1e0IxIbwUMDDpYlVBlC08TACg4puwFGkZfLS+56Tw==,
+                integrity: sha512-hTorK1dffPkpbMUk6Z+828PgRo7d07HbnizoP0hNPFjhxMHctj0Px/qoHeGMYafc6ju+u9iMldN4JbVzNQM++g==,
+            }
+        engines: { node: ">=20" }
+
+    "@shikijs/langs@3.23.0":
+        resolution:
+            {
+                integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==,
             }
 
-    "@shikijs/engine-oniguruma@3.22.0":
+    "@shikijs/langs@4.2.0":
         resolution:
             {
-                integrity: sha512-DyXsOG0vGtNtl7ygvabHd7Mt5EY8gCNqR9Y7Lpbbd/PbJvgWrqaKzH1JW6H6qFkuUa8aCxoiYVv8/YfFljiQxA==,
+                integrity: sha512-bwrVRlJ0wUhZxAbVdvBbv2TTC9yLsh4C/IO5Ofz0T8MQntgDvyVnkbjw9vi50r1kx7RCIJdnJnjZAwmAsXFLZQ==,
+            }
+        engines: { node: ">=20" }
+
+    "@shikijs/primitive@4.2.0":
+        resolution:
+            {
+                integrity: sha512-NOq+DtUkVBJtZMVXL5A0vI0Xk8nvDYaXetFHSJFlOqjDZIVhIPRYFdGkSoElDqNuegikcc3A76SNUa8dTqtAYA==,
+            }
+        engines: { node: ">=20" }
+
+    "@shikijs/rehype@4.2.0":
+        resolution:
+            {
+                integrity: sha512-ST3EWye/dwF1gWskczJNBnwFtDzEQ9ceytXZtyc/GfwR5V0qJrkoSGZO55O3SAKDDsXkTDcsfwd9pVe7ROlAHg==,
+            }
+        engines: { node: ">=20" }
+
+    "@shikijs/themes@3.23.0":
+        resolution:
+            {
+                integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==,
             }
 
-    "@shikijs/langs@3.22.0":
+    "@shikijs/themes@4.2.0":
         resolution:
             {
-                integrity: sha512-x/42TfhWmp6H00T6uwVrdTJGKgNdFbrEdhaDwSR5fd5zhQ1Q46bHq9EO61SCEWJR0HY7z2HNDMaBZp8JRmKiIA==,
+                integrity: sha512-RX8IHYeLv8Cu2W6ruc3RxUqWn0IYCqSrMBzi/uRGAmfyDNOnNO5BF/Px7o97n4XTpmFTo5GbRaazuOWj+2ak2w==,
+            }
+        engines: { node: ">=20" }
+
+    "@shikijs/types@3.23.0":
+        resolution:
+            {
+                integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==,
             }
 
-    "@shikijs/rehype@3.22.0":
+    "@shikijs/types@4.2.0":
         resolution:
             {
-                integrity: sha512-69b2VPc6XBy/VmAJlpBU5By+bJSBdE2nvgRCZXav7zujbrjXuT0F60DIrjKuutjPqNufuizE+E8tIZr2Yn8Z+g==,
+                integrity: sha512-VT/MKtlpOhEPZloSH3Pb9WCZEBDoQVMa9jedp5UAwmJOar1DVc9DRODAxmYPW9M93IK4ryuqRejFfmlvlVDemw==,
             }
-
-    "@shikijs/themes@3.22.0":
-        resolution:
-            {
-                integrity: sha512-o+tlOKqsr6FE4+mYJG08tfCFDS+3CG20HbldXeVoyP+cYSUxDhrFf3GPjE60U55iOkkjbpY2uC3It/eeja35/g==,
-            }
-
-    "@shikijs/types@3.22.0":
-        resolution:
-            {
-                integrity: sha512-491iAekgKDBFE67z70Ok5a8KBMsQ2IJwOWw3us/7ffQkIBCyOQfm/aNwVMBUriP02QshIfgHCBSIYAl3u2eWjg==,
-            }
+        engines: { node: ">=20" }
 
     "@shikijs/vscode-textmate@10.0.2":
         resolution:
@@ -1416,40 +1803,10 @@ packages:
                 integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==,
             }
 
-    "@tybys/wasm-util@0.10.1":
-        resolution:
-            {
-                integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==,
-            }
-
     "@tybys/wasm-util@0.10.2":
         resolution:
             {
                 integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==,
-            }
-
-    "@types/babel__core@7.20.5":
-        resolution:
-            {
-                integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==,
-            }
-
-    "@types/babel__generator@7.27.0":
-        resolution:
-            {
-                integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==,
-            }
-
-    "@types/babel__template@7.4.4":
-        resolution:
-            {
-                integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==,
-            }
-
-    "@types/babel__traverse@7.28.0":
-        resolution:
-            {
-                integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==,
             }
 
     "@types/chai@5.2.3":
@@ -1458,10 +1815,10 @@ packages:
                 integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==,
             }
 
-    "@types/debug@4.1.12":
+    "@types/debug@4.1.13":
         resolution:
             {
-                integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==,
+                integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==,
             }
 
     "@types/deep-eql@4.0.2":
@@ -1480,6 +1837,12 @@ packages:
         resolution:
             {
                 integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==,
+            }
+
+    "@types/estree@1.0.9":
+        resolution:
+            {
+                integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==,
             }
 
     "@types/hast@3.0.4":
@@ -1506,10 +1869,10 @@ packages:
                 integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==,
             }
 
-    "@types/mdx@2.0.13":
+    "@types/mdx@2.0.14":
         resolution:
             {
-                integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==,
+                integrity: sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==,
             }
 
     "@types/ms@2.1.0":
@@ -1518,10 +1881,16 @@ packages:
                 integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==,
             }
 
-    "@types/node@25.2.3":
+    "@types/node@25.9.3":
         resolution:
             {
-                integrity: sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==,
+                integrity: sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==,
+            }
+
+    "@types/normalize-package-data@2.4.4":
+        resolution:
+            {
+                integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==,
             }
 
     "@types/react-dom@19.2.3":
@@ -1532,10 +1901,10 @@ packages:
         peerDependencies:
             "@types/react": ^19.2.0
 
-    "@types/react@19.2.14":
+    "@types/react@19.2.17":
         resolution:
             {
-                integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==,
+                integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==,
             }
 
     "@types/unist@2.0.11":
@@ -1550,171 +1919,234 @@ packages:
                 integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==,
             }
 
-    "@typescript-eslint/eslint-plugin@8.55.0":
+    "@typescript-eslint/eslint-plugin@8.61.1":
         resolution:
             {
-                integrity: sha512-1y/MVSz0NglV1ijHC8OT49mPJ4qhPYjiK08YUQVbIOyu+5k862LKUHFkpKHWu//zmr7hDR2rhwUm6gnCGNmGBQ==,
+                integrity: sha512-ZPlVl3PB3et/59Ne0fv/sci6ZXz4T4Hp4nTJ56i/Y0gR89ARb+KphojTq6j+56E5PIezmOIOOWyY+aWQFd+IkQ==,
             }
         engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
         peerDependencies:
-            "@typescript-eslint/parser": ^8.55.0
-            eslint: ^8.57.0 || ^9.0.0
-            typescript: ">=4.8.4 <6.0.0"
+            "@typescript-eslint/parser": ^8.61.1
+            eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+            typescript: ">=4.8.4 <6.1.0"
 
-    "@typescript-eslint/parser@8.55.0":
+    "@typescript-eslint/parser@8.61.1":
         resolution:
             {
-                integrity: sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==,
+                integrity: sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==,
             }
         engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
         peerDependencies:
-            eslint: ^8.57.0 || ^9.0.0
-            typescript: ">=4.8.4 <6.0.0"
+            eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+            typescript: ">=4.8.4 <6.1.0"
 
-    "@typescript-eslint/project-service@8.55.0":
+    "@typescript-eslint/project-service@8.61.1":
         resolution:
             {
-                integrity: sha512-zRcVVPFUYWa3kNnjaZGXSu3xkKV1zXy8M4nO/pElzQhFweb7PPtluDLQtKArEOGmjXoRjnUZ29NjOiF0eCDkcQ==,
+                integrity: sha512-PrC4JYGmR241lYnfhmKGTXkFqv8+ymbTFgSAY0fVXpY82/QkMw5TZPl+vGzuDDU2QYJk9fIDOBTntF+yDv9LEA==,
             }
         engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
         peerDependencies:
-            typescript: ">=4.8.4 <6.0.0"
+            typescript: ">=4.8.4 <6.1.0"
 
-    "@typescript-eslint/scope-manager@8.55.0":
+    "@typescript-eslint/scope-manager@8.61.1":
         resolution:
             {
-                integrity: sha512-fVu5Omrd3jeqeQLiB9f1YsuK/iHFOwb04bCtY4BSCLgjNbOD33ZdV6KyEqplHr+IlpgT0QTZ/iJ+wT7hvTx49Q==,
+                integrity: sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w==,
             }
         engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
-    "@typescript-eslint/tsconfig-utils@8.55.0":
+    "@typescript-eslint/tsconfig-utils@8.61.1":
         resolution:
             {
-                integrity: sha512-1R9cXqY7RQd7WuqSN47PK9EDpgFUK3VqdmbYrvWJZYDd0cavROGn+74ktWBlmJ13NXUQKlZ/iAEQHI/V0kKe0Q==,
-            }
-        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-        peerDependencies:
-            typescript: ">=4.8.4 <6.0.0"
-
-    "@typescript-eslint/type-utils@8.55.0":
-        resolution:
-            {
-                integrity: sha512-x1iH2unH4qAt6I37I2CGlsNs+B9WGxurP2uyZLRz6UJoZWDBx9cJL1xVN/FiOmHEONEg6RIufdvyT0TEYIgC5g==,
+                integrity: sha512-UN/H4di+OO7EWx2ovME+8t31YO+KVnK0RRKEHR3kOt21/Ay8BOq3M1OMvWs5vNiqcFCYGYoxK3MXPZzmMUE+yg==,
             }
         engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
         peerDependencies:
-            eslint: ^8.57.0 || ^9.0.0
-            typescript: ">=4.8.4 <6.0.0"
+            typescript: ">=4.8.4 <6.1.0"
 
-    "@typescript-eslint/types@8.55.0":
+    "@typescript-eslint/type-utils@8.61.1":
         resolution:
             {
-                integrity: sha512-ujT0Je8GI5BJWi+/mMoR0wxwVEQaxM+pi30xuMiJETlX80OPovb2p9E8ss87gnSVtYXtJoU9U1Cowcr6w2FE0w==,
-            }
-        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-
-    "@typescript-eslint/typescript-estree@8.55.0":
-        resolution:
-            {
-                integrity: sha512-EwrH67bSWdx/3aRQhCoxDaHM+CrZjotc2UCCpEDVqfCE+7OjKAGWNY2HsCSTEVvWH2clYQK8pdeLp42EVs+xQw==,
+                integrity: sha512-GYRicKmVK0C4fsKgaACaknOUAq9Oa2kwsjnpFhFcS/5p4Ht5IP9OVLbgIgcK4SRk92nVHFluurg1lumD9dBcLw==,
             }
         engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
         peerDependencies:
-            typescript: ">=4.8.4 <6.0.0"
+            eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+            typescript: ">=4.8.4 <6.1.0"
 
-    "@typescript-eslint/utils@8.55.0":
+    "@typescript-eslint/types@8.61.1":
         resolution:
             {
-                integrity: sha512-BqZEsnPGdYpgyEIkDC1BadNY8oMwckftxBT+C8W0g1iKPdeqKZBtTfnvcq0nf60u7MkjFO8RBvpRGZBPw4L2ow==,
+                integrity: sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==,
+            }
+        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+    "@typescript-eslint/typescript-estree@8.61.1":
+        resolution:
+            {
+                integrity: sha512-u+oQD3BqYWPc8YV9Zab4vaJElJuwOLPRc10Jm1o/qS+6Qwen14HCWwx0Seo4LnSn2wxea2Ik8DxPt2/FHmuhrg==,
             }
         engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
         peerDependencies:
-            eslint: ^8.57.0 || ^9.0.0
-            typescript: ">=4.8.4 <6.0.0"
+            typescript: ">=4.8.4 <6.1.0"
 
-    "@typescript-eslint/visitor-keys@8.55.0":
+    "@typescript-eslint/utils@8.61.1":
         resolution:
             {
-                integrity: sha512-AxNRwEie8Nn4eFS1FzDMJWIISMGoXMb037sgCBJ3UR6o0fQTzr2tqN9WT+DkWJPhIdQCfV7T6D387566VtnCJA==,
+                integrity: sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA==,
+            }
+        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+        peerDependencies:
+            eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+            typescript: ">=4.8.4 <6.1.0"
+
+    "@typescript-eslint/visitor-keys@8.61.1":
+        resolution:
+            {
+                integrity: sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w==,
             }
         engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
-    "@ungap/structured-clone@1.3.0":
+    "@ungap/structured-clone@1.3.1":
         resolution:
             {
-                integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==,
+                integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==,
             }
-        deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
-    "@vitejs/plugin-react@5.1.4":
+    "@vanilla-extract/babel-plugin-debug-ids@1.2.2":
         resolution:
             {
-                integrity: sha512-VIcFLdRi/VYRU8OL/puL7QXMYafHmqOnwTZY50U1JPlCNj30PxCMx65c494b1K9be9hX83KVt0+gTEwTWLqToA==,
+                integrity: sha512-MeDWGICAF9zA/OZLOKwhoRlsUW+fiMwnfuOAqFVohL31Agj7Q/RBWAYweqjHLgFBCsdnr6XIfwjJnmb2znEWxw==,
+            }
+
+    "@vanilla-extract/compiler@0.7.0":
+        resolution:
+            {
+                integrity: sha512-rZQ40HVmsxfGLjoflwwsaUBLfpbpKDoZC19oiDA0FHq4LdrYtyVbFkc0MfqkNo/qBCvaZfsRezCqk0QQxCqZ8w==,
+            }
+
+    "@vanilla-extract/css@1.20.1":
+        resolution:
+            {
+                integrity: sha512-5I9RNo5uZW9tsBnqrWzJqELegOqTHBrZyDFnES0gR9gJJHBB9dom1N0bwITM9tKwBcfKrTX4a6DHVeQdJ2ubQA==,
+            }
+
+    "@vanilla-extract/esbuild-plugin@2.3.22":
+        resolution:
+            {
+                integrity: sha512-unxruCeuGR2BpmEuSV49++V4whdX7uPWADIiPwAe6zEOXwPrXQK+VtXjjZ/yN40vGfE7OJP/4WSDM5RuYX4LoQ==,
+            }
+        peerDependencies:
+            esbuild: ">=0.17.6"
+        peerDependenciesMeta:
+            esbuild:
+                optional: true
+
+    "@vanilla-extract/integration@8.0.10":
+        resolution:
+            {
+                integrity: sha512-01IB5gbrgTe8IIrtfRXXTmACl5D8Enzqp2cKbCWaMKXmnoilXXVCPbJoA96q88PXkNDXsXepCxUugMvEmL3c7A==,
+            }
+
+    "@vanilla-extract/private@1.0.9":
+        resolution:
+            {
+                integrity: sha512-gT2jbfZuaaCLrAxwXbRgIhGhcXbRZCG3v4TTUnjw0EJ7ArdBRxkq4msNJkbuRkCgfIK5ATmprB5t9ljvLeFDEA==,
+            }
+
+    "@vanilla-extract/recipes@0.5.7":
+        resolution:
+            {
+                integrity: sha512-Fvr+htdyb6LVUu+PhH61UFPhwkjgDEk8L4Zq9oIdte42sntpKrgFy90MyTRtGwjVALmrJ0pwRUVr8UoByYeW8A==,
+            }
+        peerDependencies:
+            "@vanilla-extract/css": ^1.0.0
+
+    "@vanilla-extract/vite-plugin@5.2.2":
+        resolution:
+            {
+                integrity: sha512-AUyB4fDR2b/Mo0lcXhhlf6RxnDPYwFMyKKopalJ4BwQNKYzZSoTwHJ1PLPO9SKhpz7lzXc0Z18GHQZOewzl3YA==,
+            }
+        peerDependencies:
+            vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
+    "@vitejs/plugin-react@6.0.2":
+        resolution:
+            {
+                integrity: sha512-DlSMqo4WhThw4vB8Mpn0Woe9J+Jfq1geJ61AKW0QEgLzGMNwtIMdxbDUzLxcun8W7NbJO0e2Jg/Nxm3cCSVzzg==,
             }
         engines: { node: ^20.19.0 || >=22.12.0 }
         peerDependencies:
-            vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+            "@rolldown/plugin-babel": ^0.1.7 || ^0.2.0
+            babel-plugin-react-compiler: ^1.0.0
+            vite: ^8.0.0
+        peerDependenciesMeta:
+            "@rolldown/plugin-babel":
+                optional: true
+            babel-plugin-react-compiler:
+                optional: true
 
-    "@vitest/coverage-v8@4.0.18":
+    "@vitest/coverage-v8@4.1.9":
         resolution:
             {
-                integrity: sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==,
+                integrity: sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==,
             }
         peerDependencies:
-            "@vitest/browser": 4.0.18
-            vitest: 4.0.18
+            "@vitest/browser": 4.1.9
+            vitest: 4.1.9
         peerDependenciesMeta:
             "@vitest/browser":
                 optional: true
 
-    "@vitest/expect@4.0.18":
+    "@vitest/expect@4.1.9":
         resolution:
             {
-                integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==,
+                integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==,
             }
 
-    "@vitest/mocker@4.0.18":
+    "@vitest/mocker@4.1.9":
         resolution:
             {
-                integrity: sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==,
+                integrity: sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==,
             }
         peerDependencies:
             msw: ^2.4.9
-            vite: ^6.0.0 || ^7.0.0-0
+            vite: ^6.0.0 || ^7.0.0 || ^8.0.0
         peerDependenciesMeta:
             msw:
                 optional: true
             vite:
                 optional: true
 
-    "@vitest/pretty-format@4.0.18":
+    "@vitest/pretty-format@4.1.9":
         resolution:
             {
-                integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==,
+                integrity: sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==,
             }
 
-    "@vitest/runner@4.0.18":
+    "@vitest/runner@4.1.9":
         resolution:
             {
-                integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==,
+                integrity: sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==,
             }
 
-    "@vitest/snapshot@4.0.18":
+    "@vitest/snapshot@4.1.9":
         resolution:
             {
-                integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==,
+                integrity: sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==,
             }
 
-    "@vitest/spy@4.0.18":
+    "@vitest/spy@4.1.9":
         resolution:
             {
-                integrity: sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==,
+                integrity: sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==,
             }
 
-    "@vitest/utils@4.0.18":
+    "@vitest/utils@4.1.9":
         resolution:
             {
-                integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==,
+                integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==,
             }
 
     acorn-jsx@5.3.2:
@@ -1729,6 +2161,14 @@ packages:
         resolution:
             {
                 integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==,
+            }
+        engines: { node: ">=0.4.0" }
+        hasBin: true
+
+    acorn@8.17.0:
+        resolution:
+            {
+                integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==,
             }
         engines: { node: ">=0.4.0" }
         hasBin: true
@@ -1774,13 +2214,13 @@ packages:
             }
         engines: { node: ">=14" }
 
-    ardo@2.7.0:
+    ardo@3.5.0:
         resolution:
             {
-                integrity: sha512-QfrLdx9tt4YJ+DxJGg0xbV/V+3a0GN53WP3dF4BJg793gRKV6SBoB6QS+yU2Zsrb/ArQFe9K2F7iNKv0FAuthQ==,
+                integrity: sha512-hGV2xZ3Z+rssh1spIGFxB0qCoEPx0PUJisCp4ulYVsaPOLc+B4G0bV3AmE5OHNSHNmCxc/el0DO3EG4Kei3P6g==,
             }
         peerDependencies:
-            lucide-react: ">=0.400.0"
+            lucide-react: ">=0.400.0 <2.0.0"
             vite: ^6.0.0 || ^7.0.0 || ^8.0.0-beta.0
         peerDependenciesMeta:
             lucide-react:
@@ -1811,17 +2251,17 @@ packages:
             }
         engines: { node: ">=12" }
 
-    ast-kit@3.0.0-beta.1:
+    ast-kit@3.0.0:
         resolution:
             {
-                integrity: sha512-trmleAnZ2PxN/loHWVhhx1qeOHSRXq4TDsBBxq3GqeJitfk3+jTQ+v/C1km/KYq9M7wKqCewMh+/NAvVH7m+bw==,
+                integrity: sha512-8OG92q3R35qjC/4i6BLBMg8IB+fClWu/1PEwg2Z9Rn+BuNaiEgJzpzn+pxWOdHJWDCAwu2JP0wCDTozAM4QirQ==,
             }
-        engines: { node: ">=20.19.0" }
+        engines: { node: ^22.18.0 || >=24.11.0 }
 
-    ast-v8-to-istanbul@0.3.11:
+    ast-v8-to-istanbul@1.0.4:
         resolution:
             {
-                integrity: sha512-Qya9fkoofMjCBNVdWINMjB5KZvkYfaO9/anwkWnjxibpWUxo5iHl2sOdP7/uAqaRuUYuoo8rDwnbaaKVFxoUvw==,
+                integrity: sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==,
             }
 
     astring@1.9.0:
@@ -1849,11 +2289,19 @@ packages:
                 integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==,
             }
 
-    baseline-browser-mapping@2.9.19:
+    balanced-match@4.0.4:
         resolution:
             {
-                integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==,
+                integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==,
             }
+        engines: { node: 18 || 20 || >=22 }
+
+    baseline-browser-mapping@2.10.37:
+        resolution:
+            {
+                integrity: sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==,
+            }
+        engines: { node: ">=6.0.0" }
         hasBin: true
 
     birpc@4.0.0:
@@ -1868,11 +2316,12 @@ packages:
                 integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==,
             }
 
-    brace-expansion@2.0.2:
+    brace-expansion@5.0.6:
         resolution:
             {
-                integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==,
+                integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==,
             }
+        engines: { node: 18 || 20 || >=22 }
 
     braces@3.0.3:
         resolution:
@@ -1881,10 +2330,10 @@ packages:
             }
         engines: { node: ">=8" }
 
-    browserslist@4.28.1:
+    browserslist@4.28.2:
         resolution:
             {
-                integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==,
+                integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==,
             }
         engines: { node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7 }
         hasBin: true
@@ -1910,10 +2359,10 @@ packages:
             }
         engines: { node: ">=6" }
 
-    caniuse-lite@1.0.30001769:
+    caniuse-lite@1.0.30001799:
         resolution:
             {
-                integrity: sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==,
+                integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==,
             }
 
     ccount@2.0.1:
@@ -2025,6 +2474,12 @@ packages:
                 integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==,
             }
 
+    confbox@0.1.8:
+        resolution:
+            {
+                integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==,
+            }
+
     confbox@0.2.4:
         resolution:
             {
@@ -2051,6 +2506,13 @@ packages:
             }
         engines: { node: ">= 8" }
 
+    css-what@6.2.2:
+        resolution:
+            {
+                integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==,
+            }
+        engines: { node: ">= 6" }
+
     csstype@3.2.3:
         resolution:
             {
@@ -2075,10 +2537,10 @@ packages:
                 integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==,
             }
 
-    dedent@1.7.1:
+    dedent@1.7.2:
         resolution:
             {
-                integrity: sha512-9JmrhGZpOlEgOLdQgSm0zxFaYoQon408V1v49aqTWuXENVlnCuY9JBZcXZiCsZQWDjTm5Qf/nIvAy77mXDAjEg==,
+                integrity: sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==,
             }
         peerDependencies:
             babel-plugin-macros: ^3.1.0
@@ -2091,6 +2553,19 @@ packages:
             {
                 integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==,
             }
+
+    deep-object-diff@1.1.9:
+        resolution:
+            {
+                integrity: sha512-Rn+RuwkmkDwCi2/oXOFS9Gsr5lJZu/yTGpK7wAaAIE75CC+LCGEZHpY6VQJa/RoJcrmaA/docWJZvYohlNkWPA==,
+            }
+
+    deepmerge@4.3.1:
+        resolution:
+            {
+                integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==,
+            }
+        engines: { node: ">=0.10.0" }
 
     defu@6.1.7:
         resolution:
@@ -2130,10 +2605,10 @@ packages:
             oxc-resolver:
                 optional: true
 
-    electron-to-chromium@1.5.286:
+    electron-to-chromium@1.5.374:
         resolution:
             {
-                integrity: sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==,
+                integrity: sha512-HCF5i7izveksHSGqa7mhDh6tr3Uz9Dar2RAjwuh69bw3QGPVObjQIgLwQWeO/Rxp9/r0KdboKy9RbpQDl97fjg==,
             }
 
     emoji-regex@10.6.0:
@@ -2176,6 +2651,12 @@ packages:
                 integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==,
             }
 
+    es-module-lexer@2.1.0:
+        resolution:
+            {
+                integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==,
+            }
+
     esast-util-from-estree@2.0.0:
         resolution:
             {
@@ -2188,10 +2669,18 @@ packages:
                 integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==,
             }
 
-    esbuild@0.27.3:
+    esbuild@0.27.7:
         resolution:
             {
-                integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==,
+                integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==,
+            }
+        engines: { node: ">=18" }
+        hasBin: true
+
+    esbuild@0.28.1:
+        resolution:
+            {
+                integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==,
             }
         engines: { node: ">=18" }
         hasBin: true
@@ -2246,6 +2735,13 @@ packages:
                 integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==,
             }
         engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+    eslint-visitor-keys@5.0.1:
+        resolution:
+            {
+                integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==,
+            }
+        engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
 
     eslint@9.39.2:
         resolution:
@@ -2357,6 +2853,13 @@ packages:
             }
         engines: { node: ">=0.10.0" }
 
+    eval@0.1.8:
+        resolution:
+            {
+                integrity: sha512-EzV94NYKoO09GLXGjXj9JIlXijVck4ONSr5wiCWDvhsvj5jxSrzTmRU/9C1DyB6uToszLs8aifA6NQ7lEQdvFw==,
+            }
+        engines: { node: ">= 0.8" }
+
     eventemitter3@5.0.4:
         resolution:
             {
@@ -2446,6 +2949,13 @@ packages:
             }
         engines: { node: ">=8" }
 
+    find-up-simple@1.0.1:
+        resolution:
+            {
+                integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==,
+            }
+        engines: { node: ">=18" }
+
     find-up@5.0.0:
         resolution:
             {
@@ -2494,12 +3004,6 @@ packages:
                 integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==,
             }
         engines: { node: ">=18" }
-
-    get-tsconfig@4.13.6:
-        resolution:
-            {
-                integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==,
-            }
 
     get-tsconfig@5.0.0-beta.5:
         resolution:
@@ -2596,6 +3100,13 @@ packages:
                 integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==,
             }
 
+    hosted-git-info@9.0.3:
+        resolution:
+            {
+                integrity: sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==,
+            }
+        engines: { node: ^20.17.0 || >=22.9.0 }
+
     html-escaper@2.0.2:
         resolution:
             {
@@ -2650,6 +3161,13 @@ packages:
                 integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==,
             }
         engines: { node: ">=0.8.19" }
+
+    index-to-position@1.2.0:
+        resolution:
+            {
+                integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==,
+            }
+        engines: { node: ">=18" }
 
     inline-style-parser@0.2.7:
         resolution:
@@ -2723,10 +3241,10 @@ packages:
             }
         engines: { node: ">=12" }
 
-    isbot@5.1.35:
+    isbot@5.1.43:
         resolution:
             {
-                integrity: sha512-waFfC72ZNfwLLuJ2iLaoVaqcNo+CAaLR7xCpAn0Y5WfGzkNHv7ZN39Vbi1y+kb+Zs46XHOX3tZNExroFUPX+Kg==,
+                integrity: sha512-drJhFmibra4LO6Wd7D3Oi6UICRK9244vSZkmxzhlZP0TTdwCA2ueK4PEkUkzPYeuqug9+cqqdWPgihjk5+83Cg==,
             }
         engines: { node: ">=18" }
 
@@ -2756,6 +3274,12 @@ packages:
                 integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==,
             }
         engines: { node: ">=8" }
+
+    javascript-stringify@2.1.0:
+        resolution:
+            {
+                integrity: sha512-JVAfqNPTvNq3sB/VHQJAFxN/sPgKnsKrCwyRt15zwNCdrMMJDdcEOdubuy+DuJYYdm0ox1J4uzEuYKkN+9yhVg==,
+            }
 
     js-tokens@10.0.0:
         resolution:
@@ -2787,6 +3311,14 @@ packages:
         resolution:
             {
                 integrity: sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==,
+            }
+        engines: { node: ">=6" }
+        hasBin: true
+
+    jsesc@3.1.0:
+        resolution:
+            {
+                integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==,
             }
         engines: { node: ">=6" }
         hasBin: true
@@ -2837,120 +3369,120 @@ packages:
             }
         engines: { node: ">= 0.8.0" }
 
-    lightningcss-android-arm64@1.31.1:
+    lightningcss-android-arm64@1.32.0:
         resolution:
             {
-                integrity: sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg==,
+                integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==,
             }
         engines: { node: ">= 12.0.0" }
         cpu: [arm64]
         os: [android]
 
-    lightningcss-darwin-arm64@1.31.1:
+    lightningcss-darwin-arm64@1.32.0:
         resolution:
             {
-                integrity: sha512-02uTEqf3vIfNMq3h/z2cJfcOXnQ0GRwQrkmPafhueLb2h7mqEidiCzkE4gBMEH65abHRiQvhdcQ+aP0D0g67sg==,
+                integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==,
             }
         engines: { node: ">= 12.0.0" }
         cpu: [arm64]
         os: [darwin]
 
-    lightningcss-darwin-x64@1.31.1:
+    lightningcss-darwin-x64@1.32.0:
         resolution:
             {
-                integrity: sha512-1ObhyoCY+tGxtsz1lSx5NXCj3nirk0Y0kB/g8B8DT+sSx4G9djitg9ejFnjb3gJNWo7qXH4DIy2SUHvpoFwfTA==,
+                integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==,
             }
         engines: { node: ">= 12.0.0" }
         cpu: [x64]
         os: [darwin]
 
-    lightningcss-freebsd-x64@1.31.1:
+    lightningcss-freebsd-x64@1.32.0:
         resolution:
             {
-                integrity: sha512-1RINmQKAItO6ISxYgPwszQE1BrsVU5aB45ho6O42mu96UiZBxEXsuQ7cJW4zs4CEodPUioj/QrXW1r9pLUM74A==,
+                integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==,
             }
         engines: { node: ">= 12.0.0" }
         cpu: [x64]
         os: [freebsd]
 
-    lightningcss-linux-arm-gnueabihf@1.31.1:
+    lightningcss-linux-arm-gnueabihf@1.32.0:
         resolution:
             {
-                integrity: sha512-OOCm2//MZJ87CdDK62rZIu+aw9gBv4azMJuA8/KB74wmfS3lnC4yoPHm0uXZ/dvNNHmnZnB8XLAZzObeG0nS1g==,
+                integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==,
             }
         engines: { node: ">= 12.0.0" }
         cpu: [arm]
         os: [linux]
 
-    lightningcss-linux-arm64-gnu@1.31.1:
+    lightningcss-linux-arm64-gnu@1.32.0:
         resolution:
             {
-                integrity: sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg==,
+                integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==,
             }
         engines: { node: ">= 12.0.0" }
         cpu: [arm64]
         os: [linux]
         libc: [glibc]
 
-    lightningcss-linux-arm64-musl@1.31.1:
+    lightningcss-linux-arm64-musl@1.32.0:
         resolution:
             {
-                integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==,
+                integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==,
             }
         engines: { node: ">= 12.0.0" }
         cpu: [arm64]
         os: [linux]
         libc: [musl]
 
-    lightningcss-linux-x64-gnu@1.31.1:
+    lightningcss-linux-x64-gnu@1.32.0:
         resolution:
             {
-                integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==,
+                integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==,
             }
         engines: { node: ">= 12.0.0" }
         cpu: [x64]
         os: [linux]
         libc: [glibc]
 
-    lightningcss-linux-x64-musl@1.31.1:
+    lightningcss-linux-x64-musl@1.32.0:
         resolution:
             {
-                integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==,
+                integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==,
             }
         engines: { node: ">= 12.0.0" }
         cpu: [x64]
         os: [linux]
         libc: [musl]
 
-    lightningcss-win32-arm64-msvc@1.31.1:
+    lightningcss-win32-arm64-msvc@1.32.0:
         resolution:
             {
-                integrity: sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==,
+                integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==,
             }
         engines: { node: ">= 12.0.0" }
         cpu: [arm64]
         os: [win32]
 
-    lightningcss-win32-x64-msvc@1.31.1:
+    lightningcss-win32-x64-msvc@1.32.0:
         resolution:
             {
-                integrity: sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw==,
+                integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==,
             }
         engines: { node: ">= 12.0.0" }
         cpu: [x64]
         os: [win32]
 
-    lightningcss@1.31.1:
+    lightningcss@1.32.0:
         resolution:
             {
-                integrity: sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==,
+                integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==,
             }
         engines: { node: ">= 12.0.0" }
 
-    linkify-it@5.0.0:
+    linkify-it@5.0.1:
         resolution:
             {
-                integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==,
+                integrity: sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==,
             }
 
     lint-staged@16.2.7:
@@ -2981,10 +3513,10 @@ packages:
                 integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==,
             }
 
-    lodash@4.17.23:
+    lodash@4.18.1:
         resolution:
             {
-                integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==,
+                integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==,
             }
 
     log-update@6.1.0:
@@ -3000,16 +3532,29 @@ packages:
                 integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==,
             }
 
+    lru-cache@10.4.3:
+        resolution:
+            {
+                integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==,
+            }
+
+    lru-cache@11.5.1:
+        resolution:
+            {
+                integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==,
+            }
+        engines: { node: 20 || >=22 }
+
     lru-cache@5.1.1:
         resolution:
             {
                 integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==,
             }
 
-    lucide-react@0.564.0:
+    lucide-react@1.20.0:
         resolution:
             {
-                integrity: sha512-JJ8GVTQqFwuliifD48U6+h7DXEHdkhJ/E87kksGByII3qHxtPciVb8T8woQONHBQgHVOl7rSMrrip3SeVNy7Fg==,
+                integrity: sha512-jhXLeC/7m0/tjL1nzMdKk6x256zWA6AtbhTVreHOiKPoeX2d6MK4FbyIQPpVq0E6iPWBisyy1TW+pEge/uMEuQ==,
             }
         peerDependencies:
             react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -3026,10 +3571,10 @@ packages:
                 integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==,
             }
 
-    magicast@0.5.2:
+    magicast@0.5.3:
         resolution:
             {
-                integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==,
+                integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==,
             }
 
     make-dir@4.0.0:
@@ -3046,10 +3591,10 @@ packages:
             }
         engines: { node: ">=16" }
 
-    markdown-it@14.1.1:
+    markdown-it@14.2.0:
         resolution:
             {
-                integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==,
+                integrity: sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==,
             }
         hasBin: true
 
@@ -3059,22 +3604,16 @@ packages:
                 integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==,
             }
 
-    mdast-util-directive@3.1.0:
-        resolution:
-            {
-                integrity: sha512-I3fNFt+DHmpWCYAT7quoM6lHf9wuqtI+oCOfvILnoicNIqjh5E3dEJWiXuYME2gNe8vl1iMQwyUHa7bgFmak6Q==,
-            }
-
     mdast-util-find-and-replace@3.0.2:
         resolution:
             {
                 integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==,
             }
 
-    mdast-util-from-markdown@2.0.2:
+    mdast-util-from-markdown@2.0.3:
         resolution:
             {
-                integrity: sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==,
+                integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==,
             }
 
     mdast-util-frontmatter@2.0.1:
@@ -3173,16 +3712,16 @@ packages:
                 integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==,
             }
 
+    media-query-parser@2.0.2:
+        resolution:
+            {
+                integrity: sha512-1N4qp+jE0pL5Xv4uEcwVUhIkwdUO3S/9gML90nqKA7v7FcOS5vUtatfzok9S9U1EJU8dHWlcv95WLnKmmxZI9w==,
+            }
+
     micromark-core-commonmark@2.0.3:
         resolution:
             {
                 integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==,
-            }
-
-    micromark-extension-directive@4.0.0:
-        resolution:
-            {
-                integrity: sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==,
             }
 
     micromark-extension-frontmatter@2.0.0:
@@ -3409,23 +3948,35 @@ packages:
             }
         engines: { node: ">=18" }
 
+    minimatch@10.2.5:
+        resolution:
+            {
+                integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==,
+            }
+        engines: { node: 18 || 20 || >=22 }
+
     minimatch@3.1.2:
         resolution:
             {
                 integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==,
             }
 
-    minimatch@9.0.5:
-        resolution:
-            {
-                integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==,
-            }
-        engines: { node: ">=16 || 14 >=14.17" }
-
     minisearch@7.2.0:
         resolution:
             {
                 integrity: sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==,
+            }
+
+    mlly@1.8.2:
+        resolution:
+            {
+                integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==,
+            }
+
+    modern-ahocorasick@1.1.0:
+        resolution:
+            {
+                integrity: sha512-sEKPVl2rM+MNVkGQt3ChdmD8YsigmXdn5NifZn6jiwn9LRJpWm8F3guhaqrJT/JOat6pwpbXEk6kv+b9DMIjsQ==,
             }
 
     ms@2.1.3:
@@ -3441,10 +3992,10 @@ packages:
             }
         engines: { node: ">=20.17" }
 
-    nanoid@3.3.11:
+    nanoid@3.3.12:
         resolution:
             {
-                integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==,
+                integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==,
             }
         engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
         hasBin: true
@@ -3455,17 +4006,26 @@ packages:
                 integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==,
             }
 
-    node-releases@2.0.27:
+    node-releases@2.0.47:
         resolution:
             {
-                integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==,
+                integrity: sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==,
             }
+        engines: { node: ">=18" }
 
-    obug@2.1.1:
+    normalize-package-data@8.0.0:
         resolution:
             {
-                integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==,
+                integrity: sha512-RWk+PI433eESQ7ounYxIp67CYuVsS1uYSonX3kA6ps/3LWfjVQa/ptEg6Y3T6uAMq1mWpX9PQ+qx+QaHpsc7gQ==,
             }
+        engines: { node: ^20.17.0 || >=22.9.0 }
+
+    obug@2.1.3:
+        resolution:
+            {
+                integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==,
+            }
+        engines: { node: ">=12.20.0" }
 
     onetime@7.0.0:
         resolution:
@@ -3474,16 +4034,16 @@ packages:
             }
         engines: { node: ">=18" }
 
-    oniguruma-parser@0.12.1:
+    oniguruma-parser@0.12.2:
         resolution:
             {
-                integrity: sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==,
+                integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==,
             }
 
-    oniguruma-to-es@4.3.4:
+    oniguruma-to-es@4.3.6:
         resolution:
             {
-                integrity: sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA==,
+                integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==,
             }
 
     optionator@0.9.4:
@@ -3526,6 +4086,13 @@ packages:
             {
                 integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==,
             }
+
+    parse-json@8.3.0:
+        resolution:
+            {
+                integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==,
+            }
+        engines: { node: ">=18" }
 
     parse5@7.3.0:
         resolution:
@@ -3572,13 +4139,6 @@ packages:
             }
         engines: { node: ">=8.6" }
 
-    picomatch@4.0.3:
-        resolution:
-            {
-                integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==,
-            }
-        engines: { node: ">=12" }
-
     picomatch@4.0.4:
         resolution:
             {
@@ -3594,16 +4154,22 @@ packages:
         engines: { node: ">=0.10" }
         hasBin: true
 
-    pkg-types@2.3.0:
+    pkg-types@1.3.1:
         resolution:
             {
-                integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==,
+                integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==,
             }
 
-    postcss@8.5.6:
+    pkg-types@2.3.1:
         resolution:
             {
-                integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==,
+                integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==,
+            }
+
+    postcss@8.5.15:
+        resolution:
+            {
+                integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==,
             }
         engines: { node: ^10 || ^12 || >=14 }
 
@@ -3614,18 +4180,18 @@ packages:
             }
         engines: { node: ">= 0.8.0" }
 
-    prettier@3.8.1:
+    prettier@3.8.4:
         resolution:
             {
-                integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==,
+                integrity: sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==,
             }
         engines: { node: ">=14" }
         hasBin: true
 
-    property-information@7.1.0:
+    property-information@7.2.0:
         resolution:
             {
-                integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==,
+                integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==,
             }
 
     punycode.js@2.3.1:
@@ -3648,13 +4214,13 @@ packages:
                 integrity: sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==,
             }
 
-    react-dom@19.2.4:
+    react-dom@19.2.7:
         resolution:
             {
-                integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==,
+                integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==,
             }
         peerDependencies:
-            react: ^19.2.4
+            react: ^19.2.7
 
     react-refresh@0.14.2:
         resolution:
@@ -3663,17 +4229,10 @@ packages:
             }
         engines: { node: ">=0.10.0" }
 
-    react-refresh@0.18.0:
+    react-router@7.18.0:
         resolution:
             {
-                integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==,
-            }
-        engines: { node: ">=0.10.0" }
-
-    react-router@7.13.0:
-        resolution:
-            {
-                integrity: sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw==,
+                integrity: sha512-pTTGt8J+ji1NOmYnjzT+bAJy/1zD+Jp4ziO6cL7T3ZLvXKtusO7BpFqlRXitqpcPVqllsIXFHRMt+2/k3Xn6HQ==,
             }
         engines: { node: ">=20.0.0" }
         peerDependencies:
@@ -3683,12 +4242,26 @@ packages:
             react-dom:
                 optional: true
 
-    react@19.2.4:
+    react@19.2.7:
         resolution:
             {
-                integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==,
+                integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==,
             }
         engines: { node: ">=0.10.0" }
+
+    read-package-up@12.0.0:
+        resolution:
+            {
+                integrity: sha512-Q5hMVBYur/eQNWDdbF4/Wqqr9Bjvtrw2kjGxxBbKLbx8bVCL8gcArjTy8zDUuLGQicftpMuU0riQNcAsbtOVsw==,
+            }
+        engines: { node: ">=20" }
+
+    read-pkg@10.1.0:
+        resolution:
+            {
+                integrity: sha512-I8g2lArQiP78ll51UeMZojewtYgIRCKCWqZEgOO8c/uefTI+XDXvCSXu3+YNUaTNvZzobrL5+SqHjBrByRRTdg==,
+            }
+        engines: { node: ">=20" }
 
     readdirp@4.1.2:
         resolution:
@@ -3759,12 +4332,6 @@ packages:
                 integrity: sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==,
             }
 
-    remark-directive@4.0.0:
-        resolution:
-            {
-                integrity: sha512-7sxn4RfF1o3izevPV1DheyGDD6X4c9hrGpfdUpm7uC++dqrnJxIZVkk7CoKqcLm0VUMAuOol7Mno3m6g8cfMuA==,
-            }
-
     remark-frontmatter@5.0.0:
         resolution:
             {
@@ -3807,6 +4374,12 @@ packages:
                 integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==,
             }
 
+    require-like@0.1.2:
+        resolution:
+            {
+                integrity: sha512-oyrU88skkMtDdauHDuKVrgR+zuItqr6/c//FXzvmxRGMexSDc6hNvJInGW3LL46n+8b50RykrvwSUIIQH2LQ5A==,
+            }
+
     resolve-from@4.0.0:
         resolution:
             {
@@ -3833,18 +4406,18 @@ packages:
                 integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==,
             }
 
-    rolldown-plugin-dts@0.25.2:
+    rolldown-plugin-dts@0.26.0:
         resolution:
             {
-                integrity: sha512-nMhN/R+vmR8GM45ZW1FWMSjRTSDDn/6w4GTf8RNrEFCBdl8B1kySWrU1ixPtbwzXoRlcO+R/S88VgXuJQwfdDg==,
+                integrity: sha512-e+kEPtUiDES0htk5iqkSeF4EzAV7R+vugGB44iPDuw1Kw9E+WyL1VG7PaV0IIjGHLiacztMBcMTyrr8ON9CT1Q==,
             }
-        engines: { node: ^22.18.0 || >=24.0.0 }
+        engines: { node: ^22.18.0 || >=24.11.0 }
         peerDependencies:
             "@ts-macro/tsc": ^0.3.6
             "@typescript/native-preview": ">=7.0.0-dev.20260325.1"
             rolldown: ^1.0.0
             typescript: ^5.0.0 || ^6.0.0
-            vue-tsc: ~3.2.0
+            vue-tsc: ~3.2.0 || ~3.3.0
         peerDependenciesMeta:
             "@ts-macro/tsc":
                 optional: true
@@ -3855,10 +4428,10 @@ packages:
             vue-tsc:
                 optional: true
 
-    rolldown@1.0.0-rc.3:
+    rolldown@1.0.3:
         resolution:
             {
-                integrity: sha512-Po/YZECDOqVXjIXrtC5h++a5NLvKAQNrd9ggrIG3sbDfGO5BqTUsrI6l8zdniKRp3r5Tp/2JTrXqx4GIguFCMw==,
+                integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==,
             }
         engines: { node: ^20.19.0 || >=22.12.0 }
         hasBin: true
@@ -3871,10 +4444,10 @@ packages:
         engines: { node: ^20.19.0 || >=22.12.0 }
         hasBin: true
 
-    rollup@4.57.1:
+    rollup@4.62.0:
         resolution:
             {
-                integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==,
+                integrity: sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA==,
             }
         engines: { node: ">=18.0.0", npm: ">=8.0.0" }
         hasBin: true
@@ -3897,14 +4470,6 @@ packages:
             {
                 integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==,
             }
-        hasBin: true
-
-    semver@7.7.4:
-        resolution:
-            {
-                integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==,
-            }
-        engines: { node: ">=10" }
         hasBin: true
 
     semver@7.8.4:
@@ -3935,11 +4500,12 @@ packages:
             }
         engines: { node: ">=8" }
 
-    shiki@3.22.0:
+    shiki@4.2.0:
         resolution:
             {
-                integrity: sha512-LBnhsoYEe0Eou4e1VgJACes+O6S6QC0w71fCSp5Oya79inkwkm15gQ1UF6VtQ8j/taMDh79hAB49WUk8ALQW3g==,
+                integrity: sha512-hjNax6o/ylDy9lefQEaSDtzaT3iVNtZ3WmpQnbuQNoG4xvnSKf2kSKbihZVO4JRG1TTMejs7CmNRYlWgAL66pQ==,
             }
+        engines: { node: ">=20" }
 
     siginfo@2.0.0:
         resolution:
@@ -3981,6 +4547,30 @@ packages:
                 integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==,
             }
 
+    spdx-correct@3.2.0:
+        resolution:
+            {
+                integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==,
+            }
+
+    spdx-exceptions@2.5.0:
+        resolution:
+            {
+                integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==,
+            }
+
+    spdx-expression-parse@3.0.1:
+        resolution:
+            {
+                integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==,
+            }
+
+    spdx-license-ids@3.0.23:
+        resolution:
+            {
+                integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==,
+            }
+
     sprintf-js@1.0.3:
         resolution:
             {
@@ -3993,10 +4583,10 @@ packages:
                 integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==,
             }
 
-    std-env@3.10.0:
+    std-env@4.1.0:
         resolution:
             {
-                integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==,
+                integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==,
             }
 
     string-argv@0.3.2:
@@ -4066,10 +4656,17 @@ packages:
             }
         engines: { node: ">=8" }
 
-    tailwindcss@4.1.18:
+    tagged-tag@1.0.0:
         resolution:
             {
-                integrity: sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==,
+                integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==,
+            }
+        engines: { node: ">=20" }
+
+    tailwindcss@4.3.1:
+        resolution:
+            {
+                integrity: sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==,
             }
 
     tinybench@2.9.0:
@@ -4078,26 +4675,12 @@ packages:
                 integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==,
             }
 
-    tinyexec@1.0.2:
-        resolution:
-            {
-                integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==,
-            }
-        engines: { node: ">=18" }
-
     tinyexec@1.2.4:
         resolution:
             {
                 integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==,
             }
         engines: { node: ">=18" }
-
-    tinyglobby@0.2.15:
-        resolution:
-            {
-                integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==,
-            }
-        engines: { node: ">=12.0.0" }
 
     tinyglobby@0.2.17:
         resolution:
@@ -4106,10 +4689,10 @@ packages:
             }
         engines: { node: ">=12.0.0" }
 
-    tinyrainbow@3.0.3:
+    tinyrainbow@3.1.0:
         resolution:
             {
-                integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==,
+                integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==,
             }
         engines: { node: ">=14.0.0" }
 
@@ -4145,26 +4728,26 @@ packages:
                 integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==,
             }
 
-    ts-api-utils@2.4.0:
+    ts-api-utils@2.5.0:
         resolution:
             {
-                integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==,
+                integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==,
             }
         engines: { node: ">=18.12" }
         peerDependencies:
             typescript: ">=4.8.4"
 
-    tsdown@0.22.2:
+    tsdown@0.22.3:
         resolution:
             {
-                integrity: sha512-VX9gsyKXsTnBZjnIM4jsHl9aRv+GfgkE/k1hQslilaBfZMlaw3JuGR+6yhiU0QxWBtOCDnTjwOSoXzgB7Rr50g==,
+                integrity: sha512-louqbfA8Qf//B9jTTL0FPtXTNpjCWv1VPkbcmQMph2pTpzs+LnB1tbe4tDDRVpo2BjF5SgUXaTZe45SxB8pWHg==,
             }
-        engines: { node: ^22.18.0 || >=24.0.0 }
+        engines: { node: ^22.18.0 || >=24.11.0 }
         hasBin: true
         peerDependencies:
             "@arethetypeswrong/core": ^0.18.1
-            "@tsdown/css": 0.22.2
-            "@tsdown/exe": 0.22.2
+            "@tsdown/css": 0.22.3
+            "@tsdown/exe": 0.22.3
             "@vitejs/devtools": "*"
             publint: ^0.3.8
             tsx: "*"
@@ -4197,10 +4780,10 @@ packages:
                 integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==,
             }
 
-    tsx@4.21.0:
+    tsx@4.22.4:
         resolution:
             {
-                integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==,
+                integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==,
             }
         engines: { node: ">=18.0.0" }
         hasBin: true
@@ -4212,25 +4795,39 @@ packages:
             }
         engines: { node: ">= 0.8.0" }
 
-    typedoc@0.28.16:
+    type-fest@4.41.0:
         resolution:
             {
-                integrity: sha512-x4xW77QC3i5DUFMBp0qjukOTnr/sSg+oEs86nB3LjDslvAmwe/PUGDWbe3GrIqt59oTqoXK5GRK9tAa0sYMiog==,
+                integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==,
+            }
+        engines: { node: ">=16" }
+
+    type-fest@5.7.0:
+        resolution:
+            {
+                integrity: sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==,
+            }
+        engines: { node: ">=20" }
+
+    typedoc@0.28.19:
+        resolution:
+            {
+                integrity: sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==,
             }
         engines: { node: ">= 18", pnpm: ">= 10" }
         hasBin: true
         peerDependencies:
-            typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x
+            typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x
 
-    typescript-eslint@8.55.0:
+    typescript-eslint@8.61.1:
         resolution:
             {
-                integrity: sha512-HE4wj+r5lmDVS9gdaN0/+iqNvPZwGfnJ5lZuz7s5vLlg9ODw0bIiiETaios9LvFI1U94/VBXGm3CB2Y5cNFMpw==,
+                integrity: sha512-V7PayAfJokV3pEHgN7/v03D1SpujhRfQtYLbLIiBfDDncdg4PAiRBfoS4cnCANK4jmAPncczi59QO3afiXUlNw==,
             }
         engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
         peerDependencies:
-            eslint: ^8.57.0 || ^9.0.0
-            typescript: ">=4.8.4 <6.0.0"
+            eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+            typescript: ">=4.8.4 <6.1.0"
 
     typescript@5.9.3:
         resolution:
@@ -4246,17 +4843,30 @@ packages:
                 integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==,
             }
 
+    ufo@1.6.4:
+        resolution:
+            {
+                integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==,
+            }
+
     unconfig-core@7.5.0:
         resolution:
             {
                 integrity: sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==,
             }
 
-    undici-types@7.16.0:
+    undici-types@7.24.6:
         resolution:
             {
-                integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==,
+                integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==,
             }
+
+    unicorn-magic@0.4.0:
+        resolution:
+            {
+                integrity: sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==,
+            }
+        engines: { node: ">=20" }
 
     unified@11.0.5:
         resolution:
@@ -4321,16 +4931,22 @@ packages:
                 integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==,
             }
 
-    valibot@1.2.0:
+    valibot@1.4.1:
         resolution:
             {
-                integrity: sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==,
+                integrity: sha512-klCmFTz2jeDluy9RwX+F884TCiogtdBJ/YaxSx1EOBYXa3NXNWj8kR1jjN8rzluwojJVWWaHJ4r1U5LfICnM3g==,
             }
         peerDependencies:
             typescript: ">=5"
         peerDependenciesMeta:
             typescript:
                 optional: true
+
+    validate-npm-package-license@3.0.4:
+        resolution:
+            {
+                integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==,
+            }
 
     vfile-location@5.0.3:
         resolution:
@@ -4358,10 +4974,18 @@ packages:
         engines: { node: ^18.0.0 || ^20.0.0 || >=22.0.0 }
         hasBin: true
 
-    vite@7.3.1:
+    vite-node@6.0.0:
         resolution:
             {
-                integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==,
+                integrity: sha512-oj4PVrT+pDh6GYf5wfUXkcZyekYS8kKPfLPXVl8qe324Ec6l4K2DUKNadRbZ3LQl0qGcDz+PyOo7ZAh00Y+JjQ==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        hasBin: true
+
+    vite@7.3.5:
+        resolution:
+            {
+                integrity: sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==,
             }
         engines: { node: ^20.19.0 || >=22.12.0 }
         hasBin: true
@@ -4401,17 +5025,17 @@ packages:
             yaml:
                 optional: true
 
-    vite@8.0.0-beta.13:
+    vite@8.0.16:
         resolution:
             {
-                integrity: sha512-7s/rfpYOAo7WUHh9irzaGjhhKb12hGv0BpDegAMV5A391wdyvM45WtX6VMV7hvEtZF2j/QtpDpR6ldXI3GgARQ==,
+                integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==,
             }
         engines: { node: ^20.19.0 || >=22.12.0 }
         hasBin: true
         peerDependencies:
             "@types/node": ^20.19.0 || >=22.12.0
-            "@vitejs/devtools": ^0.0.0-alpha.24
-            esbuild: ^0.27.0
+            "@vitejs/devtools": ^0.1.18
+            esbuild: ^0.27.0 || ^0.28.0
             jiti: ">=1.21.0"
             less: ^4.0.0
             sass: ^1.70.0
@@ -4447,10 +5071,10 @@ packages:
             yaml:
                 optional: true
 
-    vitest@4.0.18:
+    vitest@4.1.9:
         resolution:
             {
-                integrity: sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==,
+                integrity: sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==,
             }
         engines: { node: ^20.0.0 || ^22.0.0 || >=24.0.0 }
         hasBin: true
@@ -4458,12 +5082,15 @@ packages:
             "@edge-runtime/vm": "*"
             "@opentelemetry/api": ^1.9.0
             "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
-            "@vitest/browser-playwright": 4.0.18
-            "@vitest/browser-preview": 4.0.18
-            "@vitest/browser-webdriverio": 4.0.18
-            "@vitest/ui": 4.0.18
+            "@vitest/browser-playwright": 4.1.9
+            "@vitest/browser-preview": 4.1.9
+            "@vitest/browser-webdriverio": 4.1.9
+            "@vitest/coverage-istanbul": 4.1.9
+            "@vitest/coverage-v8": 4.1.9
+            "@vitest/ui": 4.1.9
             happy-dom: "*"
             jsdom: "*"
+            vite: ^6.0.0 || ^7.0.0 || ^8.0.0
         peerDependenciesMeta:
             "@edge-runtime/vm":
                 optional: true
@@ -4476,6 +5103,10 @@ packages:
             "@vitest/browser-preview":
                 optional: true
             "@vitest/browser-webdriverio":
+                optional: true
+            "@vitest/coverage-istanbul":
+                optional: true
+            "@vitest/coverage-v8":
                 optional: true
             "@vitest/ui":
                 optional: true
@@ -4534,6 +5165,14 @@ packages:
         engines: { node: ">= 14.6" }
         hasBin: true
 
+    yaml@2.9.0:
+        resolution:
+            {
+                integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==,
+            }
+        engines: { node: ">= 14.6" }
+        hasBin: true
+
     yocto-queue@0.1.0:
         resolution:
             {
@@ -4548,25 +5187,25 @@ packages:
             }
 
 snapshots:
-    "@babel/code-frame@7.29.0":
+    "@babel/code-frame@7.29.7":
         dependencies:
-            "@babel/helper-validator-identifier": 7.28.5
+            "@babel/helper-validator-identifier": 7.29.7
             js-tokens: 4.0.0
             picocolors: 1.1.1
 
-    "@babel/compat-data@7.29.0": {}
+    "@babel/compat-data@7.29.7": {}
 
-    "@babel/core@7.29.0":
+    "@babel/core@7.29.7":
         dependencies:
-            "@babel/code-frame": 7.29.0
-            "@babel/generator": 7.29.1
-            "@babel/helper-compilation-targets": 7.28.6
-            "@babel/helper-module-transforms": 7.28.6(@babel/core@7.29.0)
-            "@babel/helpers": 7.28.6
-            "@babel/parser": 7.29.0
-            "@babel/template": 7.28.6
-            "@babel/traverse": 7.29.0
-            "@babel/types": 7.29.0
+            "@babel/code-frame": 7.29.7
+            "@babel/generator": 7.29.7
+            "@babel/helper-compilation-targets": 7.29.7
+            "@babel/helper-module-transforms": 7.29.7(@babel/core@7.29.7)
+            "@babel/helpers": 7.29.7
+            "@babel/parser": 7.29.7
+            "@babel/template": 7.29.7
+            "@babel/traverse": 7.29.7
+            "@babel/types": 7.29.7
             "@jridgewell/remapping": 2.3.5
             convert-source-map: 2.0.0
             debug: 4.4.3
@@ -4576,197 +5215,195 @@ snapshots:
         transitivePeerDependencies:
             - supports-color
 
-    "@babel/generator@7.29.1":
+    "@babel/generator@7.29.7":
         dependencies:
-            "@babel/parser": 7.29.0
-            "@babel/types": 7.29.0
+            "@babel/parser": 7.29.7
+            "@babel/types": 7.29.7
             "@jridgewell/gen-mapping": 0.3.13
             "@jridgewell/trace-mapping": 0.3.31
             jsesc: 3.0.2
 
-    "@babel/generator@8.0.0-rc.6":
+    "@babel/generator@8.0.0":
         dependencies:
-            "@babel/parser": 8.0.0-rc.6
-            "@babel/types": 8.0.0-rc.6
+            "@babel/parser": 8.0.0
+            "@babel/types": 8.0.0
             "@jridgewell/gen-mapping": 0.3.13
             "@jridgewell/trace-mapping": 0.3.31
             "@types/jsesc": 2.5.1
-            jsesc: 3.0.2
+            jsesc: 3.1.0
 
-    "@babel/helper-annotate-as-pure@7.27.3":
+    "@babel/helper-annotate-as-pure@7.29.7":
         dependencies:
-            "@babel/types": 7.29.0
+            "@babel/types": 7.29.7
 
-    "@babel/helper-compilation-targets@7.28.6":
+    "@babel/helper-compilation-targets@7.29.7":
         dependencies:
-            "@babel/compat-data": 7.29.0
-            "@babel/helper-validator-option": 7.27.1
-            browserslist: 4.28.1
+            "@babel/compat-data": 7.29.7
+            "@babel/helper-validator-option": 7.29.7
+            browserslist: 4.28.2
             lru-cache: 5.1.1
             semver: 6.3.1
 
-    "@babel/helper-create-class-features-plugin@7.28.6(@babel/core@7.29.0)":
+    "@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7)":
         dependencies:
-            "@babel/core": 7.29.0
-            "@babel/helper-annotate-as-pure": 7.27.3
-            "@babel/helper-member-expression-to-functions": 7.28.5
-            "@babel/helper-optimise-call-expression": 7.27.1
-            "@babel/helper-replace-supers": 7.28.6(@babel/core@7.29.0)
-            "@babel/helper-skip-transparent-expression-wrappers": 7.27.1
-            "@babel/traverse": 7.29.0
+            "@babel/core": 7.29.7
+            "@babel/helper-annotate-as-pure": 7.29.7
+            "@babel/helper-member-expression-to-functions": 7.29.7
+            "@babel/helper-optimise-call-expression": 7.29.7
+            "@babel/helper-replace-supers": 7.29.7(@babel/core@7.29.7)
+            "@babel/helper-skip-transparent-expression-wrappers": 7.29.7
+            "@babel/traverse": 7.29.7
             semver: 6.3.1
         transitivePeerDependencies:
             - supports-color
 
-    "@babel/helper-globals@7.28.0": {}
+    "@babel/helper-globals@7.29.7": {}
 
-    "@babel/helper-member-expression-to-functions@7.28.5":
+    "@babel/helper-member-expression-to-functions@7.29.7":
         dependencies:
-            "@babel/traverse": 7.29.0
-            "@babel/types": 7.29.0
+            "@babel/traverse": 7.29.7
+            "@babel/types": 7.29.7
         transitivePeerDependencies:
             - supports-color
 
-    "@babel/helper-module-imports@7.28.6":
+    "@babel/helper-module-imports@7.29.7":
         dependencies:
-            "@babel/traverse": 7.29.0
-            "@babel/types": 7.29.0
+            "@babel/traverse": 7.29.7
+            "@babel/types": 7.29.7
         transitivePeerDependencies:
             - supports-color
 
-    "@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)":
+    "@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)":
         dependencies:
-            "@babel/core": 7.29.0
-            "@babel/helper-module-imports": 7.28.6
-            "@babel/helper-validator-identifier": 7.28.5
-            "@babel/traverse": 7.29.0
+            "@babel/core": 7.29.7
+            "@babel/helper-module-imports": 7.29.7
+            "@babel/helper-validator-identifier": 7.29.7
+            "@babel/traverse": 7.29.7
         transitivePeerDependencies:
             - supports-color
 
-    "@babel/helper-optimise-call-expression@7.27.1":
+    "@babel/helper-optimise-call-expression@7.29.7":
         dependencies:
-            "@babel/types": 7.29.0
+            "@babel/types": 7.29.7
 
-    "@babel/helper-plugin-utils@7.28.6": {}
+    "@babel/helper-plugin-utils@7.29.7": {}
 
-    "@babel/helper-replace-supers@7.28.6(@babel/core@7.29.0)":
+    "@babel/helper-replace-supers@7.29.7(@babel/core@7.29.7)":
         dependencies:
-            "@babel/core": 7.29.0
-            "@babel/helper-member-expression-to-functions": 7.28.5
-            "@babel/helper-optimise-call-expression": 7.27.1
-            "@babel/traverse": 7.29.0
+            "@babel/core": 7.29.7
+            "@babel/helper-member-expression-to-functions": 7.29.7
+            "@babel/helper-optimise-call-expression": 7.29.7
+            "@babel/traverse": 7.29.7
         transitivePeerDependencies:
             - supports-color
 
-    "@babel/helper-skip-transparent-expression-wrappers@7.27.1":
+    "@babel/helper-skip-transparent-expression-wrappers@7.29.7":
         dependencies:
-            "@babel/traverse": 7.29.0
-            "@babel/types": 7.29.0
+            "@babel/traverse": 7.29.7
+            "@babel/types": 7.29.7
         transitivePeerDependencies:
             - supports-color
 
-    "@babel/helper-string-parser@7.27.1": {}
+    "@babel/helper-string-parser@7.29.7": {}
 
-    "@babel/helper-string-parser@8.0.0-rc.6": {}
+    "@babel/helper-string-parser@8.0.0": {}
 
-    "@babel/helper-validator-identifier@7.28.5": {}
+    "@babel/helper-validator-identifier@7.29.7": {}
 
-    "@babel/helper-validator-identifier@8.0.0-rc.6": {}
+    "@babel/helper-validator-identifier@8.0.0": {}
 
-    "@babel/helper-validator-option@7.27.1": {}
+    "@babel/helper-validator-option@7.29.7": {}
 
-    "@babel/helpers@7.28.6":
+    "@babel/helpers@7.29.7":
         dependencies:
-            "@babel/template": 7.28.6
-            "@babel/types": 7.29.0
+            "@babel/template": 7.29.7
+            "@babel/types": 7.29.7
 
-    "@babel/parser@7.29.0":
+    "@babel/parser@7.29.7":
         dependencies:
-            "@babel/types": 7.29.0
+            "@babel/types": 7.29.7
 
-    "@babel/parser@8.0.0-rc.6":
+    "@babel/parser@8.0.0":
         dependencies:
-            "@babel/types": 8.0.0-rc.6
+            "@babel/types": 8.0.0
 
-    "@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0)":
+    "@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7)":
         dependencies:
-            "@babel/core": 7.29.0
-            "@babel/helper-plugin-utils": 7.28.6
+            "@babel/core": 7.29.7
+            "@babel/helper-plugin-utils": 7.29.7
 
-    "@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0)":
+    "@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7)":
         dependencies:
-            "@babel/core": 7.29.0
-            "@babel/helper-plugin-utils": 7.28.6
+            "@babel/core": 7.29.7
+            "@babel/helper-plugin-utils": 7.29.7
 
-    "@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.29.0)":
+    "@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.29.7)":
         dependencies:
-            "@babel/core": 7.29.0
-            "@babel/helper-module-transforms": 7.28.6(@babel/core@7.29.0)
-            "@babel/helper-plugin-utils": 7.28.6
+            "@babel/core": 7.29.7
+            "@babel/helper-module-transforms": 7.29.7(@babel/core@7.29.7)
+            "@babel/helper-plugin-utils": 7.29.7
         transitivePeerDependencies:
             - supports-color
 
-    "@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)":
+    "@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7)":
         dependencies:
-            "@babel/core": 7.29.0
-            "@babel/helper-plugin-utils": 7.28.6
-
-    "@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)":
-        dependencies:
-            "@babel/core": 7.29.0
-            "@babel/helper-plugin-utils": 7.28.6
-
-    "@babel/plugin-transform-typescript@7.28.6(@babel/core@7.29.0)":
-        dependencies:
-            "@babel/core": 7.29.0
-            "@babel/helper-annotate-as-pure": 7.27.3
-            "@babel/helper-create-class-features-plugin": 7.28.6(@babel/core@7.29.0)
-            "@babel/helper-plugin-utils": 7.28.6
-            "@babel/helper-skip-transparent-expression-wrappers": 7.27.1
-            "@babel/plugin-syntax-typescript": 7.28.6(@babel/core@7.29.0)
+            "@babel/core": 7.29.7
+            "@babel/helper-annotate-as-pure": 7.29.7
+            "@babel/helper-create-class-features-plugin": 7.29.7(@babel/core@7.29.7)
+            "@babel/helper-plugin-utils": 7.29.7
+            "@babel/helper-skip-transparent-expression-wrappers": 7.29.7
+            "@babel/plugin-syntax-typescript": 7.29.7(@babel/core@7.29.7)
         transitivePeerDependencies:
             - supports-color
 
-    "@babel/preset-typescript@7.28.5(@babel/core@7.29.0)":
+    "@babel/preset-typescript@7.29.7(@babel/core@7.29.7)":
         dependencies:
-            "@babel/core": 7.29.0
-            "@babel/helper-plugin-utils": 7.28.6
-            "@babel/helper-validator-option": 7.27.1
-            "@babel/plugin-syntax-jsx": 7.28.6(@babel/core@7.29.0)
-            "@babel/plugin-transform-modules-commonjs": 7.28.6(@babel/core@7.29.0)
-            "@babel/plugin-transform-typescript": 7.28.6(@babel/core@7.29.0)
+            "@babel/core": 7.29.7
+            "@babel/helper-plugin-utils": 7.29.7
+            "@babel/helper-validator-option": 7.29.7
+            "@babel/plugin-syntax-jsx": 7.29.7(@babel/core@7.29.7)
+            "@babel/plugin-transform-modules-commonjs": 7.29.7(@babel/core@7.29.7)
+            "@babel/plugin-transform-typescript": 7.29.7(@babel/core@7.29.7)
         transitivePeerDependencies:
             - supports-color
 
-    "@babel/template@7.28.6":
-        dependencies:
-            "@babel/code-frame": 7.29.0
-            "@babel/parser": 7.29.0
-            "@babel/types": 7.29.0
+    "@babel/runtime@7.29.7": {}
 
-    "@babel/traverse@7.29.0":
+    "@babel/template@7.29.7":
         dependencies:
-            "@babel/code-frame": 7.29.0
-            "@babel/generator": 7.29.1
-            "@babel/helper-globals": 7.28.0
-            "@babel/parser": 7.29.0
-            "@babel/template": 7.28.6
-            "@babel/types": 7.29.0
+            "@babel/code-frame": 7.29.7
+            "@babel/parser": 7.29.7
+            "@babel/types": 7.29.7
+
+    "@babel/traverse@7.29.7":
+        dependencies:
+            "@babel/code-frame": 7.29.7
+            "@babel/generator": 7.29.7
+            "@babel/helper-globals": 7.29.7
+            "@babel/parser": 7.29.7
+            "@babel/template": 7.29.7
+            "@babel/types": 7.29.7
             debug: 4.4.3
         transitivePeerDependencies:
             - supports-color
 
-    "@babel/types@7.29.0":
+    "@babel/types@7.29.7":
         dependencies:
-            "@babel/helper-string-parser": 7.27.1
-            "@babel/helper-validator-identifier": 7.28.5
+            "@babel/helper-string-parser": 7.29.7
+            "@babel/helper-validator-identifier": 7.29.7
 
-    "@babel/types@8.0.0-rc.6":
+    "@babel/types@8.0.0":
         dependencies:
-            "@babel/helper-string-parser": 8.0.0-rc.6
-            "@babel/helper-validator-identifier": 8.0.0-rc.6
+            "@babel/helper-string-parser": 8.0.0
+            "@babel/helper-validator-identifier": 8.0.0
 
     "@bcoe/v8-coverage@1.0.2": {}
+
+    "@emnapi/core@1.10.0":
+        dependencies:
+            "@emnapi/wasi-threads": 1.2.1
+            tslib: 2.8.1
+        optional: true
 
     "@emnapi/core@1.11.0":
         dependencies:
@@ -4774,9 +5411,8 @@ snapshots:
             tslib: 2.8.1
         optional: true
 
-    "@emnapi/core@1.8.1":
+    "@emnapi/runtime@1.10.0":
         dependencies:
-            "@emnapi/wasi-threads": 1.1.0
             tslib: 2.8.1
         optional: true
 
@@ -4785,12 +5421,7 @@ snapshots:
             tslib: 2.8.1
         optional: true
 
-    "@emnapi/runtime@1.8.1":
-        dependencies:
-            tslib: 2.8.1
-        optional: true
-
-    "@emnapi/wasi-threads@1.1.0":
+    "@emnapi/wasi-threads@1.2.1":
         dependencies:
             tslib: 2.8.1
         optional: true
@@ -4800,82 +5431,162 @@ snapshots:
             tslib: 2.8.1
         optional: true
 
-    "@esbuild/aix-ppc64@0.27.3":
+    "@emotion/hash@0.9.2": {}
+
+    "@esbuild/aix-ppc64@0.27.7":
         optional: true
 
-    "@esbuild/android-arm64@0.27.3":
+    "@esbuild/aix-ppc64@0.28.1":
         optional: true
 
-    "@esbuild/android-arm@0.27.3":
+    "@esbuild/android-arm64@0.27.7":
         optional: true
 
-    "@esbuild/android-x64@0.27.3":
+    "@esbuild/android-arm64@0.28.1":
         optional: true
 
-    "@esbuild/darwin-arm64@0.27.3":
+    "@esbuild/android-arm@0.27.7":
         optional: true
 
-    "@esbuild/darwin-x64@0.27.3":
+    "@esbuild/android-arm@0.28.1":
         optional: true
 
-    "@esbuild/freebsd-arm64@0.27.3":
+    "@esbuild/android-x64@0.27.7":
         optional: true
 
-    "@esbuild/freebsd-x64@0.27.3":
+    "@esbuild/android-x64@0.28.1":
         optional: true
 
-    "@esbuild/linux-arm64@0.27.3":
+    "@esbuild/darwin-arm64@0.27.7":
         optional: true
 
-    "@esbuild/linux-arm@0.27.3":
+    "@esbuild/darwin-arm64@0.28.1":
         optional: true
 
-    "@esbuild/linux-ia32@0.27.3":
+    "@esbuild/darwin-x64@0.27.7":
         optional: true
 
-    "@esbuild/linux-loong64@0.27.3":
+    "@esbuild/darwin-x64@0.28.1":
         optional: true
 
-    "@esbuild/linux-mips64el@0.27.3":
+    "@esbuild/freebsd-arm64@0.27.7":
         optional: true
 
-    "@esbuild/linux-ppc64@0.27.3":
+    "@esbuild/freebsd-arm64@0.28.1":
         optional: true
 
-    "@esbuild/linux-riscv64@0.27.3":
+    "@esbuild/freebsd-x64@0.27.7":
         optional: true
 
-    "@esbuild/linux-s390x@0.27.3":
+    "@esbuild/freebsd-x64@0.28.1":
         optional: true
 
-    "@esbuild/linux-x64@0.27.3":
+    "@esbuild/linux-arm64@0.27.7":
         optional: true
 
-    "@esbuild/netbsd-arm64@0.27.3":
+    "@esbuild/linux-arm64@0.28.1":
         optional: true
 
-    "@esbuild/netbsd-x64@0.27.3":
+    "@esbuild/linux-arm@0.27.7":
         optional: true
 
-    "@esbuild/openbsd-arm64@0.27.3":
+    "@esbuild/linux-arm@0.28.1":
         optional: true
 
-    "@esbuild/openbsd-x64@0.27.3":
+    "@esbuild/linux-ia32@0.27.7":
         optional: true
 
-    "@esbuild/openharmony-arm64@0.27.3":
+    "@esbuild/linux-ia32@0.28.1":
         optional: true
 
-    "@esbuild/sunos-x64@0.27.3":
+    "@esbuild/linux-loong64@0.27.7":
         optional: true
 
-    "@esbuild/win32-arm64@0.27.3":
+    "@esbuild/linux-loong64@0.28.1":
         optional: true
 
-    "@esbuild/win32-ia32@0.27.3":
+    "@esbuild/linux-mips64el@0.27.7":
         optional: true
 
-    "@esbuild/win32-x64@0.27.3":
+    "@esbuild/linux-mips64el@0.28.1":
+        optional: true
+
+    "@esbuild/linux-ppc64@0.27.7":
+        optional: true
+
+    "@esbuild/linux-ppc64@0.28.1":
+        optional: true
+
+    "@esbuild/linux-riscv64@0.27.7":
+        optional: true
+
+    "@esbuild/linux-riscv64@0.28.1":
+        optional: true
+
+    "@esbuild/linux-s390x@0.27.7":
+        optional: true
+
+    "@esbuild/linux-s390x@0.28.1":
+        optional: true
+
+    "@esbuild/linux-x64@0.27.7":
+        optional: true
+
+    "@esbuild/linux-x64@0.28.1":
+        optional: true
+
+    "@esbuild/netbsd-arm64@0.27.7":
+        optional: true
+
+    "@esbuild/netbsd-arm64@0.28.1":
+        optional: true
+
+    "@esbuild/netbsd-x64@0.27.7":
+        optional: true
+
+    "@esbuild/netbsd-x64@0.28.1":
+        optional: true
+
+    "@esbuild/openbsd-arm64@0.27.7":
+        optional: true
+
+    "@esbuild/openbsd-arm64@0.28.1":
+        optional: true
+
+    "@esbuild/openbsd-x64@0.27.7":
+        optional: true
+
+    "@esbuild/openbsd-x64@0.28.1":
+        optional: true
+
+    "@esbuild/openharmony-arm64@0.27.7":
+        optional: true
+
+    "@esbuild/openharmony-arm64@0.28.1":
+        optional: true
+
+    "@esbuild/sunos-x64@0.27.7":
+        optional: true
+
+    "@esbuild/sunos-x64@0.28.1":
+        optional: true
+
+    "@esbuild/win32-arm64@0.27.7":
+        optional: true
+
+    "@esbuild/win32-arm64@0.28.1":
+        optional: true
+
+    "@esbuild/win32-ia32@0.27.7":
+        optional: true
+
+    "@esbuild/win32-ia32@0.28.1":
+        optional: true
+
+    "@esbuild/win32-x64@0.27.7":
+        optional: true
+
+    "@esbuild/win32-x64@0.28.1":
         optional: true
 
     "@eslint-community/eslint-utils@4.9.1(eslint@9.39.2)":
@@ -4924,12 +5635,12 @@ snapshots:
             "@eslint/core": 0.17.0
             levn: 0.4.1
 
-    "@gerrit0/mini-shiki@3.22.0":
+    "@gerrit0/mini-shiki@3.23.0":
         dependencies:
-            "@shikijs/engine-oniguruma": 3.22.0
-            "@shikijs/langs": 3.22.0
-            "@shikijs/themes": 3.22.0
-            "@shikijs/types": 3.22.0
+            "@shikijs/engine-oniguruma": 3.23.0
+            "@shikijs/langs": 3.23.0
+            "@shikijs/themes": 3.23.0
+            "@shikijs/types": 3.23.0
             "@shikijs/vscode-textmate": 10.0.2
 
     "@humanfs/core@0.19.1": {}
@@ -4964,11 +5675,11 @@ snapshots:
 
     "@mdx-js/mdx@3.1.1":
         dependencies:
-            "@types/estree": 1.0.8
+            "@types/estree": 1.0.9
             "@types/estree-jsx": 1.0.5
             "@types/hast": 3.0.4
-            "@types/mdx": 2.0.13
-            acorn: 8.15.0
+            "@types/mdx": 2.0.14
+            acorn: 8.17.0
             collapse-white-space: 2.1.0
             devlop: 1.1.0
             estree-util-is-identifier-name: 3.0.0
@@ -4977,7 +5688,7 @@ snapshots:
             hast-util-to-jsx-runtime: 2.3.6
             markdown-extensions: 2.0.0
             recma-build-jsx: 1.0.0
-            recma-jsx: 1.0.1(acorn@8.15.0)
+            recma-jsx: 1.0.1(acorn@8.17.0)
             recma-stringify: 1.0.0
             rehype-recma: 1.0.0
             remark-mdx: 3.1.1
@@ -4992,11 +5703,11 @@ snapshots:
         transitivePeerDependencies:
             - supports-color
 
-    "@mdx-js/rollup@3.1.1(rollup@4.57.1)":
+    "@mdx-js/rollup@3.1.1(rollup@4.62.0)":
         dependencies:
             "@mdx-js/mdx": 3.1.1
-            "@rollup/pluginutils": 5.3.0(rollup@4.57.1)
-            rollup: 4.57.1
+            "@rollup/pluginutils": 5.4.0(rollup@4.62.0)
+            rollup: 4.62.0
             source-map: 0.7.6
             vfile: 6.0.3
         transitivePeerDependencies:
@@ -5004,11 +5715,11 @@ snapshots:
 
     "@mjackson/node-fetch-server@0.2.0": {}
 
-    "@napi-rs/wasm-runtime@1.1.1":
+    "@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)":
         dependencies:
-            "@emnapi/core": 1.8.1
-            "@emnapi/runtime": 1.8.1
-            "@tybys/wasm-util": 0.10.1
+            "@emnapi/core": 1.10.0
+            "@emnapi/runtime": 1.10.0
+            "@tybys/wasm-util": 0.10.2
         optional: true
 
     "@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)":
@@ -5018,9 +5729,7 @@ snapshots:
             "@tybys/wasm-util": 0.10.2
         optional: true
 
-    "@oxc-project/runtime@0.112.0": {}
-
-    "@oxc-project/types@0.112.0": {}
+    "@oxc-project/types@0.133.0": {}
 
     "@oxc-project/types@0.135.0": {}
 
@@ -5028,38 +5737,38 @@ snapshots:
         dependencies:
             quansync: 1.0.0
 
-    "@react-router/dev@7.13.0(@types/node@25.2.3)(lightningcss@1.31.1)(react-router@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.0-beta.13(@types/node@25.2.3)(esbuild@0.27.3)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)":
+    "@react-router/dev@7.18.0(@types/node@25.9.3)(lightningcss@1.32.0)(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(tsx@4.22.4)(typescript@5.9.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.2))(yaml@2.9.0)":
         dependencies:
-            "@babel/core": 7.29.0
-            "@babel/generator": 7.29.1
-            "@babel/parser": 7.29.0
-            "@babel/plugin-syntax-jsx": 7.28.6(@babel/core@7.29.0)
-            "@babel/preset-typescript": 7.28.5(@babel/core@7.29.0)
-            "@babel/traverse": 7.29.0
-            "@babel/types": 7.29.0
-            "@react-router/node": 7.13.0(react-router@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
-            "@remix-run/node-fetch-server": 0.13.0
+            "@babel/core": 7.29.7
+            "@babel/generator": 7.29.7
+            "@babel/parser": 7.29.7
+            "@babel/plugin-syntax-jsx": 7.29.7(@babel/core@7.29.7)
+            "@babel/preset-typescript": 7.29.7(@babel/core@7.29.7)
+            "@babel/traverse": 7.29.7
+            "@babel/types": 7.29.7
+            "@react-router/node": 7.18.0(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)
+            "@remix-run/node-fetch-server": 0.13.3
             arg: 5.0.2
             babel-dead-code-elimination: 1.0.12
             chokidar: 4.0.3
-            dedent: 1.7.1
+            dedent: 1.7.2
             es-module-lexer: 1.7.0
             exit-hook: 2.2.1
-            isbot: 5.1.35
+            isbot: 5.1.43
             jsesc: 3.0.2
-            lodash: 4.17.23
+            lodash: 4.18.1
             p-map: 7.0.4
             pathe: 1.1.2
             picocolors: 1.1.1
-            pkg-types: 2.3.0
-            prettier: 3.8.1
+            pkg-types: 2.3.1
+            prettier: 3.8.4
             react-refresh: 0.14.2
-            react-router: 7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-            semver: 7.7.4
-            tinyglobby: 0.2.15
-            valibot: 1.2.0(typescript@5.9.3)
-            vite: 8.0.0-beta.13(@types/node@25.2.3)(esbuild@0.27.3)(tsx@4.21.0)(yaml@2.8.2)
-            vite-node: 3.2.4(@types/node@25.2.3)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+            react-router: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+            semver: 7.8.4
+            tinyglobby: 0.2.17
+            valibot: 1.4.1(typescript@5.9.3)
+            vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.2)
+            vite-node: 3.2.4(@types/node@25.9.3)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
         optionalDependencies:
             typescript: 5.9.3
         transitivePeerDependencies:
@@ -5077,84 +5786,143 @@ snapshots:
             - tsx
             - yaml
 
-    "@react-router/node@7.13.0(react-router@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)":
+    "@react-router/node@7.18.0(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)":
         dependencies:
             "@mjackson/node-fetch-server": 0.2.0
-            react-router: 7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+            react-router: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
         optionalDependencies:
             typescript: 5.9.3
 
-    "@remix-run/node-fetch-server@0.13.0": {}
+    "@remix-run/node-fetch-server@0.13.3": {}
 
-    "@rolldown/binding-android-arm64@1.0.0-rc.3":
+    "@resvg/resvg-js-android-arm-eabi@2.6.2":
+        optional: true
+
+    "@resvg/resvg-js-android-arm64@2.6.2":
+        optional: true
+
+    "@resvg/resvg-js-darwin-arm64@2.6.2":
+        optional: true
+
+    "@resvg/resvg-js-darwin-x64@2.6.2":
+        optional: true
+
+    "@resvg/resvg-js-linux-arm-gnueabihf@2.6.2":
+        optional: true
+
+    "@resvg/resvg-js-linux-arm64-gnu@2.6.2":
+        optional: true
+
+    "@resvg/resvg-js-linux-arm64-musl@2.6.2":
+        optional: true
+
+    "@resvg/resvg-js-linux-x64-gnu@2.6.2":
+        optional: true
+
+    "@resvg/resvg-js-linux-x64-musl@2.6.2":
+        optional: true
+
+    "@resvg/resvg-js-win32-arm64-msvc@2.6.2":
+        optional: true
+
+    "@resvg/resvg-js-win32-ia32-msvc@2.6.2":
+        optional: true
+
+    "@resvg/resvg-js-win32-x64-msvc@2.6.2":
+        optional: true
+
+    "@resvg/resvg-js@2.6.2":
+        optionalDependencies:
+            "@resvg/resvg-js-android-arm-eabi": 2.6.2
+            "@resvg/resvg-js-android-arm64": 2.6.2
+            "@resvg/resvg-js-darwin-arm64": 2.6.2
+            "@resvg/resvg-js-darwin-x64": 2.6.2
+            "@resvg/resvg-js-linux-arm-gnueabihf": 2.6.2
+            "@resvg/resvg-js-linux-arm64-gnu": 2.6.2
+            "@resvg/resvg-js-linux-arm64-musl": 2.6.2
+            "@resvg/resvg-js-linux-x64-gnu": 2.6.2
+            "@resvg/resvg-js-linux-x64-musl": 2.6.2
+            "@resvg/resvg-js-win32-arm64-msvc": 2.6.2
+            "@resvg/resvg-js-win32-ia32-msvc": 2.6.2
+            "@resvg/resvg-js-win32-x64-msvc": 2.6.2
+
+    "@rolldown/binding-android-arm64@1.0.3":
         optional: true
 
     "@rolldown/binding-android-arm64@1.1.1":
         optional: true
 
-    "@rolldown/binding-darwin-arm64@1.0.0-rc.3":
+    "@rolldown/binding-darwin-arm64@1.0.3":
         optional: true
 
     "@rolldown/binding-darwin-arm64@1.1.1":
         optional: true
 
-    "@rolldown/binding-darwin-x64@1.0.0-rc.3":
+    "@rolldown/binding-darwin-x64@1.0.3":
         optional: true
 
     "@rolldown/binding-darwin-x64@1.1.1":
         optional: true
 
-    "@rolldown/binding-freebsd-x64@1.0.0-rc.3":
+    "@rolldown/binding-freebsd-x64@1.0.3":
         optional: true
 
     "@rolldown/binding-freebsd-x64@1.1.1":
         optional: true
 
-    "@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.3":
+    "@rolldown/binding-linux-arm-gnueabihf@1.0.3":
         optional: true
 
     "@rolldown/binding-linux-arm-gnueabihf@1.1.1":
         optional: true
 
-    "@rolldown/binding-linux-arm64-gnu@1.0.0-rc.3":
+    "@rolldown/binding-linux-arm64-gnu@1.0.3":
         optional: true
 
     "@rolldown/binding-linux-arm64-gnu@1.1.1":
         optional: true
 
-    "@rolldown/binding-linux-arm64-musl@1.0.0-rc.3":
+    "@rolldown/binding-linux-arm64-musl@1.0.3":
         optional: true
 
     "@rolldown/binding-linux-arm64-musl@1.1.1":
         optional: true
 
+    "@rolldown/binding-linux-ppc64-gnu@1.0.3":
+        optional: true
+
     "@rolldown/binding-linux-ppc64-gnu@1.1.1":
+        optional: true
+
+    "@rolldown/binding-linux-s390x-gnu@1.0.3":
         optional: true
 
     "@rolldown/binding-linux-s390x-gnu@1.1.1":
         optional: true
 
-    "@rolldown/binding-linux-x64-gnu@1.0.0-rc.3":
+    "@rolldown/binding-linux-x64-gnu@1.0.3":
         optional: true
 
     "@rolldown/binding-linux-x64-gnu@1.1.1":
         optional: true
 
-    "@rolldown/binding-linux-x64-musl@1.0.0-rc.3":
+    "@rolldown/binding-linux-x64-musl@1.0.3":
         optional: true
 
     "@rolldown/binding-linux-x64-musl@1.1.1":
         optional: true
 
-    "@rolldown/binding-openharmony-arm64@1.0.0-rc.3":
+    "@rolldown/binding-openharmony-arm64@1.0.3":
         optional: true
 
     "@rolldown/binding-openharmony-arm64@1.1.1":
         optional: true
 
-    "@rolldown/binding-wasm32-wasi@1.0.0-rc.3":
+    "@rolldown/binding-wasm32-wasi@1.0.3":
         dependencies:
-            "@napi-rs/wasm-runtime": 1.1.1
+            "@emnapi/core": 1.10.0
+            "@emnapi/runtime": 1.10.0
+            "@napi-rs/wasm-runtime": 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
         optional: true
 
     "@rolldown/binding-wasm32-wasi@1.1.1":
@@ -5164,141 +5932,164 @@ snapshots:
             "@napi-rs/wasm-runtime": 1.1.5(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)
         optional: true
 
-    "@rolldown/binding-win32-arm64-msvc@1.0.0-rc.3":
+    "@rolldown/binding-win32-arm64-msvc@1.0.3":
         optional: true
 
     "@rolldown/binding-win32-arm64-msvc@1.1.1":
         optional: true
 
-    "@rolldown/binding-win32-x64-msvc@1.0.0-rc.3":
+    "@rolldown/binding-win32-x64-msvc@1.0.3":
         optional: true
 
     "@rolldown/binding-win32-x64-msvc@1.1.1":
         optional: true
 
-    "@rolldown/pluginutils@1.0.0-rc.3": {}
-
     "@rolldown/pluginutils@1.0.1": {}
 
-    "@rollup/pluginutils@5.3.0(rollup@4.57.1)":
+    "@rollup/pluginutils@5.4.0(rollup@4.62.0)":
         dependencies:
-            "@types/estree": 1.0.8
+            "@types/estree": 1.0.9
             estree-walker: 2.0.2
-            picomatch: 4.0.3
+            picomatch: 4.0.4
         optionalDependencies:
-            rollup: 4.57.1
+            rollup: 4.62.0
 
-    "@rollup/rollup-android-arm-eabi@4.57.1":
+    "@rollup/rollup-android-arm-eabi@4.62.0":
         optional: true
 
-    "@rollup/rollup-android-arm64@4.57.1":
+    "@rollup/rollup-android-arm64@4.62.0":
         optional: true
 
-    "@rollup/rollup-darwin-arm64@4.57.1":
+    "@rollup/rollup-darwin-arm64@4.62.0":
         optional: true
 
-    "@rollup/rollup-darwin-x64@4.57.1":
+    "@rollup/rollup-darwin-x64@4.62.0":
         optional: true
 
-    "@rollup/rollup-freebsd-arm64@4.57.1":
+    "@rollup/rollup-freebsd-arm64@4.62.0":
         optional: true
 
-    "@rollup/rollup-freebsd-x64@4.57.1":
+    "@rollup/rollup-freebsd-x64@4.62.0":
         optional: true
 
-    "@rollup/rollup-linux-arm-gnueabihf@4.57.1":
+    "@rollup/rollup-linux-arm-gnueabihf@4.62.0":
         optional: true
 
-    "@rollup/rollup-linux-arm-musleabihf@4.57.1":
+    "@rollup/rollup-linux-arm-musleabihf@4.62.0":
         optional: true
 
-    "@rollup/rollup-linux-arm64-gnu@4.57.1":
+    "@rollup/rollup-linux-arm64-gnu@4.62.0":
         optional: true
 
-    "@rollup/rollup-linux-arm64-musl@4.57.1":
+    "@rollup/rollup-linux-arm64-musl@4.62.0":
         optional: true
 
-    "@rollup/rollup-linux-loong64-gnu@4.57.1":
+    "@rollup/rollup-linux-loong64-gnu@4.62.0":
         optional: true
 
-    "@rollup/rollup-linux-loong64-musl@4.57.1":
+    "@rollup/rollup-linux-loong64-musl@4.62.0":
         optional: true
 
-    "@rollup/rollup-linux-ppc64-gnu@4.57.1":
+    "@rollup/rollup-linux-ppc64-gnu@4.62.0":
         optional: true
 
-    "@rollup/rollup-linux-ppc64-musl@4.57.1":
+    "@rollup/rollup-linux-ppc64-musl@4.62.0":
         optional: true
 
-    "@rollup/rollup-linux-riscv64-gnu@4.57.1":
+    "@rollup/rollup-linux-riscv64-gnu@4.62.0":
         optional: true
 
-    "@rollup/rollup-linux-riscv64-musl@4.57.1":
+    "@rollup/rollup-linux-riscv64-musl@4.62.0":
         optional: true
 
-    "@rollup/rollup-linux-s390x-gnu@4.57.1":
+    "@rollup/rollup-linux-s390x-gnu@4.62.0":
         optional: true
 
-    "@rollup/rollup-linux-x64-gnu@4.57.1":
+    "@rollup/rollup-linux-x64-gnu@4.62.0":
         optional: true
 
-    "@rollup/rollup-linux-x64-musl@4.57.1":
+    "@rollup/rollup-linux-x64-musl@4.62.0":
         optional: true
 
-    "@rollup/rollup-openbsd-x64@4.57.1":
+    "@rollup/rollup-openbsd-x64@4.62.0":
         optional: true
 
-    "@rollup/rollup-openharmony-arm64@4.57.1":
+    "@rollup/rollup-openharmony-arm64@4.62.0":
         optional: true
 
-    "@rollup/rollup-win32-arm64-msvc@4.57.1":
+    "@rollup/rollup-win32-arm64-msvc@4.62.0":
         optional: true
 
-    "@rollup/rollup-win32-ia32-msvc@4.57.1":
+    "@rollup/rollup-win32-ia32-msvc@4.62.0":
         optional: true
 
-    "@rollup/rollup-win32-x64-gnu@4.57.1":
+    "@rollup/rollup-win32-x64-gnu@4.62.0":
         optional: true
 
-    "@rollup/rollup-win32-x64-msvc@4.57.1":
+    "@rollup/rollup-win32-x64-msvc@4.62.0":
         optional: true
 
-    "@shikijs/core@3.22.0":
+    "@shikijs/core@4.2.0":
         dependencies:
-            "@shikijs/types": 3.22.0
+            "@shikijs/primitive": 4.2.0
+            "@shikijs/types": 4.2.0
             "@shikijs/vscode-textmate": 10.0.2
             "@types/hast": 3.0.4
             hast-util-to-html: 9.0.5
 
-    "@shikijs/engine-javascript@3.22.0":
+    "@shikijs/engine-javascript@4.2.0":
         dependencies:
-            "@shikijs/types": 3.22.0
+            "@shikijs/types": 4.2.0
             "@shikijs/vscode-textmate": 10.0.2
-            oniguruma-to-es: 4.3.4
+            oniguruma-to-es: 4.3.6
 
-    "@shikijs/engine-oniguruma@3.22.0":
+    "@shikijs/engine-oniguruma@3.23.0":
         dependencies:
-            "@shikijs/types": 3.22.0
+            "@shikijs/types": 3.23.0
             "@shikijs/vscode-textmate": 10.0.2
 
-    "@shikijs/langs@3.22.0":
+    "@shikijs/engine-oniguruma@4.2.0":
         dependencies:
-            "@shikijs/types": 3.22.0
+            "@shikijs/types": 4.2.0
+            "@shikijs/vscode-textmate": 10.0.2
 
-    "@shikijs/rehype@3.22.0":
+    "@shikijs/langs@3.23.0":
         dependencies:
-            "@shikijs/types": 3.22.0
+            "@shikijs/types": 3.23.0
+
+    "@shikijs/langs@4.2.0":
+        dependencies:
+            "@shikijs/types": 4.2.0
+
+    "@shikijs/primitive@4.2.0":
+        dependencies:
+            "@shikijs/types": 4.2.0
+            "@shikijs/vscode-textmate": 10.0.2
+            "@types/hast": 3.0.4
+
+    "@shikijs/rehype@4.2.0":
+        dependencies:
+            "@shikijs/types": 4.2.0
             "@types/hast": 3.0.4
             hast-util-to-string: 3.0.1
-            shiki: 3.22.0
+            shiki: 4.2.0
             unified: 11.0.5
             unist-util-visit: 5.1.0
 
-    "@shikijs/themes@3.22.0":
+    "@shikijs/themes@3.23.0":
         dependencies:
-            "@shikijs/types": 3.22.0
+            "@shikijs/types": 3.23.0
 
-    "@shikijs/types@3.22.0":
+    "@shikijs/themes@4.2.0":
+        dependencies:
+            "@shikijs/types": 4.2.0
+
+    "@shikijs/types@3.23.0":
+        dependencies:
+            "@shikijs/vscode-textmate": 10.0.2
+            "@types/hast": 3.0.4
+
+    "@shikijs/types@4.2.0":
         dependencies:
             "@shikijs/vscode-textmate": 10.0.2
             "@types/hast": 3.0.4
@@ -5307,43 +6098,17 @@ snapshots:
 
     "@standard-schema/spec@1.1.0": {}
 
-    "@tybys/wasm-util@0.10.1":
-        dependencies:
-            tslib: 2.8.1
-        optional: true
-
     "@tybys/wasm-util@0.10.2":
         dependencies:
             tslib: 2.8.1
         optional: true
-
-    "@types/babel__core@7.20.5":
-        dependencies:
-            "@babel/parser": 7.29.0
-            "@babel/types": 7.29.0
-            "@types/babel__generator": 7.27.0
-            "@types/babel__template": 7.4.4
-            "@types/babel__traverse": 7.28.0
-
-    "@types/babel__generator@7.27.0":
-        dependencies:
-            "@babel/types": 7.29.0
-
-    "@types/babel__template@7.4.4":
-        dependencies:
-            "@babel/parser": 7.29.0
-            "@babel/types": 7.29.0
-
-    "@types/babel__traverse@7.28.0":
-        dependencies:
-            "@babel/types": 7.29.0
 
     "@types/chai@5.2.3":
         dependencies:
             "@types/deep-eql": 4.0.2
             assertion-error: 2.0.1
 
-    "@types/debug@4.1.12":
+    "@types/debug@4.1.13":
         dependencies:
             "@types/ms": 2.1.0
 
@@ -5351,9 +6116,11 @@ snapshots:
 
     "@types/estree-jsx@1.0.5":
         dependencies:
-            "@types/estree": 1.0.8
+            "@types/estree": 1.0.9
 
     "@types/estree@1.0.8": {}
+
+    "@types/estree@1.0.9": {}
 
     "@types/hast@3.0.4":
         dependencies:
@@ -5367,19 +6134,21 @@ snapshots:
         dependencies:
             "@types/unist": 3.0.3
 
-    "@types/mdx@2.0.13": {}
+    "@types/mdx@2.0.14": {}
 
     "@types/ms@2.1.0": {}
 
-    "@types/node@25.2.3":
+    "@types/node@25.9.3":
         dependencies:
-            undici-types: 7.16.0
+            undici-types: 7.24.6
 
-    "@types/react-dom@19.2.3(@types/react@19.2.14)":
+    "@types/normalize-package-data@2.4.4": {}
+
+    "@types/react-dom@19.2.3(@types/react@19.2.17)":
         dependencies:
-            "@types/react": 19.2.14
+            "@types/react": 19.2.17
 
-    "@types/react@19.2.14":
+    "@types/react@19.2.17":
         dependencies:
             csstype: 3.2.3
 
@@ -5387,169 +6156,266 @@ snapshots:
 
     "@types/unist@3.0.3": {}
 
-    "@typescript-eslint/eslint-plugin@8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3)":
+    "@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3)":
         dependencies:
             "@eslint-community/regexpp": 4.12.2
-            "@typescript-eslint/parser": 8.55.0(eslint@9.39.2)(typescript@5.9.3)
-            "@typescript-eslint/scope-manager": 8.55.0
-            "@typescript-eslint/type-utils": 8.55.0(eslint@9.39.2)(typescript@5.9.3)
-            "@typescript-eslint/utils": 8.55.0(eslint@9.39.2)(typescript@5.9.3)
-            "@typescript-eslint/visitor-keys": 8.55.0
+            "@typescript-eslint/parser": 8.61.1(eslint@9.39.2)(typescript@5.9.3)
+            "@typescript-eslint/scope-manager": 8.61.1
+            "@typescript-eslint/type-utils": 8.61.1(eslint@9.39.2)(typescript@5.9.3)
+            "@typescript-eslint/utils": 8.61.1(eslint@9.39.2)(typescript@5.9.3)
+            "@typescript-eslint/visitor-keys": 8.61.1
             eslint: 9.39.2
             ignore: 7.0.5
             natural-compare: 1.4.0
-            ts-api-utils: 2.4.0(typescript@5.9.3)
+            ts-api-utils: 2.5.0(typescript@5.9.3)
             typescript: 5.9.3
         transitivePeerDependencies:
             - supports-color
 
-    "@typescript-eslint/parser@8.55.0(eslint@9.39.2)(typescript@5.9.3)":
+    "@typescript-eslint/parser@8.61.1(eslint@9.39.2)(typescript@5.9.3)":
         dependencies:
-            "@typescript-eslint/scope-manager": 8.55.0
-            "@typescript-eslint/types": 8.55.0
-            "@typescript-eslint/typescript-estree": 8.55.0(typescript@5.9.3)
-            "@typescript-eslint/visitor-keys": 8.55.0
+            "@typescript-eslint/scope-manager": 8.61.1
+            "@typescript-eslint/types": 8.61.1
+            "@typescript-eslint/typescript-estree": 8.61.1(typescript@5.9.3)
+            "@typescript-eslint/visitor-keys": 8.61.1
             debug: 4.4.3
             eslint: 9.39.2
             typescript: 5.9.3
         transitivePeerDependencies:
             - supports-color
 
-    "@typescript-eslint/project-service@8.55.0(typescript@5.9.3)":
+    "@typescript-eslint/project-service@8.61.1(typescript@5.9.3)":
         dependencies:
-            "@typescript-eslint/tsconfig-utils": 8.55.0(typescript@5.9.3)
-            "@typescript-eslint/types": 8.55.0
+            "@typescript-eslint/tsconfig-utils": 8.61.1(typescript@5.9.3)
+            "@typescript-eslint/types": 8.61.1
             debug: 4.4.3
             typescript: 5.9.3
         transitivePeerDependencies:
             - supports-color
 
-    "@typescript-eslint/scope-manager@8.55.0":
+    "@typescript-eslint/scope-manager@8.61.1":
         dependencies:
-            "@typescript-eslint/types": 8.55.0
-            "@typescript-eslint/visitor-keys": 8.55.0
+            "@typescript-eslint/types": 8.61.1
+            "@typescript-eslint/visitor-keys": 8.61.1
 
-    "@typescript-eslint/tsconfig-utils@8.55.0(typescript@5.9.3)":
+    "@typescript-eslint/tsconfig-utils@8.61.1(typescript@5.9.3)":
         dependencies:
             typescript: 5.9.3
 
-    "@typescript-eslint/type-utils@8.55.0(eslint@9.39.2)(typescript@5.9.3)":
+    "@typescript-eslint/type-utils@8.61.1(eslint@9.39.2)(typescript@5.9.3)":
         dependencies:
-            "@typescript-eslint/types": 8.55.0
-            "@typescript-eslint/typescript-estree": 8.55.0(typescript@5.9.3)
-            "@typescript-eslint/utils": 8.55.0(eslint@9.39.2)(typescript@5.9.3)
+            "@typescript-eslint/types": 8.61.1
+            "@typescript-eslint/typescript-estree": 8.61.1(typescript@5.9.3)
+            "@typescript-eslint/utils": 8.61.1(eslint@9.39.2)(typescript@5.9.3)
             debug: 4.4.3
             eslint: 9.39.2
-            ts-api-utils: 2.4.0(typescript@5.9.3)
+            ts-api-utils: 2.5.0(typescript@5.9.3)
             typescript: 5.9.3
         transitivePeerDependencies:
             - supports-color
 
-    "@typescript-eslint/types@8.55.0": {}
+    "@typescript-eslint/types@8.61.1": {}
 
-    "@typescript-eslint/typescript-estree@8.55.0(typescript@5.9.3)":
+    "@typescript-eslint/typescript-estree@8.61.1(typescript@5.9.3)":
         dependencies:
-            "@typescript-eslint/project-service": 8.55.0(typescript@5.9.3)
-            "@typescript-eslint/tsconfig-utils": 8.55.0(typescript@5.9.3)
-            "@typescript-eslint/types": 8.55.0
-            "@typescript-eslint/visitor-keys": 8.55.0
+            "@typescript-eslint/project-service": 8.61.1(typescript@5.9.3)
+            "@typescript-eslint/tsconfig-utils": 8.61.1(typescript@5.9.3)
+            "@typescript-eslint/types": 8.61.1
+            "@typescript-eslint/visitor-keys": 8.61.1
             debug: 4.4.3
-            minimatch: 9.0.5
-            semver: 7.7.4
-            tinyglobby: 0.2.15
-            ts-api-utils: 2.4.0(typescript@5.9.3)
+            minimatch: 10.2.5
+            semver: 7.8.4
+            tinyglobby: 0.2.17
+            ts-api-utils: 2.5.0(typescript@5.9.3)
             typescript: 5.9.3
         transitivePeerDependencies:
             - supports-color
 
-    "@typescript-eslint/utils@8.55.0(eslint@9.39.2)(typescript@5.9.3)":
+    "@typescript-eslint/utils@8.61.1(eslint@9.39.2)(typescript@5.9.3)":
         dependencies:
             "@eslint-community/eslint-utils": 4.9.1(eslint@9.39.2)
-            "@typescript-eslint/scope-manager": 8.55.0
-            "@typescript-eslint/types": 8.55.0
-            "@typescript-eslint/typescript-estree": 8.55.0(typescript@5.9.3)
+            "@typescript-eslint/scope-manager": 8.61.1
+            "@typescript-eslint/types": 8.61.1
+            "@typescript-eslint/typescript-estree": 8.61.1(typescript@5.9.3)
             eslint: 9.39.2
             typescript: 5.9.3
         transitivePeerDependencies:
             - supports-color
 
-    "@typescript-eslint/visitor-keys@8.55.0":
+    "@typescript-eslint/visitor-keys@8.61.1":
         dependencies:
-            "@typescript-eslint/types": 8.55.0
-            eslint-visitor-keys: 4.2.1
+            "@typescript-eslint/types": 8.61.1
+            eslint-visitor-keys: 5.0.1
 
-    "@ungap/structured-clone@1.3.0": {}
+    "@ungap/structured-clone@1.3.1": {}
 
-    "@vitejs/plugin-react@5.1.4(vite@8.0.0-beta.13(@types/node@25.2.3)(esbuild@0.27.3)(tsx@4.21.0)(yaml@2.8.2))":
+    "@vanilla-extract/babel-plugin-debug-ids@1.2.2":
         dependencies:
-            "@babel/core": 7.29.0
-            "@babel/plugin-transform-react-jsx-self": 7.27.1(@babel/core@7.29.0)
-            "@babel/plugin-transform-react-jsx-source": 7.27.1(@babel/core@7.29.0)
-            "@rolldown/pluginutils": 1.0.0-rc.3
-            "@types/babel__core": 7.20.5
-            react-refresh: 0.18.0
-            vite: 8.0.0-beta.13(@types/node@25.2.3)(esbuild@0.27.3)(tsx@4.21.0)(yaml@2.8.2)
+            "@babel/core": 7.29.7
         transitivePeerDependencies:
             - supports-color
 
-    "@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@25.2.3)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))":
+    "@vanilla-extract/compiler@0.7.0(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)":
+        dependencies:
+            "@vanilla-extract/css": 1.20.1
+            "@vanilla-extract/integration": 8.0.10
+            vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
+            vite-node: 6.0.0(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
+        transitivePeerDependencies:
+            - "@types/node"
+            - "@vitejs/devtools"
+            - babel-plugin-macros
+            - esbuild
+            - jiti
+            - less
+            - sass
+            - sass-embedded
+            - stylus
+            - sugarss
+            - supports-color
+            - terser
+            - tsx
+            - yaml
+
+    "@vanilla-extract/css@1.20.1":
+        dependencies:
+            "@emotion/hash": 0.9.2
+            "@vanilla-extract/private": 1.0.9
+            css-what: 6.2.2
+            csstype: 3.2.3
+            dedent: 1.7.2
+            deep-object-diff: 1.1.9
+            deepmerge: 4.3.1
+            lru-cache: 10.4.3
+            media-query-parser: 2.0.2
+            modern-ahocorasick: 1.1.0
+            picocolors: 1.1.1
+        transitivePeerDependencies:
+            - babel-plugin-macros
+
+    "@vanilla-extract/esbuild-plugin@2.3.22(esbuild@0.28.1)":
+        dependencies:
+            "@vanilla-extract/integration": 8.0.10
+        optionalDependencies:
+            esbuild: 0.28.1
+        transitivePeerDependencies:
+            - babel-plugin-macros
+            - supports-color
+
+    "@vanilla-extract/integration@8.0.10":
+        dependencies:
+            "@babel/core": 7.29.7
+            "@babel/plugin-syntax-typescript": 7.29.7(@babel/core@7.29.7)
+            "@vanilla-extract/babel-plugin-debug-ids": 1.2.2
+            "@vanilla-extract/css": 1.20.1
+            dedent: 1.7.2
+            esbuild: 0.28.1
+            eval: 0.1.8
+            find-up: 5.0.0
+            javascript-stringify: 2.1.0
+            mlly: 1.8.2
+        transitivePeerDependencies:
+            - babel-plugin-macros
+            - supports-color
+
+    "@vanilla-extract/private@1.0.9": {}
+
+    "@vanilla-extract/recipes@0.5.7(@vanilla-extract/css@1.20.1)":
+        dependencies:
+            "@vanilla-extract/css": 1.20.1
+
+    "@vanilla-extract/vite-plugin@5.2.2(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.2))(yaml@2.9.0)":
+        dependencies:
+            "@vanilla-extract/compiler": 0.7.0(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
+            "@vanilla-extract/integration": 8.0.10
+            vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.2)
+        transitivePeerDependencies:
+            - "@types/node"
+            - "@vitejs/devtools"
+            - babel-plugin-macros
+            - esbuild
+            - jiti
+            - less
+            - sass
+            - sass-embedded
+            - stylus
+            - sugarss
+            - supports-color
+            - terser
+            - tsx
+            - yaml
+
+    "@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.2))":
+        dependencies:
+            "@rolldown/pluginutils": 1.0.1
+            vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.2)
+
+    "@vitest/coverage-v8@4.1.9(vitest@4.1.9)":
         dependencies:
             "@bcoe/v8-coverage": 1.0.2
-            "@vitest/utils": 4.0.18
-            ast-v8-to-istanbul: 0.3.11
+            "@vitest/utils": 4.1.9
+            ast-v8-to-istanbul: 1.0.4
             istanbul-lib-coverage: 3.2.2
             istanbul-lib-report: 3.0.1
             istanbul-reports: 3.2.0
-            magicast: 0.5.2
-            obug: 2.1.1
-            std-env: 3.10.0
-            tinyrainbow: 3.0.3
-            vitest: 4.0.18(@types/node@25.2.3)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+            magicast: 0.5.3
+            obug: 2.1.3
+            std-env: 4.1.0
+            tinyrainbow: 3.1.0
+            vitest: 4.1.9(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))
 
-    "@vitest/expect@4.0.18":
+    "@vitest/expect@4.1.9":
         dependencies:
             "@standard-schema/spec": 1.1.0
             "@types/chai": 5.2.3
-            "@vitest/spy": 4.0.18
-            "@vitest/utils": 4.0.18
+            "@vitest/spy": 4.1.9
+            "@vitest/utils": 4.1.9
             chai: 6.2.2
-            tinyrainbow: 3.0.3
+            tinyrainbow: 3.1.0
 
-    "@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.2.3)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))":
+    "@vitest/mocker@4.1.9(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))":
         dependencies:
-            "@vitest/spy": 4.0.18
+            "@vitest/spy": 4.1.9
             estree-walker: 3.0.3
             magic-string: 0.30.21
         optionalDependencies:
-            vite: 7.3.1(@types/node@25.2.3)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+            vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
 
-    "@vitest/pretty-format@4.0.18":
+    "@vitest/pretty-format@4.1.9":
         dependencies:
-            tinyrainbow: 3.0.3
+            tinyrainbow: 3.1.0
 
-    "@vitest/runner@4.0.18":
+    "@vitest/runner@4.1.9":
         dependencies:
-            "@vitest/utils": 4.0.18
+            "@vitest/utils": 4.1.9
             pathe: 2.0.3
 
-    "@vitest/snapshot@4.0.18":
+    "@vitest/snapshot@4.1.9":
         dependencies:
-            "@vitest/pretty-format": 4.0.18
+            "@vitest/pretty-format": 4.1.9
+            "@vitest/utils": 4.1.9
             magic-string: 0.30.21
             pathe: 2.0.3
 
-    "@vitest/spy@4.0.18": {}
+    "@vitest/spy@4.1.9": {}
 
-    "@vitest/utils@4.0.18":
+    "@vitest/utils@4.1.9":
         dependencies:
-            "@vitest/pretty-format": 4.0.18
-            tinyrainbow: 3.0.3
+            "@vitest/pretty-format": 4.1.9
+            convert-source-map: 2.0.0
+            tinyrainbow: 3.1.0
 
     acorn-jsx@5.3.2(acorn@8.15.0):
         dependencies:
             acorn: 8.15.0
 
+    acorn-jsx@5.3.2(acorn@8.17.0):
+        dependencies:
+            acorn: 8.17.0
+
     acorn@8.15.0: {}
+
+    acorn@8.17.0: {}
 
     ajv@6.12.6:
         dependencies:
@@ -5572,40 +6438,48 @@ snapshots:
 
     ansis@4.3.1: {}
 
-    ardo@2.7.0(@types/node@25.2.3)(lightningcss@1.31.1)(lucide-react@0.564.0(react@19.2.4))(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.0-beta.13(@types/node@25.2.3)(esbuild@0.27.3)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2):
+    ardo@3.5.0(@types/node@25.9.3)(esbuild@0.28.1)(lightningcss@1.32.0)(lucide-react@1.20.0(react@19.2.7))(rollup@4.62.0)(tsx@4.22.4)(typescript@5.9.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.2))(yaml@2.9.0):
         dependencies:
-            "@mdx-js/rollup": 3.1.1(rollup@4.57.1)
-            "@react-router/dev": 7.13.0(@types/node@25.2.3)(lightningcss@1.31.1)(react-router@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.0-beta.13(@types/node@25.2.3)(esbuild@0.27.3)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)
-            "@shikijs/rehype": 3.22.0
-            "@vitejs/plugin-react": 5.1.4(vite@8.0.0-beta.13(@types/node@25.2.3)(esbuild@0.27.3)(tsx@4.21.0)(yaml@2.8.2))
+            "@mdx-js/rollup": 3.1.1(rollup@4.62.0)
+            "@react-router/dev": 7.18.0(@types/node@25.9.3)(lightningcss@1.32.0)(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(tsx@4.22.4)(typescript@5.9.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.2))(yaml@2.9.0)
+            "@resvg/resvg-js": 2.6.2
+            "@shikijs/rehype": 4.2.0
+            "@vanilla-extract/css": 1.20.1
+            "@vanilla-extract/esbuild-plugin": 2.3.22(esbuild@0.28.1)
+            "@vanilla-extract/recipes": 0.5.7(@vanilla-extract/css@1.20.1)
+            "@vanilla-extract/vite-plugin": 5.2.2(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.2))(yaml@2.9.0)
+            "@vitejs/plugin-react": 6.0.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.2))
             gray-matter: 4.0.3
             hast-util-to-jsx-runtime: 2.3.6
-            mdast-util-directive: 3.1.0
             minisearch: 7.2.0
-            react: 19.2.4
-            react-dom: 19.2.4(react@19.2.4)
-            react-router: 7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+            react: 19.2.7
+            react-dom: 19.2.7(react@19.2.7)
+            react-router: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+            read-package-up: 12.0.0
             rehype-parse: 9.0.1
             rehype-stringify: 10.0.1
-            remark-directive: 4.0.0
             remark-frontmatter: 5.0.0
             remark-gfm: 4.0.1
             remark-mdx-frontmatter: 5.2.0
             remark-parse: 11.0.0
             remark-rehype: 11.1.2
-            shiki: 3.22.0
-            tailwindcss: 4.1.18
-            typedoc: 0.28.16(typescript@5.9.3)
+            shiki: 4.2.0
+            tailwindcss: 4.3.1
+            typedoc: 0.28.19(typescript@5.9.3)
             unified: 11.0.5
             unist-util-visit: 5.1.0
-            vite: 8.0.0-beta.13(@types/node@25.2.3)(esbuild@0.27.3)(tsx@4.21.0)(yaml@2.8.2)
+            vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.2)
         optionalDependencies:
-            lucide-react: 0.564.0(react@19.2.4)
+            lucide-react: 1.20.0(react@19.2.7)
         transitivePeerDependencies:
             - "@react-router/serve"
+            - "@rolldown/plugin-babel"
             - "@types/node"
+            - "@vitejs/devtools"
             - "@vitejs/plugin-rsc"
             - babel-plugin-macros
+            - babel-plugin-react-compiler
+            - esbuild
             - jiti
             - less
             - lightningcss
@@ -5632,13 +6506,13 @@ snapshots:
 
     assertion-error@2.0.1: {}
 
-    ast-kit@3.0.0-beta.1:
+    ast-kit@3.0.0:
         dependencies:
-            "@babel/parser": 8.0.0-rc.6
+            "@babel/parser": 8.0.0
             estree-walker: 3.0.3
             pathe: 2.0.3
 
-    ast-v8-to-istanbul@0.3.11:
+    ast-v8-to-istanbul@1.0.4:
         dependencies:
             "@jridgewell/trace-mapping": 0.3.31
             estree-walker: 3.0.3
@@ -5648,10 +6522,10 @@ snapshots:
 
     babel-dead-code-elimination@1.0.12:
         dependencies:
-            "@babel/core": 7.29.0
-            "@babel/parser": 7.29.0
-            "@babel/traverse": 7.29.0
-            "@babel/types": 7.29.0
+            "@babel/core": 7.29.7
+            "@babel/parser": 7.29.7
+            "@babel/traverse": 7.29.7
+            "@babel/types": 7.29.7
         transitivePeerDependencies:
             - supports-color
 
@@ -5659,7 +6533,9 @@ snapshots:
 
     balanced-match@1.0.2: {}
 
-    baseline-browser-mapping@2.9.19: {}
+    balanced-match@4.0.4: {}
+
+    baseline-browser-mapping@2.10.37: {}
 
     birpc@4.0.0: {}
 
@@ -5668,21 +6544,21 @@ snapshots:
             balanced-match: 1.0.2
             concat-map: 0.0.1
 
-    brace-expansion@2.0.2:
+    brace-expansion@5.0.6:
         dependencies:
-            balanced-match: 1.0.2
+            balanced-match: 4.0.4
 
     braces@3.0.3:
         dependencies:
             fill-range: 7.1.1
 
-    browserslist@4.28.1:
+    browserslist@4.28.2:
         dependencies:
-            baseline-browser-mapping: 2.9.19
-            caniuse-lite: 1.0.30001769
-            electron-to-chromium: 1.5.286
-            node-releases: 2.0.27
-            update-browserslist-db: 1.2.3(browserslist@4.28.1)
+            baseline-browser-mapping: 2.10.37
+            caniuse-lite: 1.0.30001799
+            electron-to-chromium: 1.5.374
+            node-releases: 2.0.47
+            update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
     cac@6.7.14: {}
 
@@ -5690,7 +6566,7 @@ snapshots:
 
     callsites@3.1.0: {}
 
-    caniuse-lite@1.0.30001769: {}
+    caniuse-lite@1.0.30001799: {}
 
     ccount@2.0.1: {}
 
@@ -5738,6 +6614,8 @@ snapshots:
 
     concat-map@0.0.1: {}
 
+    confbox@0.1.8: {}
+
     confbox@0.2.4: {}
 
     convert-source-map@2.0.0: {}
@@ -5750,6 +6628,8 @@ snapshots:
             shebang-command: 2.0.0
             which: 2.0.2
 
+    css-what@6.2.2: {}
+
     csstype@3.2.3: {}
 
     debug@4.4.3:
@@ -5760,9 +6640,13 @@ snapshots:
         dependencies:
             character-entities: 2.0.2
 
-    dedent@1.7.1: {}
+    dedent@1.7.2: {}
 
     deep-is@0.1.4: {}
+
+    deep-object-diff@1.1.9: {}
+
+    deepmerge@4.3.1: {}
 
     defu@6.1.7: {}
 
@@ -5776,7 +6660,7 @@ snapshots:
 
     dts-resolver@3.0.0: {}
 
-    electron-to-chromium@1.5.286: {}
+    electron-to-chromium@1.5.374: {}
 
     emoji-regex@10.6.0: {}
 
@@ -5790,6 +6674,8 @@ snapshots:
 
     es-module-lexer@1.7.0: {}
 
+    es-module-lexer@2.1.0: {}
+
     esast-util-from-estree@2.0.0:
         dependencies:
             "@types/estree-jsx": 1.0.5
@@ -5800,38 +6686,67 @@ snapshots:
     esast-util-from-js@2.0.1:
         dependencies:
             "@types/estree-jsx": 1.0.5
-            acorn: 8.15.0
+            acorn: 8.17.0
             esast-util-from-estree: 2.0.0
             vfile-message: 4.0.3
 
-    esbuild@0.27.3:
+    esbuild@0.27.7:
         optionalDependencies:
-            "@esbuild/aix-ppc64": 0.27.3
-            "@esbuild/android-arm": 0.27.3
-            "@esbuild/android-arm64": 0.27.3
-            "@esbuild/android-x64": 0.27.3
-            "@esbuild/darwin-arm64": 0.27.3
-            "@esbuild/darwin-x64": 0.27.3
-            "@esbuild/freebsd-arm64": 0.27.3
-            "@esbuild/freebsd-x64": 0.27.3
-            "@esbuild/linux-arm": 0.27.3
-            "@esbuild/linux-arm64": 0.27.3
-            "@esbuild/linux-ia32": 0.27.3
-            "@esbuild/linux-loong64": 0.27.3
-            "@esbuild/linux-mips64el": 0.27.3
-            "@esbuild/linux-ppc64": 0.27.3
-            "@esbuild/linux-riscv64": 0.27.3
-            "@esbuild/linux-s390x": 0.27.3
-            "@esbuild/linux-x64": 0.27.3
-            "@esbuild/netbsd-arm64": 0.27.3
-            "@esbuild/netbsd-x64": 0.27.3
-            "@esbuild/openbsd-arm64": 0.27.3
-            "@esbuild/openbsd-x64": 0.27.3
-            "@esbuild/openharmony-arm64": 0.27.3
-            "@esbuild/sunos-x64": 0.27.3
-            "@esbuild/win32-arm64": 0.27.3
-            "@esbuild/win32-ia32": 0.27.3
-            "@esbuild/win32-x64": 0.27.3
+            "@esbuild/aix-ppc64": 0.27.7
+            "@esbuild/android-arm": 0.27.7
+            "@esbuild/android-arm64": 0.27.7
+            "@esbuild/android-x64": 0.27.7
+            "@esbuild/darwin-arm64": 0.27.7
+            "@esbuild/darwin-x64": 0.27.7
+            "@esbuild/freebsd-arm64": 0.27.7
+            "@esbuild/freebsd-x64": 0.27.7
+            "@esbuild/linux-arm": 0.27.7
+            "@esbuild/linux-arm64": 0.27.7
+            "@esbuild/linux-ia32": 0.27.7
+            "@esbuild/linux-loong64": 0.27.7
+            "@esbuild/linux-mips64el": 0.27.7
+            "@esbuild/linux-ppc64": 0.27.7
+            "@esbuild/linux-riscv64": 0.27.7
+            "@esbuild/linux-s390x": 0.27.7
+            "@esbuild/linux-x64": 0.27.7
+            "@esbuild/netbsd-arm64": 0.27.7
+            "@esbuild/netbsd-x64": 0.27.7
+            "@esbuild/openbsd-arm64": 0.27.7
+            "@esbuild/openbsd-x64": 0.27.7
+            "@esbuild/openharmony-arm64": 0.27.7
+            "@esbuild/sunos-x64": 0.27.7
+            "@esbuild/win32-arm64": 0.27.7
+            "@esbuild/win32-ia32": 0.27.7
+            "@esbuild/win32-x64": 0.27.7
+
+    esbuild@0.28.1:
+        optionalDependencies:
+            "@esbuild/aix-ppc64": 0.28.1
+            "@esbuild/android-arm": 0.28.1
+            "@esbuild/android-arm64": 0.28.1
+            "@esbuild/android-x64": 0.28.1
+            "@esbuild/darwin-arm64": 0.28.1
+            "@esbuild/darwin-x64": 0.28.1
+            "@esbuild/freebsd-arm64": 0.28.1
+            "@esbuild/freebsd-x64": 0.28.1
+            "@esbuild/linux-arm": 0.28.1
+            "@esbuild/linux-arm64": 0.28.1
+            "@esbuild/linux-ia32": 0.28.1
+            "@esbuild/linux-loong64": 0.28.1
+            "@esbuild/linux-mips64el": 0.28.1
+            "@esbuild/linux-ppc64": 0.28.1
+            "@esbuild/linux-riscv64": 0.28.1
+            "@esbuild/linux-s390x": 0.28.1
+            "@esbuild/linux-x64": 0.28.1
+            "@esbuild/netbsd-arm64": 0.28.1
+            "@esbuild/netbsd-x64": 0.28.1
+            "@esbuild/openbsd-arm64": 0.28.1
+            "@esbuild/openbsd-x64": 0.28.1
+            "@esbuild/openharmony-arm64": 0.28.1
+            "@esbuild/sunos-x64": 0.28.1
+            "@esbuild/win32-arm64": 0.28.1
+            "@esbuild/win32-ia32": 0.28.1
+            "@esbuild/win32-x64": 0.28.1
 
     escalade@3.2.0: {}
 
@@ -5851,6 +6766,8 @@ snapshots:
     eslint-visitor-keys@3.4.3: {}
 
     eslint-visitor-keys@4.2.1: {}
+
+    eslint-visitor-keys@5.0.1: {}
 
     eslint@9.39.2:
         dependencies:
@@ -5911,7 +6828,7 @@ snapshots:
 
     estree-util-attach-comments@3.0.0:
         dependencies:
-            "@types/estree": 1.0.8
+            "@types/estree": 1.0.9
 
     estree-util-build-jsx@3.0.1:
         dependencies:
@@ -5924,7 +6841,7 @@ snapshots:
 
     estree-util-scope@1.0.0:
         dependencies:
-            "@types/estree": 1.0.8
+            "@types/estree": 1.0.9
             devlop: 1.1.0
 
     estree-util-to-js@2.0.0:
@@ -5935,7 +6852,7 @@ snapshots:
 
     estree-util-value-to-estree@3.5.0:
         dependencies:
-            "@types/estree": 1.0.8
+            "@types/estree": 1.0.9
 
     estree-util-visit@2.0.0:
         dependencies:
@@ -5946,9 +6863,14 @@ snapshots:
 
     estree-walker@3.0.3:
         dependencies:
-            "@types/estree": 1.0.8
+            "@types/estree": 1.0.9
 
     esutils@2.0.3: {}
+
+    eval@0.1.8:
+        dependencies:
+            "@types/node": 25.9.3
+            require-like: 0.1.2
 
     eventemitter3@5.0.4: {}
 
@@ -5974,10 +6896,6 @@ snapshots:
         dependencies:
             format: 0.2.2
 
-    fdir@6.5.0(picomatch@4.0.3):
-        optionalDependencies:
-            picomatch: 4.0.3
-
     fdir@6.5.0(picomatch@4.0.4):
         optionalDependencies:
             picomatch: 4.0.4
@@ -5989,6 +6907,8 @@ snapshots:
     fill-range@7.1.1:
         dependencies:
             to-regex-range: 5.0.1
+
+    find-up-simple@1.0.1: {}
 
     find-up@5.0.0:
         dependencies:
@@ -6010,10 +6930,6 @@ snapshots:
     gensync@1.0.0-beta.2: {}
 
     get-east-asian-width@1.4.0: {}
-
-    get-tsconfig@4.13.6:
-        dependencies:
-            resolve-pkg-maps: 1.0.0
 
     get-tsconfig@5.0.0-beta.5:
         dependencies:
@@ -6049,7 +6965,7 @@ snapshots:
             "@types/unist": 3.0.3
             devlop: 1.1.0
             hastscript: 9.0.1
-            property-information: 7.1.0
+            property-information: 7.2.0
             vfile: 6.0.3
             vfile-location: 5.0.3
             web-namespaces: 2.0.1
@@ -6060,7 +6976,7 @@ snapshots:
 
     hast-util-to-estree@3.1.3:
         dependencies:
-            "@types/estree": 1.0.8
+            "@types/estree": 1.0.9
             "@types/estree-jsx": 1.0.5
             "@types/hast": 3.0.4
             comma-separated-tokens: 2.0.3
@@ -6071,7 +6987,7 @@ snapshots:
             mdast-util-mdx-expression: 2.0.1
             mdast-util-mdx-jsx: 3.2.0
             mdast-util-mdxjs-esm: 2.0.1
-            property-information: 7.1.0
+            property-information: 7.2.0
             space-separated-tokens: 2.0.2
             style-to-js: 1.1.21
             unist-util-position: 5.0.0
@@ -6088,14 +7004,14 @@ snapshots:
             hast-util-whitespace: 3.0.0
             html-void-elements: 3.0.0
             mdast-util-to-hast: 13.2.1
-            property-information: 7.1.0
+            property-information: 7.2.0
             space-separated-tokens: 2.0.2
             stringify-entities: 4.0.4
             zwitch: 2.0.4
 
     hast-util-to-jsx-runtime@2.3.6:
         dependencies:
-            "@types/estree": 1.0.8
+            "@types/estree": 1.0.9
             "@types/hast": 3.0.4
             "@types/unist": 3.0.3
             comma-separated-tokens: 2.0.3
@@ -6105,7 +7021,7 @@ snapshots:
             mdast-util-mdx-expression: 2.0.1
             mdast-util-mdx-jsx: 3.2.0
             mdast-util-mdxjs-esm: 2.0.1
-            property-information: 7.1.0
+            property-information: 7.2.0
             space-separated-tokens: 2.0.2
             style-to-js: 1.1.21
             unist-util-position: 5.0.0
@@ -6126,10 +7042,14 @@ snapshots:
             "@types/hast": 3.0.4
             comma-separated-tokens: 2.0.3
             hast-util-parse-selector: 4.0.0
-            property-information: 7.1.0
+            property-information: 7.2.0
             space-separated-tokens: 2.0.2
 
     hookable@6.1.1: {}
+
+    hosted-git-info@9.0.3:
+        dependencies:
+            lru-cache: 11.5.1
 
     html-escaper@2.0.2: {}
 
@@ -6149,6 +7069,8 @@ snapshots:
     import-without-cache@0.4.0: {}
 
     imurmurhash@0.1.4: {}
+
+    index-to-position@1.2.0: {}
 
     inline-style-parser@0.2.7: {}
 
@@ -6179,7 +7101,7 @@ snapshots:
 
     is-plain-obj@4.1.0: {}
 
-    isbot@5.1.35: {}
+    isbot@5.1.43: {}
 
     isexe@2.0.0: {}
 
@@ -6196,6 +7118,8 @@ snapshots:
             html-escaper: 2.0.2
             istanbul-lib-report: 3.0.1
 
+    javascript-stringify@2.1.0: {}
+
     js-tokens@10.0.0: {}
 
     js-tokens@4.0.0: {}
@@ -6210,6 +7134,8 @@ snapshots:
             argparse: 2.0.1
 
     jsesc@3.0.2: {}
+
+    jsesc@3.1.0: {}
 
     json-buffer@3.0.1: {}
 
@@ -6230,56 +7156,56 @@ snapshots:
             prelude-ls: 1.2.1
             type-check: 0.4.0
 
-    lightningcss-android-arm64@1.31.1:
+    lightningcss-android-arm64@1.32.0:
         optional: true
 
-    lightningcss-darwin-arm64@1.31.1:
+    lightningcss-darwin-arm64@1.32.0:
         optional: true
 
-    lightningcss-darwin-x64@1.31.1:
+    lightningcss-darwin-x64@1.32.0:
         optional: true
 
-    lightningcss-freebsd-x64@1.31.1:
+    lightningcss-freebsd-x64@1.32.0:
         optional: true
 
-    lightningcss-linux-arm-gnueabihf@1.31.1:
+    lightningcss-linux-arm-gnueabihf@1.32.0:
         optional: true
 
-    lightningcss-linux-arm64-gnu@1.31.1:
+    lightningcss-linux-arm64-gnu@1.32.0:
         optional: true
 
-    lightningcss-linux-arm64-musl@1.31.1:
+    lightningcss-linux-arm64-musl@1.32.0:
         optional: true
 
-    lightningcss-linux-x64-gnu@1.31.1:
+    lightningcss-linux-x64-gnu@1.32.0:
         optional: true
 
-    lightningcss-linux-x64-musl@1.31.1:
+    lightningcss-linux-x64-musl@1.32.0:
         optional: true
 
-    lightningcss-win32-arm64-msvc@1.31.1:
+    lightningcss-win32-arm64-msvc@1.32.0:
         optional: true
 
-    lightningcss-win32-x64-msvc@1.31.1:
+    lightningcss-win32-x64-msvc@1.32.0:
         optional: true
 
-    lightningcss@1.31.1:
+    lightningcss@1.32.0:
         dependencies:
             detect-libc: 2.1.2
         optionalDependencies:
-            lightningcss-android-arm64: 1.31.1
-            lightningcss-darwin-arm64: 1.31.1
-            lightningcss-darwin-x64: 1.31.1
-            lightningcss-freebsd-x64: 1.31.1
-            lightningcss-linux-arm-gnueabihf: 1.31.1
-            lightningcss-linux-arm64-gnu: 1.31.1
-            lightningcss-linux-arm64-musl: 1.31.1
-            lightningcss-linux-x64-gnu: 1.31.1
-            lightningcss-linux-x64-musl: 1.31.1
-            lightningcss-win32-arm64-msvc: 1.31.1
-            lightningcss-win32-x64-msvc: 1.31.1
+            lightningcss-android-arm64: 1.32.0
+            lightningcss-darwin-arm64: 1.32.0
+            lightningcss-darwin-x64: 1.32.0
+            lightningcss-freebsd-x64: 1.32.0
+            lightningcss-linux-arm-gnueabihf: 1.32.0
+            lightningcss-linux-arm64-gnu: 1.32.0
+            lightningcss-linux-arm64-musl: 1.32.0
+            lightningcss-linux-x64-gnu: 1.32.0
+            lightningcss-linux-x64-musl: 1.32.0
+            lightningcss-win32-arm64-msvc: 1.32.0
+            lightningcss-win32-x64-msvc: 1.32.0
 
-    linkify-it@5.0.0:
+    linkify-it@5.0.1:
         dependencies:
             uc.micro: 2.1.0
 
@@ -6308,7 +7234,7 @@ snapshots:
 
     lodash.merge@4.6.2: {}
 
-    lodash@4.17.23: {}
+    lodash@4.18.1: {}
 
     log-update@6.1.0:
         dependencies:
@@ -6320,13 +7246,17 @@ snapshots:
 
     longest-streak@3.1.0: {}
 
+    lru-cache@10.4.3: {}
+
+    lru-cache@11.5.1: {}
+
     lru-cache@5.1.1:
         dependencies:
             yallist: 3.1.1
 
-    lucide-react@0.564.0(react@19.2.4):
+    lucide-react@1.20.0(react@19.2.7):
         dependencies:
-            react: 19.2.4
+            react: 19.2.7
 
     lunr@2.3.9: {}
 
@@ -6334,42 +7264,28 @@ snapshots:
         dependencies:
             "@jridgewell/sourcemap-codec": 1.5.5
 
-    magicast@0.5.2:
+    magicast@0.5.3:
         dependencies:
-            "@babel/parser": 7.29.0
-            "@babel/types": 7.29.0
+            "@babel/parser": 7.29.7
+            "@babel/types": 7.29.7
             source-map-js: 1.2.1
 
     make-dir@4.0.0:
         dependencies:
-            semver: 7.7.4
+            semver: 7.8.4
 
     markdown-extensions@2.0.0: {}
 
-    markdown-it@14.1.1:
+    markdown-it@14.2.0:
         dependencies:
             argparse: 2.0.1
             entities: 4.5.0
-            linkify-it: 5.0.0
+            linkify-it: 5.0.1
             mdurl: 2.0.0
             punycode.js: 2.3.1
             uc.micro: 2.1.0
 
     markdown-table@3.0.4: {}
-
-    mdast-util-directive@3.1.0:
-        dependencies:
-            "@types/mdast": 4.0.4
-            "@types/unist": 3.0.3
-            ccount: 2.0.1
-            devlop: 1.1.0
-            mdast-util-from-markdown: 2.0.2
-            mdast-util-to-markdown: 2.1.2
-            parse-entities: 4.0.2
-            stringify-entities: 4.0.4
-            unist-util-visit-parents: 6.0.2
-        transitivePeerDependencies:
-            - supports-color
 
     mdast-util-find-and-replace@3.0.2:
         dependencies:
@@ -6378,7 +7294,7 @@ snapshots:
             unist-util-is: 6.0.1
             unist-util-visit-parents: 6.0.2
 
-    mdast-util-from-markdown@2.0.2:
+    mdast-util-from-markdown@2.0.3:
         dependencies:
             "@types/mdast": 4.0.4
             "@types/unist": 3.0.3
@@ -6400,7 +7316,7 @@ snapshots:
             "@types/mdast": 4.0.4
             devlop: 1.1.0
             escape-string-regexp: 5.0.0
-            mdast-util-from-markdown: 2.0.2
+            mdast-util-from-markdown: 2.0.3
             mdast-util-to-markdown: 2.1.2
             micromark-extension-frontmatter: 2.0.0
         transitivePeerDependencies:
@@ -6418,7 +7334,7 @@ snapshots:
         dependencies:
             "@types/mdast": 4.0.4
             devlop: 1.1.0
-            mdast-util-from-markdown: 2.0.2
+            mdast-util-from-markdown: 2.0.3
             mdast-util-to-markdown: 2.1.2
             micromark-util-normalize-identifier: 2.0.1
         transitivePeerDependencies:
@@ -6427,7 +7343,7 @@ snapshots:
     mdast-util-gfm-strikethrough@2.0.0:
         dependencies:
             "@types/mdast": 4.0.4
-            mdast-util-from-markdown: 2.0.2
+            mdast-util-from-markdown: 2.0.3
             mdast-util-to-markdown: 2.1.2
         transitivePeerDependencies:
             - supports-color
@@ -6437,7 +7353,7 @@ snapshots:
             "@types/mdast": 4.0.4
             devlop: 1.1.0
             markdown-table: 3.0.4
-            mdast-util-from-markdown: 2.0.2
+            mdast-util-from-markdown: 2.0.3
             mdast-util-to-markdown: 2.1.2
         transitivePeerDependencies:
             - supports-color
@@ -6446,14 +7362,14 @@ snapshots:
         dependencies:
             "@types/mdast": 4.0.4
             devlop: 1.1.0
-            mdast-util-from-markdown: 2.0.2
+            mdast-util-from-markdown: 2.0.3
             mdast-util-to-markdown: 2.1.2
         transitivePeerDependencies:
             - supports-color
 
     mdast-util-gfm@3.1.0:
         dependencies:
-            mdast-util-from-markdown: 2.0.2
+            mdast-util-from-markdown: 2.0.3
             mdast-util-gfm-autolink-literal: 2.0.1
             mdast-util-gfm-footnote: 2.1.0
             mdast-util-gfm-strikethrough: 2.0.0
@@ -6469,7 +7385,7 @@ snapshots:
             "@types/hast": 3.0.4
             "@types/mdast": 4.0.4
             devlop: 1.1.0
-            mdast-util-from-markdown: 2.0.2
+            mdast-util-from-markdown: 2.0.3
             mdast-util-to-markdown: 2.1.2
         transitivePeerDependencies:
             - supports-color
@@ -6482,7 +7398,7 @@ snapshots:
             "@types/unist": 3.0.3
             ccount: 2.0.1
             devlop: 1.1.0
-            mdast-util-from-markdown: 2.0.2
+            mdast-util-from-markdown: 2.0.3
             mdast-util-to-markdown: 2.1.2
             parse-entities: 4.0.2
             stringify-entities: 4.0.4
@@ -6493,7 +7409,7 @@ snapshots:
 
     mdast-util-mdx@3.0.0:
         dependencies:
-            mdast-util-from-markdown: 2.0.2
+            mdast-util-from-markdown: 2.0.3
             mdast-util-mdx-expression: 2.0.1
             mdast-util-mdx-jsx: 3.2.0
             mdast-util-mdxjs-esm: 2.0.1
@@ -6507,7 +7423,7 @@ snapshots:
             "@types/hast": 3.0.4
             "@types/mdast": 4.0.4
             devlop: 1.1.0
-            mdast-util-from-markdown: 2.0.2
+            mdast-util-from-markdown: 2.0.3
             mdast-util-to-markdown: 2.1.2
         transitivePeerDependencies:
             - supports-color
@@ -6521,7 +7437,7 @@ snapshots:
         dependencies:
             "@types/hast": 3.0.4
             "@types/mdast": 4.0.4
-            "@ungap/structured-clone": 1.3.0
+            "@ungap/structured-clone": 1.3.1
             devlop: 1.1.0
             micromark-util-sanitize-uri: 2.0.1
             trim-lines: 3.0.1
@@ -6547,6 +7463,10 @@ snapshots:
 
     mdurl@2.0.0: {}
 
+    media-query-parser@2.0.2:
+        dependencies:
+            "@babel/runtime": 7.29.7
+
     micromark-core-commonmark@2.0.3:
         dependencies:
             decode-named-character-reference: 1.3.0
@@ -6565,16 +7485,6 @@ snapshots:
             micromark-util-subtokenize: 2.1.0
             micromark-util-symbol: 2.0.1
             micromark-util-types: 2.0.2
-
-    micromark-extension-directive@4.0.0:
-        dependencies:
-            devlop: 1.1.0
-            micromark-factory-space: 2.0.1
-            micromark-factory-whitespace: 2.0.1
-            micromark-util-character: 2.1.1
-            micromark-util-symbol: 2.0.1
-            micromark-util-types: 2.0.2
-            parse-entities: 4.0.2
 
     micromark-extension-frontmatter@2.0.0:
         dependencies:
@@ -6643,7 +7553,7 @@ snapshots:
 
     micromark-extension-mdx-expression@3.0.1:
         dependencies:
-            "@types/estree": 1.0.8
+            "@types/estree": 1.0.9
             devlop: 1.1.0
             micromark-factory-mdx-expression: 2.0.3
             micromark-factory-space: 2.0.1
@@ -6654,7 +7564,7 @@ snapshots:
 
     micromark-extension-mdx-jsx@3.0.2:
         dependencies:
-            "@types/estree": 1.0.8
+            "@types/estree": 1.0.9
             devlop: 1.1.0
             estree-util-is-identifier-name: 3.0.0
             micromark-factory-mdx-expression: 2.0.3
@@ -6671,7 +7581,7 @@ snapshots:
 
     micromark-extension-mdxjs-esm@3.0.0:
         dependencies:
-            "@types/estree": 1.0.8
+            "@types/estree": 1.0.9
             devlop: 1.1.0
             micromark-core-commonmark: 2.0.3
             micromark-util-character: 2.1.1
@@ -6683,8 +7593,8 @@ snapshots:
 
     micromark-extension-mdxjs@3.0.0:
         dependencies:
-            acorn: 8.15.0
-            acorn-jsx: 5.3.2(acorn@8.15.0)
+            acorn: 8.17.0
+            acorn-jsx: 5.3.2(acorn@8.17.0)
             micromark-extension-mdx-expression: 3.0.1
             micromark-extension-mdx-jsx: 3.0.2
             micromark-extension-mdx-md: 2.0.0
@@ -6707,7 +7617,7 @@ snapshots:
 
     micromark-factory-mdx-expression@2.0.3:
         dependencies:
-            "@types/estree": 1.0.8
+            "@types/estree": 1.0.9
             devlop: 1.1.0
             micromark-factory-space: 2.0.1
             micromark-util-character: 2.1.1
@@ -6771,7 +7681,7 @@ snapshots:
 
     micromark-util-events-to-acorn@2.0.3:
         dependencies:
-            "@types/estree": 1.0.8
+            "@types/estree": 1.0.9
             "@types/unist": 3.0.3
             devlop: 1.1.0
             estree-util-visit: 2.0.0
@@ -6808,7 +7718,7 @@ snapshots:
 
     micromark@4.0.2:
         dependencies:
-            "@types/debug": 4.1.12
+            "@types/debug": 4.1.13
             debug: 4.4.3
             decode-named-character-reference: 1.3.0
             devlop: 1.1.0
@@ -6835,37 +7745,52 @@ snapshots:
 
     mimic-function@5.0.1: {}
 
+    minimatch@10.2.5:
+        dependencies:
+            brace-expansion: 5.0.6
+
     minimatch@3.1.2:
         dependencies:
             brace-expansion: 1.1.12
 
-    minimatch@9.0.5:
-        dependencies:
-            brace-expansion: 2.0.2
-
     minisearch@7.2.0: {}
+
+    mlly@1.8.2:
+        dependencies:
+            acorn: 8.17.0
+            pathe: 2.0.3
+            pkg-types: 1.3.1
+            ufo: 1.6.4
+
+    modern-ahocorasick@1.1.0: {}
 
     ms@2.1.3: {}
 
     nano-spawn@2.0.0: {}
 
-    nanoid@3.3.11: {}
+    nanoid@3.3.12: {}
 
     natural-compare@1.4.0: {}
 
-    node-releases@2.0.27: {}
+    node-releases@2.0.47: {}
 
-    obug@2.1.1: {}
+    normalize-package-data@8.0.0:
+        dependencies:
+            hosted-git-info: 9.0.3
+            semver: 7.8.4
+            validate-npm-package-license: 3.0.4
+
+    obug@2.1.3: {}
 
     onetime@7.0.0:
         dependencies:
             mimic-function: 5.0.1
 
-    oniguruma-parser@0.12.1: {}
+    oniguruma-parser@0.12.2: {}
 
-    oniguruma-to-es@4.3.4:
+    oniguruma-to-es@4.3.6:
         dependencies:
-            oniguruma-parser: 0.12.1
+            oniguruma-parser: 0.12.2
             regex: 6.1.0
             regex-recursion: 6.0.2
 
@@ -6902,6 +7827,12 @@ snapshots:
             is-decimal: 2.0.1
             is-hexadecimal: 2.0.1
 
+    parse-json@8.3.0:
+        dependencies:
+            "@babel/code-frame": 7.29.7
+            index-to-position: 1.2.0
+            type-fest: 4.41.0
+
     parse5@7.3.0:
         dependencies:
             entities: 6.0.1
@@ -6918,29 +7849,33 @@ snapshots:
 
     picomatch@2.3.1: {}
 
-    picomatch@4.0.3: {}
-
     picomatch@4.0.4: {}
 
     pidtree@0.6.0: {}
 
-    pkg-types@2.3.0:
+    pkg-types@1.3.1:
+        dependencies:
+            confbox: 0.1.8
+            mlly: 1.8.2
+            pathe: 2.0.3
+
+    pkg-types@2.3.1:
         dependencies:
             confbox: 0.2.4
             exsolve: 1.0.8
             pathe: 2.0.3
 
-    postcss@8.5.6:
+    postcss@8.5.15:
         dependencies:
-            nanoid: 3.3.11
+            nanoid: 3.3.12
             picocolors: 1.1.1
             source-map-js: 1.2.1
 
     prelude-ls@1.2.1: {}
 
-    prettier@3.8.1: {}
+    prettier@3.8.4: {}
 
-    property-information@7.1.0: {}
+    property-information@7.2.0: {}
 
     punycode.js@2.3.1: {}
 
@@ -6948,37 +7883,49 @@ snapshots:
 
     quansync@1.0.0: {}
 
-    react-dom@19.2.4(react@19.2.4):
+    react-dom@19.2.7(react@19.2.7):
         dependencies:
-            react: 19.2.4
+            react: 19.2.7
             scheduler: 0.27.0
 
     react-refresh@0.14.2: {}
 
-    react-refresh@0.18.0: {}
-
-    react-router@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
         dependencies:
             cookie: 1.1.1
-            react: 19.2.4
+            react: 19.2.7
             set-cookie-parser: 2.7.2
         optionalDependencies:
-            react-dom: 19.2.4(react@19.2.4)
+            react-dom: 19.2.7(react@19.2.7)
 
-    react@19.2.4: {}
+    react@19.2.7: {}
+
+    read-package-up@12.0.0:
+        dependencies:
+            find-up-simple: 1.0.1
+            read-pkg: 10.1.0
+            type-fest: 5.7.0
+
+    read-pkg@10.1.0:
+        dependencies:
+            "@types/normalize-package-data": 2.4.4
+            normalize-package-data: 8.0.0
+            parse-json: 8.3.0
+            type-fest: 5.7.0
+            unicorn-magic: 0.4.0
 
     readdirp@4.1.2: {}
 
     recma-build-jsx@1.0.0:
         dependencies:
-            "@types/estree": 1.0.8
+            "@types/estree": 1.0.9
             estree-util-build-jsx: 3.0.1
             vfile: 6.0.3
 
-    recma-jsx@1.0.1(acorn@8.15.0):
+    recma-jsx@1.0.1(acorn@8.17.0):
         dependencies:
-            acorn: 8.15.0
-            acorn-jsx: 5.3.2(acorn@8.15.0)
+            acorn: 8.17.0
+            acorn-jsx: 5.3.2(acorn@8.17.0)
             estree-util-to-js: 2.0.0
             recma-parse: 1.0.0
             recma-stringify: 1.0.0
@@ -6986,14 +7933,14 @@ snapshots:
 
     recma-parse@1.0.0:
         dependencies:
-            "@types/estree": 1.0.8
+            "@types/estree": 1.0.9
             esast-util-from-js: 2.0.1
             unified: 11.0.5
             vfile: 6.0.3
 
     recma-stringify@1.0.0:
         dependencies:
-            "@types/estree": 1.0.8
+            "@types/estree": 1.0.9
             estree-util-to-js: 2.0.0
             unified: 11.0.5
             vfile: 6.0.3
@@ -7016,7 +7963,7 @@ snapshots:
 
     rehype-recma@1.0.0:
         dependencies:
-            "@types/estree": 1.0.8
+            "@types/estree": 1.0.9
             "@types/hast": 3.0.4
             hast-util-to-estree: 3.1.3
         transitivePeerDependencies:
@@ -7027,15 +7974,6 @@ snapshots:
             "@types/hast": 3.0.4
             hast-util-to-html: 9.0.5
             unified: 11.0.5
-
-    remark-directive@4.0.0:
-        dependencies:
-            "@types/mdast": 4.0.4
-            mdast-util-directive: 3.1.0
-            micromark-extension-directive: 4.0.0
-            unified: 11.0.5
-        transitivePeerDependencies:
-            - supports-color
 
     remark-frontmatter@5.0.0:
         dependencies:
@@ -7064,7 +8002,7 @@ snapshots:
             toml: 3.0.0
             unified: 11.0.5
             unist-util-mdx-define: 1.1.2
-            yaml: 2.8.2
+            yaml: 2.9.0
 
     remark-mdx@3.1.1:
         dependencies:
@@ -7076,7 +8014,7 @@ snapshots:
     remark-parse@11.0.0:
         dependencies:
             "@types/mdast": 4.0.4
-            mdast-util-from-markdown: 2.0.2
+            mdast-util-from-markdown: 2.0.3
             micromark-util-types: 2.0.2
             unified: 11.0.5
         transitivePeerDependencies:
@@ -7096,6 +8034,8 @@ snapshots:
             mdast-util-to-markdown: 2.1.2
             unified: 11.0.5
 
+    require-like@0.1.2: {}
+
     resolve-from@4.0.0: {}
 
     resolve-pkg-maps@1.0.0: {}
@@ -7107,40 +8047,42 @@ snapshots:
 
     rfdc@1.4.1: {}
 
-    rolldown-plugin-dts@0.25.2(rolldown@1.1.1)(typescript@5.9.3):
+    rolldown-plugin-dts@0.26.0(rolldown@1.1.1)(typescript@5.9.3):
         dependencies:
-            "@babel/generator": 8.0.0-rc.6
-            "@babel/helper-validator-identifier": 8.0.0-rc.6
-            "@babel/parser": 8.0.0-rc.6
-            ast-kit: 3.0.0-beta.1
+            "@babel/generator": 8.0.0
+            "@babel/helper-validator-identifier": 8.0.0
+            "@babel/parser": 8.0.0
+            ast-kit: 3.0.0
             birpc: 4.0.0
             dts-resolver: 3.0.0
             get-tsconfig: 5.0.0-beta.5
-            obug: 2.1.1
+            obug: 2.1.3
             rolldown: 1.1.1
         optionalDependencies:
             typescript: 5.9.3
         transitivePeerDependencies:
             - oxc-resolver
 
-    rolldown@1.0.0-rc.3:
+    rolldown@1.0.3:
         dependencies:
-            "@oxc-project/types": 0.112.0
-            "@rolldown/pluginutils": 1.0.0-rc.3
+            "@oxc-project/types": 0.133.0
+            "@rolldown/pluginutils": 1.0.1
         optionalDependencies:
-            "@rolldown/binding-android-arm64": 1.0.0-rc.3
-            "@rolldown/binding-darwin-arm64": 1.0.0-rc.3
-            "@rolldown/binding-darwin-x64": 1.0.0-rc.3
-            "@rolldown/binding-freebsd-x64": 1.0.0-rc.3
-            "@rolldown/binding-linux-arm-gnueabihf": 1.0.0-rc.3
-            "@rolldown/binding-linux-arm64-gnu": 1.0.0-rc.3
-            "@rolldown/binding-linux-arm64-musl": 1.0.0-rc.3
-            "@rolldown/binding-linux-x64-gnu": 1.0.0-rc.3
-            "@rolldown/binding-linux-x64-musl": 1.0.0-rc.3
-            "@rolldown/binding-openharmony-arm64": 1.0.0-rc.3
-            "@rolldown/binding-wasm32-wasi": 1.0.0-rc.3
-            "@rolldown/binding-win32-arm64-msvc": 1.0.0-rc.3
-            "@rolldown/binding-win32-x64-msvc": 1.0.0-rc.3
+            "@rolldown/binding-android-arm64": 1.0.3
+            "@rolldown/binding-darwin-arm64": 1.0.3
+            "@rolldown/binding-darwin-x64": 1.0.3
+            "@rolldown/binding-freebsd-x64": 1.0.3
+            "@rolldown/binding-linux-arm-gnueabihf": 1.0.3
+            "@rolldown/binding-linux-arm64-gnu": 1.0.3
+            "@rolldown/binding-linux-arm64-musl": 1.0.3
+            "@rolldown/binding-linux-ppc64-gnu": 1.0.3
+            "@rolldown/binding-linux-s390x-gnu": 1.0.3
+            "@rolldown/binding-linux-x64-gnu": 1.0.3
+            "@rolldown/binding-linux-x64-musl": 1.0.3
+            "@rolldown/binding-openharmony-arm64": 1.0.3
+            "@rolldown/binding-wasm32-wasi": 1.0.3
+            "@rolldown/binding-win32-arm64-msvc": 1.0.3
+            "@rolldown/binding-win32-x64-msvc": 1.0.3
 
     rolldown@1.1.1:
         dependencies:
@@ -7163,35 +8105,35 @@ snapshots:
             "@rolldown/binding-win32-arm64-msvc": 1.1.1
             "@rolldown/binding-win32-x64-msvc": 1.1.1
 
-    rollup@4.57.1:
+    rollup@4.62.0:
         dependencies:
-            "@types/estree": 1.0.8
+            "@types/estree": 1.0.9
         optionalDependencies:
-            "@rollup/rollup-android-arm-eabi": 4.57.1
-            "@rollup/rollup-android-arm64": 4.57.1
-            "@rollup/rollup-darwin-arm64": 4.57.1
-            "@rollup/rollup-darwin-x64": 4.57.1
-            "@rollup/rollup-freebsd-arm64": 4.57.1
-            "@rollup/rollup-freebsd-x64": 4.57.1
-            "@rollup/rollup-linux-arm-gnueabihf": 4.57.1
-            "@rollup/rollup-linux-arm-musleabihf": 4.57.1
-            "@rollup/rollup-linux-arm64-gnu": 4.57.1
-            "@rollup/rollup-linux-arm64-musl": 4.57.1
-            "@rollup/rollup-linux-loong64-gnu": 4.57.1
-            "@rollup/rollup-linux-loong64-musl": 4.57.1
-            "@rollup/rollup-linux-ppc64-gnu": 4.57.1
-            "@rollup/rollup-linux-ppc64-musl": 4.57.1
-            "@rollup/rollup-linux-riscv64-gnu": 4.57.1
-            "@rollup/rollup-linux-riscv64-musl": 4.57.1
-            "@rollup/rollup-linux-s390x-gnu": 4.57.1
-            "@rollup/rollup-linux-x64-gnu": 4.57.1
-            "@rollup/rollup-linux-x64-musl": 4.57.1
-            "@rollup/rollup-openbsd-x64": 4.57.1
-            "@rollup/rollup-openharmony-arm64": 4.57.1
-            "@rollup/rollup-win32-arm64-msvc": 4.57.1
-            "@rollup/rollup-win32-ia32-msvc": 4.57.1
-            "@rollup/rollup-win32-x64-gnu": 4.57.1
-            "@rollup/rollup-win32-x64-msvc": 4.57.1
+            "@rollup/rollup-android-arm-eabi": 4.62.0
+            "@rollup/rollup-android-arm64": 4.62.0
+            "@rollup/rollup-darwin-arm64": 4.62.0
+            "@rollup/rollup-darwin-x64": 4.62.0
+            "@rollup/rollup-freebsd-arm64": 4.62.0
+            "@rollup/rollup-freebsd-x64": 4.62.0
+            "@rollup/rollup-linux-arm-gnueabihf": 4.62.0
+            "@rollup/rollup-linux-arm-musleabihf": 4.62.0
+            "@rollup/rollup-linux-arm64-gnu": 4.62.0
+            "@rollup/rollup-linux-arm64-musl": 4.62.0
+            "@rollup/rollup-linux-loong64-gnu": 4.62.0
+            "@rollup/rollup-linux-loong64-musl": 4.62.0
+            "@rollup/rollup-linux-ppc64-gnu": 4.62.0
+            "@rollup/rollup-linux-ppc64-musl": 4.62.0
+            "@rollup/rollup-linux-riscv64-gnu": 4.62.0
+            "@rollup/rollup-linux-riscv64-musl": 4.62.0
+            "@rollup/rollup-linux-s390x-gnu": 4.62.0
+            "@rollup/rollup-linux-x64-gnu": 4.62.0
+            "@rollup/rollup-linux-x64-musl": 4.62.0
+            "@rollup/rollup-openbsd-x64": 4.62.0
+            "@rollup/rollup-openharmony-arm64": 4.62.0
+            "@rollup/rollup-win32-arm64-msvc": 4.62.0
+            "@rollup/rollup-win32-ia32-msvc": 4.62.0
+            "@rollup/rollup-win32-x64-gnu": 4.62.0
+            "@rollup/rollup-win32-x64-msvc": 4.62.0
             fsevents: 2.3.3
 
     scheduler@0.27.0: {}
@@ -7203,8 +8145,6 @@ snapshots:
 
     semver@6.3.1: {}
 
-    semver@7.7.4: {}
-
     semver@7.8.4: {}
 
     set-cookie-parser@2.7.2: {}
@@ -7215,14 +8155,14 @@ snapshots:
 
     shebang-regex@3.0.0: {}
 
-    shiki@3.22.0:
+    shiki@4.2.0:
         dependencies:
-            "@shikijs/core": 3.22.0
-            "@shikijs/engine-javascript": 3.22.0
-            "@shikijs/engine-oniguruma": 3.22.0
-            "@shikijs/langs": 3.22.0
-            "@shikijs/themes": 3.22.0
-            "@shikijs/types": 3.22.0
+            "@shikijs/core": 4.2.0
+            "@shikijs/engine-javascript": 4.2.0
+            "@shikijs/engine-oniguruma": 4.2.0
+            "@shikijs/langs": 4.2.0
+            "@shikijs/themes": 4.2.0
+            "@shikijs/types": 4.2.0
             "@shikijs/vscode-textmate": 10.0.2
             "@types/hast": 3.0.4
 
@@ -7241,11 +8181,25 @@ snapshots:
 
     space-separated-tokens@2.0.2: {}
 
+    spdx-correct@3.2.0:
+        dependencies:
+            spdx-expression-parse: 3.0.1
+            spdx-license-ids: 3.0.23
+
+    spdx-exceptions@2.5.0: {}
+
+    spdx-expression-parse@3.0.1:
+        dependencies:
+            spdx-exceptions: 2.5.0
+            spdx-license-ids: 3.0.23
+
+    spdx-license-ids@3.0.23: {}
+
     sprintf-js@1.0.3: {}
 
     stackback@0.0.2: {}
 
-    std-env@3.10.0: {}
+    std-env@4.1.0: {}
 
     string-argv@0.3.2: {}
 
@@ -7285,25 +8239,20 @@ snapshots:
         dependencies:
             has-flag: 4.0.0
 
-    tailwindcss@4.1.18: {}
+    tagged-tag@1.0.0: {}
+
+    tailwindcss@4.3.1: {}
 
     tinybench@2.9.0: {}
 
-    tinyexec@1.0.2: {}
-
     tinyexec@1.2.4: {}
-
-    tinyglobby@0.2.15:
-        dependencies:
-            fdir: 6.5.0(picomatch@4.0.3)
-            picomatch: 4.0.3
 
     tinyglobby@0.2.17:
         dependencies:
             fdir: 6.5.0(picomatch@4.0.4)
             picomatch: 4.0.4
 
-    tinyrainbow@3.0.3: {}
+    tinyrainbow@3.1.0: {}
 
     to-regex-range@5.0.1:
         dependencies:
@@ -7317,11 +8266,11 @@ snapshots:
 
     trough@2.2.0: {}
 
-    ts-api-utils@2.4.0(typescript@5.9.3):
+    ts-api-utils@2.5.0(typescript@5.9.3):
         dependencies:
             typescript: 5.9.3
 
-    tsdown@0.22.2(tsx@4.21.0)(typescript@5.9.3):
+    tsdown@0.22.3(tsx@4.22.4)(typescript@5.9.3):
         dependencies:
             ansis: 4.3.1
             cac: 7.0.0
@@ -7329,17 +8278,17 @@ snapshots:
             empathic: 2.0.1
             hookable: 6.1.1
             import-without-cache: 0.4.0
-            obug: 2.1.1
+            obug: 2.1.3
             picomatch: 4.0.4
             rolldown: 1.1.1
-            rolldown-plugin-dts: 0.25.2(rolldown@1.1.1)(typescript@5.9.3)
+            rolldown-plugin-dts: 0.26.0(rolldown@1.1.1)(typescript@5.9.3)
             semver: 7.8.4
             tinyexec: 1.2.4
             tinyglobby: 0.2.17
             tree-kill: 1.2.2
             unconfig-core: 7.5.0
         optionalDependencies:
-            tsx: 4.21.0
+            tsx: 4.22.4
             typescript: 5.9.3
         transitivePeerDependencies:
             - "@ts-macro/tsc"
@@ -7350,10 +8299,9 @@ snapshots:
     tslib@2.8.1:
         optional: true
 
-    tsx@4.21.0:
+    tsx@4.22.4:
         dependencies:
-            esbuild: 0.27.3
-            get-tsconfig: 4.13.6
+            esbuild: 0.28.1
         optionalDependencies:
             fsevents: 2.3.3
 
@@ -7361,21 +8309,27 @@ snapshots:
         dependencies:
             prelude-ls: 1.2.1
 
-    typedoc@0.28.16(typescript@5.9.3):
-        dependencies:
-            "@gerrit0/mini-shiki": 3.22.0
-            lunr: 2.3.9
-            markdown-it: 14.1.1
-            minimatch: 9.0.5
-            typescript: 5.9.3
-            yaml: 2.8.2
+    type-fest@4.41.0: {}
 
-    typescript-eslint@8.55.0(eslint@9.39.2)(typescript@5.9.3):
+    type-fest@5.7.0:
         dependencies:
-            "@typescript-eslint/eslint-plugin": 8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3)
-            "@typescript-eslint/parser": 8.55.0(eslint@9.39.2)(typescript@5.9.3)
-            "@typescript-eslint/typescript-estree": 8.55.0(typescript@5.9.3)
-            "@typescript-eslint/utils": 8.55.0(eslint@9.39.2)(typescript@5.9.3)
+            tagged-tag: 1.0.0
+
+    typedoc@0.28.19(typescript@5.9.3):
+        dependencies:
+            "@gerrit0/mini-shiki": 3.23.0
+            lunr: 2.3.9
+            markdown-it: 14.2.0
+            minimatch: 10.2.5
+            typescript: 5.9.3
+            yaml: 2.9.0
+
+    typescript-eslint@8.61.1(eslint@9.39.2)(typescript@5.9.3):
+        dependencies:
+            "@typescript-eslint/eslint-plugin": 8.61.1(@typescript-eslint/parser@8.61.1(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3)
+            "@typescript-eslint/parser": 8.61.1(eslint@9.39.2)(typescript@5.9.3)
+            "@typescript-eslint/typescript-estree": 8.61.1(typescript@5.9.3)
+            "@typescript-eslint/utils": 8.61.1(eslint@9.39.2)(typescript@5.9.3)
             eslint: 9.39.2
             typescript: 5.9.3
         transitivePeerDependencies:
@@ -7385,12 +8339,16 @@ snapshots:
 
     uc.micro@2.1.0: {}
 
+    ufo@1.6.4: {}
+
     unconfig-core@7.5.0:
         dependencies:
             "@quansync/fs": 1.0.0
             quansync: 1.0.0
 
-    undici-types@7.16.0: {}
+    undici-types@7.24.6: {}
+
+    unicorn-magic@0.4.0: {}
 
     unified@11.0.5:
         dependencies:
@@ -7408,7 +8366,7 @@ snapshots:
 
     unist-util-mdx-define@1.1.2:
         dependencies:
-            "@types/estree": 1.0.8
+            "@types/estree": 1.0.9
             "@types/hast": 3.0.4
             "@types/mdast": 4.0.4
             estree-util-is-identifier-name: 3.0.0
@@ -7439,9 +8397,9 @@ snapshots:
             unist-util-is: 6.0.1
             unist-util-visit-parents: 6.0.2
 
-    update-browserslist-db@1.2.3(browserslist@4.28.1):
+    update-browserslist-db@1.2.3(browserslist@4.28.2):
         dependencies:
-            browserslist: 4.28.1
+            browserslist: 4.28.2
             escalade: 3.2.0
             picocolors: 1.1.1
 
@@ -7449,9 +8407,14 @@ snapshots:
         dependencies:
             punycode: 2.3.1
 
-    valibot@1.2.0(typescript@5.9.3):
+    valibot@1.4.1(typescript@5.9.3):
         optionalDependencies:
             typescript: 5.9.3
+
+    validate-npm-package-license@3.0.4:
+        dependencies:
+            spdx-correct: 3.2.0
+            spdx-expression-parse: 3.0.1
 
     vfile-location@5.0.3:
         dependencies:
@@ -7468,13 +8431,13 @@ snapshots:
             "@types/unist": 3.0.3
             vfile-message: 4.0.3
 
-    vite-node@3.2.4(@types/node@25.2.3)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2):
+    vite-node@3.2.4(@types/node@25.9.3)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0):
         dependencies:
             cac: 6.7.14
             debug: 4.4.3
             es-module-lexer: 1.7.0
             pathe: 2.0.3
-            vite: 7.3.1(@types/node@25.2.3)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+            vite: 7.3.5(@types/node@25.9.3)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
         transitivePeerDependencies:
             - "@types/node"
             - jiti
@@ -7489,66 +8452,19 @@ snapshots:
             - tsx
             - yaml
 
-    vite@7.3.1(@types/node@25.2.3)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2):
+    vite-node@6.0.0(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0):
         dependencies:
-            esbuild: 0.27.3
-            fdir: 6.5.0(picomatch@4.0.3)
-            picomatch: 4.0.3
-            postcss: 8.5.6
-            rollup: 4.57.1
-            tinyglobby: 0.2.15
-        optionalDependencies:
-            "@types/node": 25.2.3
-            fsevents: 2.3.3
-            lightningcss: 1.31.1
-            tsx: 4.21.0
-            yaml: 2.8.2
-
-    vite@8.0.0-beta.13(@types/node@25.2.3)(esbuild@0.27.3)(tsx@4.21.0)(yaml@2.8.2):
-        dependencies:
-            "@oxc-project/runtime": 0.112.0
-            fdir: 6.5.0(picomatch@4.0.3)
-            lightningcss: 1.31.1
-            picomatch: 4.0.3
-            postcss: 8.5.6
-            rolldown: 1.0.0-rc.3
-            tinyglobby: 0.2.15
-        optionalDependencies:
-            "@types/node": 25.2.3
-            esbuild: 0.27.3
-            fsevents: 2.3.3
-            tsx: 4.21.0
-            yaml: 2.8.2
-
-    vitest@4.0.18(@types/node@25.2.3)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2):
-        dependencies:
-            "@vitest/expect": 4.0.18
-            "@vitest/mocker": 4.0.18(vite@7.3.1(@types/node@25.2.3)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
-            "@vitest/pretty-format": 4.0.18
-            "@vitest/runner": 4.0.18
-            "@vitest/snapshot": 4.0.18
-            "@vitest/spy": 4.0.18
-            "@vitest/utils": 4.0.18
-            es-module-lexer: 1.7.0
-            expect-type: 1.3.0
-            magic-string: 0.30.21
-            obug: 2.1.1
+            cac: 7.0.0
+            es-module-lexer: 2.1.0
+            obug: 2.1.3
             pathe: 2.0.3
-            picomatch: 4.0.3
-            std-env: 3.10.0
-            tinybench: 2.9.0
-            tinyexec: 1.0.2
-            tinyglobby: 0.2.15
-            tinyrainbow: 3.0.3
-            vite: 7.3.1(@types/node@25.2.3)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
-            why-is-node-running: 2.3.0
-        optionalDependencies:
-            "@types/node": 25.2.3
+            vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
         transitivePeerDependencies:
+            - "@types/node"
+            - "@vitejs/devtools"
+            - esbuild
             - jiti
             - less
-            - lightningcss
-            - msw
             - sass
             - sass-embedded
             - stylus
@@ -7556,6 +8472,77 @@ snapshots:
             - terser
             - tsx
             - yaml
+
+    vite@7.3.5(@types/node@25.9.3)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0):
+        dependencies:
+            esbuild: 0.27.7
+            fdir: 6.5.0(picomatch@4.0.4)
+            picomatch: 4.0.4
+            postcss: 8.5.15
+            rollup: 4.62.0
+            tinyglobby: 0.2.17
+        optionalDependencies:
+            "@types/node": 25.9.3
+            fsevents: 2.3.3
+            lightningcss: 1.32.0
+            tsx: 4.22.4
+            yaml: 2.9.0
+
+    vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.2):
+        dependencies:
+            lightningcss: 1.32.0
+            picomatch: 4.0.4
+            postcss: 8.5.15
+            rolldown: 1.0.3
+            tinyglobby: 0.2.17
+        optionalDependencies:
+            "@types/node": 25.9.3
+            esbuild: 0.28.1
+            fsevents: 2.3.3
+            tsx: 4.22.4
+            yaml: 2.8.2
+
+    vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0):
+        dependencies:
+            lightningcss: 1.32.0
+            picomatch: 4.0.4
+            postcss: 8.5.15
+            rolldown: 1.0.3
+            tinyglobby: 0.2.17
+        optionalDependencies:
+            "@types/node": 25.9.3
+            esbuild: 0.28.1
+            fsevents: 2.3.3
+            tsx: 4.22.4
+            yaml: 2.9.0
+
+    vitest@4.1.9(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)):
+        dependencies:
+            "@vitest/expect": 4.1.9
+            "@vitest/mocker": 4.1.9(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))
+            "@vitest/pretty-format": 4.1.9
+            "@vitest/runner": 4.1.9
+            "@vitest/snapshot": 4.1.9
+            "@vitest/spy": 4.1.9
+            "@vitest/utils": 4.1.9
+            es-module-lexer: 2.1.0
+            expect-type: 1.3.0
+            magic-string: 0.30.21
+            obug: 2.1.3
+            pathe: 2.0.3
+            picomatch: 4.0.4
+            std-env: 4.1.0
+            tinybench: 2.9.0
+            tinyexec: 1.2.4
+            tinyglobby: 0.2.17
+            tinyrainbow: 3.1.0
+            vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
+            why-is-node-running: 2.3.0
+        optionalDependencies:
+            "@types/node": 25.9.3
+            "@vitest/coverage-v8": 4.1.9(vitest@4.1.9)
+        transitivePeerDependencies:
+            - msw
 
     web-namespaces@2.0.1: {}
 
@@ -7579,6 +8566,8 @@ snapshots:
     yallist@3.1.1: {}
 
     yaml@2.8.2: {}
+
+    yaml@2.9.0: {}
 
     yocto-queue@0.1.0: {}
 

--- a/src/api/aoa.test.ts
+++ b/src/api/aoa.test.ts
@@ -33,31 +33,31 @@ describe("aoa.ts — addArrayToSheet edge cases", () => {
 	});
 
 	it("should handle numeric origin", () => {
-		const ws = addArrayToSheet(null, [["A"]], { origin: 3 } as any);
+		const ws = addArrayToSheet(null, [["A"]], { origin: 3 });
 		// When no prior ref, range starts at 0,0 and data at row 3 expands e.r to 3
 		expect(ws["!ref"]).toBe("A1:A4");
 		expect((ws as any)["A4"]).toBeDefined();
 	});
 
 	it("should handle origin as cell ref string", () => {
-		const ws = addArrayToSheet(null, [["X"]], { origin: "C5" } as any);
+		const ws = addArrayToSheet(null, [["X"]], { origin: "C5" });
 		expect((ws as any)["C5"].v).toBe("X");
 	});
 
 	it("should handle origin -1 (append)", () => {
 		let ws = arrayToSheet([["Row1"]]);
-		ws = addArrayToSheet(ws, [["Row2"]], { origin: -1 } as any);
+		ws = addArrayToSheet(ws, [["Row2"]], { origin: -1 });
 		expect((ws as any)["A2"].v).toBe("Row2");
 	});
 
 	it("should handle null values with nullError", () => {
-		const ws = arrayToSheet([[null, "ok"]], { nullError: true } as any);
+		const ws = arrayToSheet([[null, "ok"]], { nullError: true });
 		expect((ws as any)["A1"].t).toBe("e");
 		expect((ws as any)["A1"].v).toBe(0);
 	});
 
 	it("should handle null values with sheetStubs", () => {
-		const ws = arrayToSheet([[null, "ok"]], { sheetStubs: true } as any);
+		const ws = arrayToSheet([[null, "ok"]], { sheetStubs: true });
 		expect((ws as any)["A1"].t).toBe("z");
 	});
 

--- a/src/api/book.test.ts
+++ b/src/api/book.test.ts
@@ -342,7 +342,7 @@ describe("book.ts: API edge cases", () => {
 	});
 
 	it("sheetToFormulae with dense mode", () => {
-		const ws = arrayToSheet([["A", 1]], { dense: true } as any);
+		const ws = arrayToSheet([["A", 1]], { dense: true });
 		const formulae = sheetToFormulae(ws);
 		expect(formulae.length).toBeGreaterThanOrEqual(2);
 	});

--- a/src/api/book.ts
+++ b/src/api/book.ts
@@ -1,4 +1,4 @@
-import type { WorkBook, WorkSheet, CellObject, Hyperlink, CellStyle, Range } from "../types.js";
+import type { WorkBook, WorkSheet, CellObject, CellStyle, Range } from "../types.js";
 import { XlsxError } from "../errors.js";
 import { validateSheetName } from "../xlsx/workbook.js";
 import {
@@ -294,7 +294,7 @@ export function setCellHyperlink(cell: CellObject, target?: string, tooltip?: st
 	if (!target) {
 		delete cell.l;
 	} else {
-		cell.l = { Target: target } as Hyperlink;
+		cell.l = { Target: target };
 		if (tooltip) {
 			cell.l.Tooltip = tooltip;
 		}

--- a/src/api/json.test.ts
+++ b/src/api/json.test.ts
@@ -158,7 +158,7 @@ describe("json.ts — addJsonToSheet edge cases", () => {
 	});
 
 	it("should handle numeric origin", () => {
-		const ws = addJsonToSheet(null, [{ a: 1 }], { origin: 5 } as any);
+		const ws = addJsonToSheet(null, [{ a: 1 }], { origin: 5 });
 		// origin=5 means header at row 5, data at row 6. Range includes row 0 start.
 		expect(ws["!ref"]).toContain("7"); // row 7 = originRow(5) + 1 data row + header offset
 	});

--- a/src/xlsx/comments.test.ts
+++ b/src/xlsx/comments.test.ts
@@ -14,7 +14,7 @@ describe("comments: insertCommentsIntoSheet", () => {
 	it("inserts legacy comment into sheet", () => {
 		const ws: any = { A1: { t: "n", v: 1 }, "!ref": "A1" };
 		const comments = [{ ref: "A1", author: "Alice", t: "Hello", r: "<t>Hello</t>", h: "" }];
-		insertCommentsIntoSheet(ws, comments as any, false);
+		insertCommentsIntoSheet(ws, comments, false);
 		expect(ws["A1"].c).toBeDefined();
 		expect(ws["A1"].c[0].t).toBe("Hello");
 	});
@@ -22,7 +22,7 @@ describe("comments: insertCommentsIntoSheet", () => {
 	it("inserts threaded comment and removes legacy", () => {
 		const ws: any = { A1: { t: "n", v: 1, c: [{ a: "Alice", t: "legacy", T: false }] }, "!ref": "A1" };
 		const comments = [{ ref: "A1", author: "Bob", t: "threaded", r: "<t>threaded</t>", h: "" }];
-		insertCommentsIntoSheet(ws, comments as any, true);
+		insertCommentsIntoSheet(ws, comments, true);
 		// Threaded should override legacy
 		expect(ws["A1"].c.some((c: any) => c.T === true)).toBe(true);
 	});
@@ -30,7 +30,7 @@ describe("comments: insertCommentsIntoSheet", () => {
 	it("does not add legacy when threaded exists", () => {
 		const ws: any = { A1: { t: "n", v: 1, c: [{ a: "Alice", t: "threaded", T: true }] }, "!ref": "A1" };
 		const comments = [{ ref: "A1", author: "Bob", t: "legacy", r: "<t>legacy</t>", h: "" }];
-		insertCommentsIntoSheet(ws, comments as any, false);
+		insertCommentsIntoSheet(ws, comments, false);
 		// Should not add legacy comment when threaded exists
 		expect(ws["A1"].c.length).toBe(1);
 	});
@@ -38,7 +38,7 @@ describe("comments: insertCommentsIntoSheet", () => {
 	it("creates cell when it doesn't exist and expands range", () => {
 		const ws: any = { "!ref": "A1" };
 		const comments = [{ ref: "C3", author: "Alice", t: "New", r: "<t>New</t>", h: "" }];
-		insertCommentsIntoSheet(ws, comments as any, false);
+		insertCommentsIntoSheet(ws, comments, false);
 		expect(ws["C3"]).toBeDefined();
 		expect(ws["C3"].c).toBeDefined();
 		// Range should be expanded
@@ -48,7 +48,7 @@ describe("comments: insertCommentsIntoSheet", () => {
 	it("inserts into dense mode worksheet", () => {
 		const ws: any = { "!data": [[{ t: "n", v: 1 }]], "!ref": "A1" };
 		const comments = [{ ref: "A1", author: "Alice", t: "Dense", r: "<t>Dense</t>", h: "" }];
-		insertCommentsIntoSheet(ws, comments as any, false);
+		insertCommentsIntoSheet(ws, comments, false);
 		expect(ws["!data"][0][0].c).toBeDefined();
 	});
 });

--- a/src/xlsx/parse-zip.ts
+++ b/src/xlsx/parse-zip.ts
@@ -239,7 +239,7 @@ export function parseZip(zip: ZipArchive, opts?: ReadOptions): WorkBook {
 
 	const themes: ThemeData = { themeElements: { clrScheme: [] } };
 	let styles: StylesData = { NumberFmt: {}, CellXf: [], Fonts: [], Fills: [], Borders: [] };
-	let strs: SST = [] as any;
+	let strs: SST = [];
 
 	// Parse shared resources unless only sheet names or properties are requested
 	if (!options.bookSheets && !options.bookProps) {

--- a/src/xlsx/roundtrip.test.ts
+++ b/src/xlsx/roundtrip.test.ts
@@ -272,7 +272,7 @@ describe("XLSX roundtrip: workbook features", () => {
 		const wb = createWorkbook(ws1, "S1");
 		appendSheet(wb, ws2, "S2");
 		const bytes = await write(wb);
-		const wb2 = await read(bytes, { sheets: "S2" } as any);
+		const wb2 = await read(bytes, { sheets: "S2" });
 		expect(wb2.SheetNames).toContain("S2");
 		// S1 might still be in SheetNames (from workbook.xml) but its data shouldn't be loaded
 		if (wb2.SheetNames.includes("S1")) {
@@ -286,7 +286,7 @@ describe("XLSX roundtrip: workbook features", () => {
 		const wb = createWorkbook(ws1, "S1");
 		appendSheet(wb, ws2, "S2");
 		const bytes = await write(wb);
-		const wb2 = await read(bytes, { sheets: 1 } as any);
+		const wb2 = await read(bytes, { sheets: 1 });
 		expect(wb2.Sheets["S2"]).toBeDefined();
 	});
 
@@ -298,7 +298,7 @@ describe("XLSX roundtrip: workbook features", () => {
 		appendSheet(wb, ws2, "S2");
 		appendSheet(wb, ws3, "S3");
 		const bytes = await write(wb);
-		const wb2 = await read(bytes, { sheets: [0, "S3"] } as any);
+		const wb2 = await read(bytes, { sheets: [0, "S3"] });
 		expect(wb2.Sheets["S1"]).toBeDefined();
 		expect(wb2.Sheets["S3"]).toBeDefined();
 	});

--- a/src/xlsx/shared-strings.test.ts
+++ b/src/xlsx/shared-strings.test.ts
@@ -274,12 +274,12 @@ describe("parseSstXml: rich text parsing", () => {
 
 describe("writeSstXml", () => {
 	it("returns empty when bookSST is false", () => {
-		const sst: SST = [] as any;
+		const sst: SST = [];
 		expect(writeSstXml(sst, { bookSST: false })).toBe("");
 	});
 
 	it("writes basic string entries", () => {
-		const sst: SST = [{ t: "Hello" }, { t: "World" }] as any;
+		const sst: SST = [{ t: "Hello" }, { t: "World" }];
 		sst.Count = 2;
 		sst.Unique = 2;
 		const xml = writeSstXml(sst, { bookSST: true });
@@ -290,7 +290,7 @@ describe("writeSstXml", () => {
 	});
 
 	it("preserves rich text XML", () => {
-		const sst: SST = [{ t: "Bold", r: "<r><rPr><b/></rPr><t>Bold</t></r>" }] as any;
+		const sst: SST = [{ t: "Bold", r: "<r><rPr><b/></rPr><t>Bold</t></r>" }];
 		sst.Count = 1;
 		sst.Unique = 1;
 		const xml = writeSstXml(sst, { bookSST: true });
@@ -298,7 +298,7 @@ describe("writeSstXml", () => {
 	});
 
 	it("handles whitespace preservation", () => {
-		const sst: SST = [{ t: "  leading" }, { t: "trailing  " }, { t: "has\ttab" }] as any;
+		const sst: SST = [{ t: "  leading" }, { t: "trailing  " }, { t: "has\ttab" }];
 		sst.Count = 3;
 		sst.Unique = 3;
 		const xml = writeSstXml(sst, { bookSST: true });
@@ -306,7 +306,7 @@ describe("writeSstXml", () => {
 	});
 
 	it("converts non-string types", () => {
-		const sst: SST = [{ t: 123 as any }] as any;
+		const sst: SST = [{ t: 123 as any }];
 		sst.Count = 1;
 		sst.Unique = 1;
 		const xml = writeSstXml(sst, { bookSST: true });
@@ -323,7 +323,7 @@ describe("writeSstXml", () => {
 	});
 
 	it("handles empty string entry", () => {
-		const sst: SST = [{ t: "" }] as any;
+		const sst: SST = [{ t: "" }];
 		sst.Count = 1;
 		sst.Unique = 1;
 		const xml = writeSstXml(sst, { bookSST: true });
@@ -331,7 +331,7 @@ describe("writeSstXml", () => {
 	});
 
 	it("handles entry with undefined t", () => {
-		const sst: SST = [{ t: undefined as any }] as any;
+		const sst: SST = [{ t: undefined as any }];
 		sst.Count = 1;
 		sst.Unique = 1;
 		const xml = writeSstXml(sst, { bookSST: true });

--- a/src/xlsx/shared-strings.ts
+++ b/src/xlsx/shared-strings.ts
@@ -349,7 +349,7 @@ const sstr2 = /<\/(?:\w+:)?(?:si|sstItem)>/;
  * @returns Array of parsed string entries with Count and Unique metadata
  */
 export function parseSstXml(data: string, opts?: SstParseOptions): SST {
-	const strings: SST = [] as any;
+	const strings: SST = [];
 	if (!data) {
 		return strings;
 	}

--- a/src/xlsx/workbook.test.ts
+++ b/src/xlsx/workbook.test.ts
@@ -301,7 +301,7 @@ describe("validateWorkbook edge cases", () => {
 
 	it("throws on empty sheet names", () => {
 		expect(() => {
-			validateWorkbook({ SheetNames: [], Sheets: {} } as any);
+			validateWorkbook({ SheetNames: [], Sheets: {} });
 		}).toThrow("empty");
 	});
 });

--- a/src/xlsx/worksheet.ts
+++ b/src/xlsx/worksheet.ts
@@ -1,4 +1,4 @@
-import type { WorkSheet, CellObject, Range, ColInfo, RowInfo, MarginInfo, SheetView } from "../types.js";
+import type { WorkSheet, CellObject, Range, ColInfo, MarginInfo, SheetView } from "../types.js";
 import { parseXmlTag, XML_HEADER } from "../xml/parser.js";
 import { unescapeXml, escapeXml } from "../xml/escape.js";
 import { writeXmlElement } from "../xml/writer.js";
@@ -68,7 +68,7 @@ function parseWorksheetXml_cols(columns: ColInfo[], cols: string[], opts?: any):
 		const hidden = tag.hidden === "1";
 		for (let j = min; j <= max; ++j) {
 			if (!columns[j]) {
-				columns[j] = {} as ColInfo;
+				columns[j] = {};
 			}
 			if (width !== undefined) {
 				columns[j].width = width;
@@ -210,7 +210,7 @@ function parseSheetData(
 				s["!rows"] = [];
 			}
 			if (!s["!rows"][R]) {
-				s["!rows"][R] = {} as RowInfo;
+				s["!rows"][R] = {};
 			}
 			if (rowTag.ht) {
 				s["!rows"][R].hpt = parseFloat(rowTag.ht);
@@ -287,46 +287,46 @@ function parseSheetData(
 				case "s": // shared string - value is an index into the SST
 					if (v !== null) {
 						const idx = parseInt(v, 10);
-						cell = { t: "s", v: "" } as CellObject;
+						cell = { t: "s", v: "" };
 						// Store SST index for later resolution via resolveSharedStrings()
 						(cell as any)._sstIdx = idx;
 					} else {
-						cell = { t: "z" } as CellObject;
+						cell = { t: "z" };
 					}
 					break;
 				case "str": // formula result that is a string
-					cell = { t: "s", v: v ? unescapeXml(v) : "" } as CellObject;
+					cell = { t: "s", v: v ? unescapeXml(v) : "" };
 					break;
 				case "inlineStr":
 					if (isMatch) {
 						const tMatch = isMatch[1].match(/<(?:\w+:)?t[^>]*>([\s\S]*?)<\/(?:\w+:)?t>/);
-						cell = { t: "s", v: tMatch ? unescapeXml(tMatch[1]) : "" } as CellObject;
+						cell = { t: "s", v: tMatch ? unescapeXml(tMatch[1]) : "" };
 					} else {
-						cell = { t: "s", v: "" } as CellObject;
+						cell = { t: "s", v: "" };
 					}
 					break;
 				case "b": // boolean
-					cell = { t: "b", v: v === "1" } as CellObject;
+					cell = { t: "b", v: v === "1" };
 					break;
 				case "e": // error
-					cell = { t: "e", v: v ? parseInt(v, 10) || 0 : 0 } as CellObject;
+					cell = { t: "e", v: v ? parseInt(v, 10) || 0 : 0 };
 					(cell as any).w = v || "";
 					break;
 				case "d": // ISO 8601 date string
 					if (v) {
-						cell = { t: "d", v: new Date(v) } as CellObject;
+						cell = { t: "d", v: new Date(v) };
 					} else {
-						cell = { t: "z" } as CellObject;
+						cell = { t: "z" };
 					}
 					break;
 				default: // "n" (number) or unrecognized
 					if (v !== null) {
-						cell = { t: "n", v: parseFloat(v) } as CellObject;
+						cell = { t: "n", v: parseFloat(v) };
 					} else {
 						if (!opts.sheetStubs) {
 							continue;
 						}
-						cell = { t: "z" } as CellObject;
+						cell = { t: "z" };
 					}
 					break;
 			}
@@ -378,7 +378,7 @@ function parseSheetData(
 						formatTable[(cell.XF && cell.XF.numFmtId) || 0];
 					if (nfmt) {
 						try {
-							cell.w = formatNumber(nfmt, cell.v as number, { date1904 });
+							cell.w = formatNumber(nfmt, cell.v, { date1904 });
 						} catch {}
 					}
 					// Convert numeric cells with date formats to Date objects if cellDates is enabled
@@ -489,17 +489,17 @@ export function parseWorksheetXml(
 	styles?: StylesData,
 ): WorkSheet {
 	if (!data) {
-		return {} as WorkSheet;
+		return {};
 	}
 	if (!opts) {
 		opts = {};
 	}
 	assertXmlPartLimits("worksheet.xml", data, opts);
 	if (!rels) {
-		rels = { "!id": {} } as any;
+		rels = { "!id": {} };
 	}
 
-	const s: WorkSheet = opts.dense ? { "!data": [] } : ({} as any);
+	const s: WorkSheet = opts.dense ? { "!data": [] } : {};
 	// Start with an inverted range that will be narrowed as cells are found
 	const refguess: Range = { s: { r: 2000000, c: 2000000 }, e: { r: 0, c: 0 } };
 
@@ -560,7 +560,7 @@ export function parseWorksheetXml(
 	// Hyperlinks
 	const hlink = data2.match(hlinkregex);
 	if (hlink) {
-		parseWorksheetXml_hlinks(s, hlink, rels!, opts);
+		parseWorksheetXml_hlinks(s, hlink, rels, opts);
 	}
 
 	// Page margins

--- a/src/xlsx/write-zip.ts
+++ b/src/xlsx/write-zip.ts
@@ -101,7 +101,7 @@ export function writeZipXlsx(wb: WorkBook, opts: any): ZipArchive {
 
 	// --- Worksheets ---
 	for (let rId = 1; rId <= wb.SheetNames.length; ++rId) {
-		const wsrels: Relationships = { "!id": {} } as any;
+		const wsrels: Relationships = { "!id": {} };
 		const ws = wb.Sheets[wb.SheetNames[rId - 1]];
 
 		filePath = "xl/worksheets/sheet" + rId + ".xml";


### PR DESCRIPTION
## Dependency group
- Root toolchain/test packages: `@types/node` 25.2.3 -> 25.9.3, `@vitest/coverage-v8` 4.0.18 -> 4.1.9, `prettier` 3.8.1 -> 3.8.4, `tsdown` 0.22.2 -> 0.22.3, `tsx` 4.21.0 -> 4.22.4, `typescript-eslint` 8.55.0 -> 8.61.1, `vitest` 4.0.18 -> 4.1.9.
- Docs app packages: `ardo` 2.7.0 -> 3.5.0, `isbot` 5.1.35 -> 5.1.43, `lucide-react` 0.564.0 -> 1.20.0, `react`/`react-dom` 19.2.4 -> 19.2.7, `react-router`/`@react-router/dev` 7.13.0 -> 7.18.0, `@types/react` 19.2.14 -> 19.2.17, `vite` 8.0.0-beta.13 -> 8.0.16.
- Why grouped: this keeps the root build/test/lint surface compatible while updating the docs stack together because `ardo`, React Router, Vite, React, and Lucide share the docs build/runtime surface.

## Upstream changes that matter here
- `vitest`/`@vitest/coverage-v8` remain on the 4.x line and keep the V8 coverage provider used by `vitest.config.ts`.
- `typescript-eslint` 8.61.1 keeps compatibility with the existing ESLint 9 and TypeScript 5.9 setup, but its stricter rule analysis now detects unnecessary type assertions that the previous version allowed.
- `tsdown` 0.22.3 keeps the existing config shape and builds successfully with rolldown 1.1.1.
- `ardo` 3.5.0 changes the public docs UI export names used by this repo (`ArdoRootLayout`, `ArdoHero`, `ArdoFeatures`) and updates its Vite/React plugin stack.
- `lucide-react` 1.20.0 no longer exports the `Github` brand icon used on the home page, so the GitHub action now uses `ExternalLink`.
- Gaps: ardo release notes are concise and do not provide a full migration guide; local impact was checked against installed package exports, peer metadata, and the docs production build.

## Local impact and code changes
- Updated `package.json`, `docs/package.json`, and `pnpm-lock.yaml` with the selected dependency groups.
- Migrated docs imports from ardo 2 names to ardo 3 public names.
- Replaced the removed Lucide `Github` export with `ExternalLink` while preserving the GitHub link and label.
- Removed unnecessary type assertions surfaced by the updated `typescript-eslint` rule behavior.
- Deferred follow-ups: ESLint 10 / `@eslint/js` 10, `lint-staged` 17, and TypeScript 6 remain separate major-version migrations.

## Validation
- `pnpm peers check`: passed.
- `pnpm run verify`: passed.
- During push, the repo hooks also ran `tsc --noEmit`, `eslint src/`, and `prettier --check src/`: passed.

## Risk
- Main runtime package risk is low because the package has no runtime dependencies and `package:check`, publint, arethetypeswrong, smoke exports, and tests all passed.
- Docs risk is moderate because ardo and lucide include major updates, but the affected imports were migrated and the production docs build completed successfully.