### PR TITLE
[codex] Update ESLint toolchain to v10

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -35,8 +35,9 @@ export default tseslint.config(
 			"@typescript-eslint/no-empty-function": "off",
 			"no-empty": ["error", { allowEmptyCatch: true }],
 
-			// Ported code uses parameter reassignment
+			// Ported code keeps SheetJS-style mutation and state assignments
 			"@typescript-eslint/no-unnecessary-condition": "off",
+			"no-useless-assignment": "off",
 
 			// Too strict for ported code
 			"@typescript-eslint/restrict-template-expressions": "off",
@@ -46,10 +47,7 @@ export default tseslint.config(
 			curly: "error",
 
 			// Unused vars as warning only
-			"@typescript-eslint/no-unused-vars": [
-				"warn",
-				{ argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
-			],
+			"@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
 		},
 	},
 );

--- a/package.json
+++ b/package.json
@@ -49,10 +49,10 @@
 		"prepare": "husky"
 	},
 	"devDependencies": {
-		"@eslint/js": "^9.39.2",
+		"@eslint/js": "^10.0.1",
 		"@types/node": "^25.9.3",
 		"@vitest/coverage-v8": "^4.1.9",
-		"eslint": "^9.39.2",
+		"eslint": "^10.5.0",
 		"eslint-config-prettier": "^10.1.8",
 		"husky": "^9.1.7",
 		"lint-staged": "^16.2.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,8 +8,8 @@ importers:
     .:
         devDependencies:
             "@eslint/js":
-                specifier: ^9.39.2
-                version: 9.39.2
+                specifier: ^10.0.1
+                version: 10.0.1(eslint@10.5.0)
             "@types/node":
                 specifier: ^25.9.3
                 version: 25.9.3
@@ -17,11 +17,11 @@ importers:
                 specifier: ^4.1.9
                 version: 4.1.9(vitest@4.1.9)
             eslint:
-                specifier: ^9.39.2
-                version: 9.39.2
+                specifier: ^10.5.0
+                version: 10.5.0
             eslint-config-prettier:
                 specifier: ^10.1.8
-                version: 10.1.8(eslint@9.39.2)
+                version: 10.1.8(eslint@10.5.0)
             husky:
                 specifier: ^9.1.7
                 version: 9.1.7
@@ -42,7 +42,7 @@ importers:
                 version: 5.9.3
             typescript-eslint:
                 specifier: ^8.61.1
-                version: 8.61.1(eslint@9.39.2)(typescript@5.9.3)
+                version: 8.61.1(eslint@10.5.0)(typescript@5.9.3)
             vitest:
                 specifier: ^4.1.9
                 version: 4.1.9(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))
@@ -874,54 +874,52 @@ packages:
             }
         engines: { node: ^12.0.0 || ^14.0.0 || >=16.0.0 }
 
-    "@eslint/config-array@0.21.1":
+    "@eslint/config-array@0.23.5":
         resolution:
             {
-                integrity: sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==,
+                integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==,
             }
-        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+        engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
 
-    "@eslint/config-helpers@0.4.2":
+    "@eslint/config-helpers@0.6.0":
         resolution:
             {
-                integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==,
+                integrity: sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==,
             }
-        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+        engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
 
-    "@eslint/core@0.17.0":
+    "@eslint/core@1.2.1":
         resolution:
             {
-                integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==,
+                integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==,
             }
-        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+        engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
 
-    "@eslint/eslintrc@3.3.3":
+    "@eslint/js@10.0.1":
         resolution:
             {
-                integrity: sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==,
+                integrity: sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==,
             }
-        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+        engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
+        peerDependencies:
+            eslint: ^10.0.0
+        peerDependenciesMeta:
+            eslint:
+                optional: true
 
-    "@eslint/js@9.39.2":
+    "@eslint/object-schema@3.0.5":
         resolution:
             {
-                integrity: sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==,
+                integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==,
             }
-        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+        engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
 
-    "@eslint/object-schema@2.1.7":
+    "@eslint/plugin-kit@0.7.2":
         resolution:
             {
-                integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==,
+                integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==,
             }
-        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-
-    "@eslint/plugin-kit@0.4.1":
-        resolution:
-            {
-                integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==,
-            }
-        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+        engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
 
     "@gerrit0/mini-shiki@3.23.0":
         resolution:
@@ -929,17 +927,24 @@ packages:
                 integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==,
             }
 
-    "@humanfs/core@0.19.1":
+    "@humanfs/core@0.19.2":
         resolution:
             {
-                integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==,
+                integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==,
             }
         engines: { node: ">=18.18.0" }
 
-    "@humanfs/node@0.16.7":
+    "@humanfs/node@0.16.8":
         resolution:
             {
-                integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==,
+                integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==,
+            }
+        engines: { node: ">=18.18.0" }
+
+    "@humanfs/types@0.15.0":
+        resolution:
+            {
+                integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==,
             }
         engines: { node: ">=18.18.0" }
 
@@ -1827,16 +1832,16 @@ packages:
                 integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==,
             }
 
+    "@types/esrecurse@4.3.1":
+        resolution:
+            {
+                integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==,
+            }
+
     "@types/estree-jsx@1.0.5":
         resolution:
             {
                 integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==,
-            }
-
-    "@types/estree@1.0.8":
-        resolution:
-            {
-                integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==,
             }
 
     "@types/estree@1.0.9":
@@ -2157,14 +2162,6 @@ packages:
         peerDependencies:
             acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
-    acorn@8.15.0:
-        resolution:
-            {
-                integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==,
-            }
-        engines: { node: ">=0.4.0" }
-        hasBin: true
-
     acorn@8.17.0:
         resolution:
             {
@@ -2173,10 +2170,10 @@ packages:
         engines: { node: ">=0.4.0" }
         hasBin: true
 
-    ajv@6.12.6:
+    ajv@6.15.0:
         resolution:
             {
-                integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==,
+                integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==,
             }
 
     ansi-escapes@7.3.0:
@@ -2192,13 +2189,6 @@ packages:
                 integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==,
             }
         engines: { node: ">=12" }
-
-    ansi-styles@4.3.0:
-        resolution:
-            {
-                integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==,
-            }
-        engines: { node: ">=8" }
 
     ansi-styles@6.2.3:
         resolution:
@@ -2283,12 +2273,6 @@ packages:
                 integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==,
             }
 
-    balanced-match@1.0.2:
-        resolution:
-            {
-                integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==,
-            }
-
     balanced-match@4.0.4:
         resolution:
             {
@@ -2308,12 +2292,6 @@ packages:
         resolution:
             {
                 integrity: sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==,
-            }
-
-    brace-expansion@1.1.12:
-        resolution:
-            {
-                integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==,
             }
 
     brace-expansion@5.0.6:
@@ -2352,13 +2330,6 @@ packages:
             }
         engines: { node: ">=20.19.0" }
 
-    callsites@3.1.0:
-        resolution:
-            {
-                integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==,
-            }
-        engines: { node: ">=6" }
-
     caniuse-lite@1.0.30001799:
         resolution:
             {
@@ -2377,13 +2348,6 @@ packages:
                 integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==,
             }
         engines: { node: ">=18" }
-
-    chalk@4.1.2:
-        resolution:
-            {
-                integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==,
-            }
-        engines: { node: ">=10" }
 
     character-entities-html4@2.1.0:
         resolution:
@@ -2436,19 +2400,6 @@ packages:
                 integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==,
             }
 
-    color-convert@2.0.1:
-        resolution:
-            {
-                integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==,
-            }
-        engines: { node: ">=7.0.0" }
-
-    color-name@1.1.4:
-        resolution:
-            {
-                integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==,
-            }
-
     colorette@2.0.20:
         resolution:
             {
@@ -2467,12 +2418,6 @@ packages:
                 integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==,
             }
         engines: { node: ">=20" }
-
-    concat-map@0.0.1:
-        resolution:
-            {
-                integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==,
-            }
 
     confbox@0.1.8:
         resolution:
@@ -2715,12 +2660,12 @@ packages:
         peerDependencies:
             eslint: ">=7.0.0"
 
-    eslint-scope@8.4.0:
+    eslint-scope@9.1.2:
         resolution:
             {
-                integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==,
+                integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==,
             }
-        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+        engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
 
     eslint-visitor-keys@3.4.3:
         resolution:
@@ -2729,13 +2674,6 @@ packages:
             }
         engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
 
-    eslint-visitor-keys@4.2.1:
-        resolution:
-            {
-                integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==,
-            }
-        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-
     eslint-visitor-keys@5.0.1:
         resolution:
             {
@@ -2743,12 +2681,12 @@ packages:
             }
         engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
 
-    eslint@9.39.2:
+    eslint@10.5.0:
         resolution:
             {
-                integrity: sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==,
+                integrity: sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==,
             }
-        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+        engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
         hasBin: true
         peerDependencies:
             jiti: "*"
@@ -2756,12 +2694,12 @@ packages:
             jiti:
                 optional: true
 
-    espree@10.4.0:
+    espree@11.2.0:
         resolution:
             {
-                integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==,
+                integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==,
             }
-        engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+        engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
 
     esprima@4.0.1:
         resolution:
@@ -2970,10 +2908,10 @@ packages:
             }
         engines: { node: ">=16" }
 
-    flatted@3.3.3:
+    flatted@3.4.2:
         resolution:
             {
-                integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==,
+                integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==,
             }
 
     format@0.2.2:
@@ -3018,13 +2956,6 @@ packages:
                 integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==,
             }
         engines: { node: ">=10.13.0" }
-
-    globals@14.0.0:
-        resolution:
-            {
-                integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==,
-            }
-        engines: { node: ">=18" }
 
     gray-matter@4.0.3:
         resolution:
@@ -3140,13 +3071,6 @@ packages:
                 integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==,
             }
         engines: { node: ">= 4" }
-
-    import-fresh@3.3.1:
-        resolution:
-            {
-                integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==,
-            }
-        engines: { node: ">=6" }
 
     import-without-cache@0.4.0:
         resolution:
@@ -3297,13 +3221,6 @@ packages:
         resolution:
             {
                 integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==,
-            }
-        hasBin: true
-
-    js-yaml@4.1.1:
-        resolution:
-            {
-                integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==,
             }
         hasBin: true
 
@@ -3506,12 +3423,6 @@ packages:
                 integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==,
             }
         engines: { node: ">=10" }
-
-    lodash.merge@4.6.2:
-        resolution:
-            {
-                integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==,
-            }
 
     lodash@4.18.1:
         resolution:
@@ -3955,12 +3866,6 @@ packages:
             }
         engines: { node: 18 || 20 || >=22 }
 
-    minimatch@3.1.2:
-        resolution:
-            {
-                integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==,
-            }
-
     minisearch@7.2.0:
         resolution:
             {
@@ -4073,13 +3978,6 @@ packages:
                 integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==,
             }
         engines: { node: ">=18" }
-
-    parent-module@1.0.1:
-        resolution:
-            {
-                integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==,
-            }
-        engines: { node: ">=6" }
 
     parse-entities@4.0.2:
         resolution:
@@ -4380,13 +4278,6 @@ packages:
                 integrity: sha512-oyrU88skkMtDdauHDuKVrgR+zuItqr6/c//FXzvmxRGMexSDc6hNvJInGW3LL46n+8b50RykrvwSUIIQH2LQ5A==,
             }
 
-    resolve-from@4.0.0:
-        resolution:
-            {
-                integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==,
-            }
-        engines: { node: ">=4" }
-
     resolve-pkg-maps@1.0.0:
         resolution:
             {
@@ -4629,13 +4520,6 @@ packages:
                 integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==,
             }
         engines: { node: ">=0.10.0" }
-
-    strip-json-comments@3.1.1:
-        resolution:
-            {
-                integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==,
-            }
-        engines: { node: ">=8" }
 
     style-to-js@1.1.21:
         resolution:
@@ -5589,50 +5473,38 @@ snapshots:
     "@esbuild/win32-x64@0.28.1":
         optional: true
 
-    "@eslint-community/eslint-utils@4.9.1(eslint@9.39.2)":
+    "@eslint-community/eslint-utils@4.9.1(eslint@10.5.0)":
         dependencies:
-            eslint: 9.39.2
+            eslint: 10.5.0
             eslint-visitor-keys: 3.4.3
 
     "@eslint-community/regexpp@4.12.2": {}
 
-    "@eslint/config-array@0.21.1":
+    "@eslint/config-array@0.23.5":
         dependencies:
-            "@eslint/object-schema": 2.1.7
+            "@eslint/object-schema": 3.0.5
             debug: 4.4.3
-            minimatch: 3.1.2
+            minimatch: 10.2.5
         transitivePeerDependencies:
             - supports-color
 
-    "@eslint/config-helpers@0.4.2":
+    "@eslint/config-helpers@0.6.0":
         dependencies:
-            "@eslint/core": 0.17.0
+            "@eslint/core": 1.2.1
 
-    "@eslint/core@0.17.0":
+    "@eslint/core@1.2.1":
         dependencies:
             "@types/json-schema": 7.0.15
 
-    "@eslint/eslintrc@3.3.3":
+    "@eslint/js@10.0.1(eslint@10.5.0)":
+        optionalDependencies:
+            eslint: 10.5.0
+
+    "@eslint/object-schema@3.0.5": {}
+
+    "@eslint/plugin-kit@0.7.2":
         dependencies:
-            ajv: 6.12.6
-            debug: 4.4.3
-            espree: 10.4.0
-            globals: 14.0.0
-            ignore: 5.3.2
-            import-fresh: 3.3.1
-            js-yaml: 4.1.1
-            minimatch: 3.1.2
-            strip-json-comments: 3.1.1
-        transitivePeerDependencies:
-            - supports-color
-
-    "@eslint/js@9.39.2": {}
-
-    "@eslint/object-schema@2.1.7": {}
-
-    "@eslint/plugin-kit@0.4.1":
-        dependencies:
-            "@eslint/core": 0.17.0
+            "@eslint/core": 1.2.1
             levn: 0.4.1
 
     "@gerrit0/mini-shiki@3.23.0":
@@ -5643,12 +5515,17 @@ snapshots:
             "@shikijs/types": 3.23.0
             "@shikijs/vscode-textmate": 10.0.2
 
-    "@humanfs/core@0.19.1": {}
-
-    "@humanfs/node@0.16.7":
+    "@humanfs/core@0.19.2":
         dependencies:
-            "@humanfs/core": 0.19.1
+            "@humanfs/types": 0.15.0
+
+    "@humanfs/node@0.16.8":
+        dependencies:
+            "@humanfs/core": 0.19.2
+            "@humanfs/types": 0.15.0
             "@humanwhocodes/retry": 0.4.3
+
+    "@humanfs/types@0.15.0": {}
 
     "@humanwhocodes/module-importer@1.0.1": {}
 
@@ -6114,11 +5991,11 @@ snapshots:
 
     "@types/deep-eql@4.0.2": {}
 
+    "@types/esrecurse@4.3.1": {}
+
     "@types/estree-jsx@1.0.5":
         dependencies:
             "@types/estree": 1.0.9
-
-    "@types/estree@1.0.8": {}
 
     "@types/estree@1.0.9": {}
 
@@ -6156,15 +6033,15 @@ snapshots:
 
     "@types/unist@3.0.3": {}
 
-    "@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3)":
+    "@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0)(typescript@5.9.3)":
         dependencies:
             "@eslint-community/regexpp": 4.12.2
-            "@typescript-eslint/parser": 8.61.1(eslint@9.39.2)(typescript@5.9.3)
+            "@typescript-eslint/parser": 8.61.1(eslint@10.5.0)(typescript@5.9.3)
             "@typescript-eslint/scope-manager": 8.61.1
-            "@typescript-eslint/type-utils": 8.61.1(eslint@9.39.2)(typescript@5.9.3)
-            "@typescript-eslint/utils": 8.61.1(eslint@9.39.2)(typescript@5.9.3)
+            "@typescript-eslint/type-utils": 8.61.1(eslint@10.5.0)(typescript@5.9.3)
+            "@typescript-eslint/utils": 8.61.1(eslint@10.5.0)(typescript@5.9.3)
             "@typescript-eslint/visitor-keys": 8.61.1
-            eslint: 9.39.2
+            eslint: 10.5.0
             ignore: 7.0.5
             natural-compare: 1.4.0
             ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -6172,14 +6049,14 @@ snapshots:
         transitivePeerDependencies:
             - supports-color
 
-    "@typescript-eslint/parser@8.61.1(eslint@9.39.2)(typescript@5.9.3)":
+    "@typescript-eslint/parser@8.61.1(eslint@10.5.0)(typescript@5.9.3)":
         dependencies:
             "@typescript-eslint/scope-manager": 8.61.1
             "@typescript-eslint/types": 8.61.1
             "@typescript-eslint/typescript-estree": 8.61.1(typescript@5.9.3)
             "@typescript-eslint/visitor-keys": 8.61.1
             debug: 4.4.3
-            eslint: 9.39.2
+            eslint: 10.5.0
             typescript: 5.9.3
         transitivePeerDependencies:
             - supports-color
@@ -6202,13 +6079,13 @@ snapshots:
         dependencies:
             typescript: 5.9.3
 
-    "@typescript-eslint/type-utils@8.61.1(eslint@9.39.2)(typescript@5.9.3)":
+    "@typescript-eslint/type-utils@8.61.1(eslint@10.5.0)(typescript@5.9.3)":
         dependencies:
             "@typescript-eslint/types": 8.61.1
             "@typescript-eslint/typescript-estree": 8.61.1(typescript@5.9.3)
-            "@typescript-eslint/utils": 8.61.1(eslint@9.39.2)(typescript@5.9.3)
+            "@typescript-eslint/utils": 8.61.1(eslint@10.5.0)(typescript@5.9.3)
             debug: 4.4.3
-            eslint: 9.39.2
+            eslint: 10.5.0
             ts-api-utils: 2.5.0(typescript@5.9.3)
             typescript: 5.9.3
         transitivePeerDependencies:
@@ -6231,13 +6108,13 @@ snapshots:
         transitivePeerDependencies:
             - supports-color
 
-    "@typescript-eslint/utils@8.61.1(eslint@9.39.2)(typescript@5.9.3)":
+    "@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3)":
         dependencies:
-            "@eslint-community/eslint-utils": 4.9.1(eslint@9.39.2)
+            "@eslint-community/eslint-utils": 4.9.1(eslint@10.5.0)
             "@typescript-eslint/scope-manager": 8.61.1
             "@typescript-eslint/types": 8.61.1
             "@typescript-eslint/typescript-estree": 8.61.1(typescript@5.9.3)
-            eslint: 9.39.2
+            eslint: 10.5.0
             typescript: 5.9.3
         transitivePeerDependencies:
             - supports-color
@@ -6405,19 +6282,13 @@ snapshots:
             convert-source-map: 2.0.0
             tinyrainbow: 3.1.0
 
-    acorn-jsx@5.3.2(acorn@8.15.0):
-        dependencies:
-            acorn: 8.15.0
-
     acorn-jsx@5.3.2(acorn@8.17.0):
         dependencies:
             acorn: 8.17.0
 
-    acorn@8.15.0: {}
-
     acorn@8.17.0: {}
 
-    ajv@6.12.6:
+    ajv@6.15.0:
         dependencies:
             fast-deep-equal: 3.1.3
             fast-json-stable-stringify: 2.1.0
@@ -6429,10 +6300,6 @@ snapshots:
             environment: 1.1.0
 
     ansi-regex@6.2.2: {}
-
-    ansi-styles@4.3.0:
-        dependencies:
-            color-convert: 2.0.1
 
     ansi-styles@6.2.3: {}
 
@@ -6531,18 +6398,11 @@ snapshots:
 
     bail@2.0.2: {}
 
-    balanced-match@1.0.2: {}
-
     balanced-match@4.0.4: {}
 
     baseline-browser-mapping@2.10.37: {}
 
     birpc@4.0.0: {}
-
-    brace-expansion@1.1.12:
-        dependencies:
-            balanced-match: 1.0.2
-            concat-map: 0.0.1
 
     brace-expansion@5.0.6:
         dependencies:
@@ -6564,18 +6424,11 @@ snapshots:
 
     cac@7.0.0: {}
 
-    callsites@3.1.0: {}
-
     caniuse-lite@1.0.30001799: {}
 
     ccount@2.0.1: {}
 
     chai@6.2.2: {}
-
-    chalk@4.1.2:
-        dependencies:
-            ansi-styles: 4.3.0
-            supports-color: 7.2.0
 
     character-entities-html4@2.1.0: {}
 
@@ -6600,19 +6453,11 @@ snapshots:
 
     collapse-white-space@2.1.0: {}
 
-    color-convert@2.0.1:
-        dependencies:
-            color-name: 1.1.4
-
-    color-name@1.1.4: {}
-
     colorette@2.0.20: {}
 
     comma-separated-tokens@2.0.3: {}
 
     commander@14.0.3: {}
-
-    concat-map@0.0.1: {}
 
     confbox@0.1.8: {}
 
@@ -6754,43 +6599,40 @@ snapshots:
 
     escape-string-regexp@5.0.0: {}
 
-    eslint-config-prettier@10.1.8(eslint@9.39.2):
+    eslint-config-prettier@10.1.8(eslint@10.5.0):
         dependencies:
-            eslint: 9.39.2
+            eslint: 10.5.0
 
-    eslint-scope@8.4.0:
+    eslint-scope@9.1.2:
         dependencies:
+            "@types/esrecurse": 4.3.1
+            "@types/estree": 1.0.9
             esrecurse: 4.3.0
             estraverse: 5.3.0
 
     eslint-visitor-keys@3.4.3: {}
 
-    eslint-visitor-keys@4.2.1: {}
-
     eslint-visitor-keys@5.0.1: {}
 
-    eslint@9.39.2:
+    eslint@10.5.0:
         dependencies:
-            "@eslint-community/eslint-utils": 4.9.1(eslint@9.39.2)
+            "@eslint-community/eslint-utils": 4.9.1(eslint@10.5.0)
             "@eslint-community/regexpp": 4.12.2
-            "@eslint/config-array": 0.21.1
-            "@eslint/config-helpers": 0.4.2
-            "@eslint/core": 0.17.0
-            "@eslint/eslintrc": 3.3.3
-            "@eslint/js": 9.39.2
-            "@eslint/plugin-kit": 0.4.1
-            "@humanfs/node": 0.16.7
+            "@eslint/config-array": 0.23.5
+            "@eslint/config-helpers": 0.6.0
+            "@eslint/core": 1.2.1
+            "@eslint/plugin-kit": 0.7.2
+            "@humanfs/node": 0.16.8
             "@humanwhocodes/module-importer": 1.0.1
             "@humanwhocodes/retry": 0.4.3
-            "@types/estree": 1.0.8
-            ajv: 6.12.6
-            chalk: 4.1.2
+            "@types/estree": 1.0.9
+            ajv: 6.15.0
             cross-spawn: 7.0.6
             debug: 4.4.3
             escape-string-regexp: 4.0.0
-            eslint-scope: 8.4.0
-            eslint-visitor-keys: 4.2.1
-            espree: 10.4.0
+            eslint-scope: 9.1.2
+            eslint-visitor-keys: 5.0.1
+            espree: 11.2.0
             esquery: 1.7.0
             esutils: 2.0.3
             fast-deep-equal: 3.1.3
@@ -6801,18 +6643,17 @@ snapshots:
             imurmurhash: 0.1.4
             is-glob: 4.0.3
             json-stable-stringify-without-jsonify: 1.0.1
-            lodash.merge: 4.6.2
-            minimatch: 3.1.2
+            minimatch: 10.2.5
             natural-compare: 1.4.0
             optionator: 0.9.4
         transitivePeerDependencies:
             - supports-color
 
-    espree@10.4.0:
+    espree@11.2.0:
         dependencies:
-            acorn: 8.15.0
-            acorn-jsx: 5.3.2(acorn@8.15.0)
-            eslint-visitor-keys: 4.2.1
+            acorn: 8.17.0
+            acorn-jsx: 5.3.2(acorn@8.17.0)
+            eslint-visitor-keys: 5.0.1
 
     esprima@4.0.1: {}
 
@@ -6917,10 +6758,10 @@ snapshots:
 
     flat-cache@4.0.1:
         dependencies:
-            flatted: 3.3.3
+            flatted: 3.4.2
             keyv: 4.5.4
 
-    flatted@3.3.3: {}
+    flatted@3.4.2: {}
 
     format@0.2.2: {}
 
@@ -6938,8 +6779,6 @@ snapshots:
     glob-parent@6.0.2:
         dependencies:
             is-glob: 4.0.3
-
-    globals@14.0.0: {}
 
     gray-matter@4.0.3:
         dependencies:
@@ -7061,11 +6900,6 @@ snapshots:
 
     ignore@7.0.5: {}
 
-    import-fresh@3.3.1:
-        dependencies:
-            parent-module: 1.0.1
-            resolve-from: 4.0.0
-
     import-without-cache@0.4.0: {}
 
     imurmurhash@0.1.4: {}
@@ -7128,10 +6962,6 @@ snapshots:
         dependencies:
             argparse: 1.0.10
             esprima: 4.0.1
-
-    js-yaml@4.1.1:
-        dependencies:
-            argparse: 2.0.1
 
     jsesc@3.0.2: {}
 
@@ -7231,8 +7061,6 @@ snapshots:
     locate-path@6.0.0:
         dependencies:
             p-locate: 5.0.0
-
-    lodash.merge@4.6.2: {}
 
     lodash@4.18.1: {}
 
@@ -7749,10 +7577,6 @@ snapshots:
         dependencies:
             brace-expansion: 5.0.6
 
-    minimatch@3.1.2:
-        dependencies:
-            brace-expansion: 1.1.12
-
     minisearch@7.2.0: {}
 
     mlly@1.8.2:
@@ -7812,10 +7636,6 @@ snapshots:
             p-limit: 3.1.0
 
     p-map@7.0.4: {}
-
-    parent-module@1.0.1:
-        dependencies:
-            callsites: 3.1.0
 
     parse-entities@4.0.2:
         dependencies:
@@ -8036,8 +7856,6 @@ snapshots:
 
     require-like@0.1.2: {}
 
-    resolve-from@4.0.0: {}
-
     resolve-pkg-maps@1.0.0: {}
 
     restore-cursor@5.1.0:
@@ -8225,8 +8043,6 @@ snapshots:
 
     strip-bom-string@1.0.0: {}
 
-    strip-json-comments@3.1.1: {}
-
     style-to-js@1.1.21:
         dependencies:
             style-to-object: 1.0.14
@@ -8324,13 +8140,13 @@ snapshots:
             typescript: 5.9.3
             yaml: 2.9.0
 
-    typescript-eslint@8.61.1(eslint@9.39.2)(typescript@5.9.3):
+    typescript-eslint@8.61.1(eslint@10.5.0)(typescript@5.9.3):
         dependencies:
-            "@typescript-eslint/eslint-plugin": 8.61.1(@typescript-eslint/parser@8.61.1(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3)
-            "@typescript-eslint/parser": 8.61.1(eslint@9.39.2)(typescript@5.9.3)
+            "@typescript-eslint/eslint-plugin": 8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0)(typescript@5.9.3)
+            "@typescript-eslint/parser": 8.61.1(eslint@10.5.0)(typescript@5.9.3)
             "@typescript-eslint/typescript-estree": 8.61.1(typescript@5.9.3)
-            "@typescript-eslint/utils": 8.61.1(eslint@9.39.2)(typescript@5.9.3)
-            eslint: 9.39.2
+            "@typescript-eslint/utils": 8.61.1(eslint@10.5.0)(typescript@5.9.3)
+            eslint: 10.5.0
             typescript: 5.9.3
         transitivePeerDependencies:
             - supports-color


### PR DESCRIPTION
## Dependency group
- Packages: `eslint` 9.39.2 -> 10.5.0, `@eslint/js` 9.39.2 -> 10.0.1
- Why grouped: same ESLint runtime and recommended-config surface.

## Upstream changes that matter here
- ESLint 10 changes the recommended-rule surface enough that `no-useless-assignment` now reports the ported SheetJS-style mutation/state assignments in `src/`.
- `@eslint/js` stays paired with the ESLint major so the recommended config and runtime agree.
- Source: https://github.com/eslint/eslint/releases/tag/v10.5.0

## Local impact and code changes
- Existing usage checked: `eslint.config.js`, `package.json` scripts, and the `src/` lint surface.
- Required migration: disabled `no-useless-assignment` with an explanatory comment because the ported code intentionally keeps mutation/state assignment style.
- Beneficial adoption: none beyond taking ESLint 10; avoiding a broad ported-code rewrite keeps this PR focused on the toolchain update.

## Validation
- `pnpm install --frozen-lockfile`: passed after rebase
- `pnpm run lint`: passed after rebase
- `pnpm run verify`: format, lint, check, coverage, and build passed; sandbox DNS blocked the external `pnpm dlx publint` step
- `pnpm run package:check`: passed with network access
- `pnpm --filter docs build`: passed

## Risk
- Lint/config risk only. The new recommended rule is intentionally not enabled because applying it would turn a dependency update into a broad rewrite of ported code.