### PR TITLE
[codex] Update lint-staged to v17

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		"eslint": "^10.5.0",
 		"eslint-config-prettier": "^10.1.8",
 		"husky": "^9.1.7",
-		"lint-staged": "^16.2.7",
+		"lint-staged": "^17.0.7",
 		"prettier": "^3.8.4",
 		"tsdown": "^0.22.3",
 		"tsx": "^4.22.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,8 +26,8 @@ importers:
                 specifier: ^9.1.7
                 version: 9.1.7
             lint-staged:
-                specifier: ^16.2.7
-                version: 16.2.7
+                specifier: ^17.0.7
+                version: 17.0.7
             prettier:
                 specifier: ^3.8.4
                 version: 3.8.4
@@ -51,7 +51,7 @@ importers:
         dependencies:
             ardo:
                 specifier: ^3.5.0
-                version: 3.5.0(@types/node@25.9.3)(esbuild@0.28.1)(lightningcss@1.32.0)(lucide-react@1.20.0(react@19.2.7))(rollup@4.62.0)(tsx@4.22.4)(typescript@5.9.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.2))(yaml@2.9.0)
+                version: 3.5.0(@types/node@25.9.3)(esbuild@0.28.1)(lightningcss@1.32.0)(lucide-react@1.20.0(react@19.2.7))(rollup@4.62.0)(tsx@4.22.4)(typescript@5.9.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))(yaml@2.9.0)
             isbot:
                 specifier: ^5.1.43
                 version: 5.1.43
@@ -70,7 +70,7 @@ importers:
         devDependencies:
             "@react-router/dev":
                 specifier: ^7.18.0
-                version: 7.18.0(@types/node@25.9.3)(lightningcss@1.32.0)(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(tsx@4.22.4)(typescript@5.9.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.2))(yaml@2.9.0)
+                version: 7.18.0(@types/node@25.9.3)(lightningcss@1.32.0)(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(tsx@4.22.4)(typescript@5.9.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))(yaml@2.9.0)
             "@types/react":
                 specifier: ^19.2.17
                 version: 19.2.17
@@ -82,7 +82,7 @@ importers:
                 version: 5.9.3
             vite:
                 specifier: ^8.0.16
-                version: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.2)
+                version: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
 
 packages:
     "@babel/code-frame@7.29.7":
@@ -2301,13 +2301,6 @@ packages:
             }
         engines: { node: 18 || 20 || >=22 }
 
-    braces@3.0.3:
-        resolution:
-            {
-                integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==,
-            }
-        engines: { node: ">=8" }
-
     browserslist@4.28.2:
         resolution:
             {
@@ -2387,10 +2380,10 @@ packages:
             }
         engines: { node: ">=18" }
 
-    cli-truncate@5.1.1:
+    cli-truncate@5.2.0:
         resolution:
             {
-                integrity: sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A==,
+                integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==,
             }
         engines: { node: ">=20" }
 
@@ -2398,6 +2391,19 @@ packages:
         resolution:
             {
                 integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==,
+            }
+
+    color-convert@2.0.1:
+        resolution:
+            {
+                integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==,
+            }
+        engines: { node: ">=7.0.0" }
+
+    color-name@1.1.4:
+        resolution:
+            {
+                integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==,
             }
 
     colorette@2.0.20:
@@ -2418,6 +2424,12 @@ packages:
                 integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==,
             }
         engines: { node: ">=20" }
+
+    concat-map@0.0.1:
+        resolution:
+            {
+                integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==,
+            }
 
     confbox@0.1.8:
         resolution:
@@ -2880,13 +2892,6 @@ packages:
             }
         engines: { node: ">=16.0.0" }
 
-    fill-range@7.1.1:
-        resolution:
-            {
-                integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==,
-            }
-        engines: { node: ">=8" }
-
     find-up-simple@1.0.1:
         resolution:
             {
@@ -2936,10 +2941,10 @@ packages:
             }
         engines: { node: ">=6.9.0" }
 
-    get-east-asian-width@1.4.0:
+    get-east-asian-width@1.6.0:
         resolution:
             {
-                integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==,
+                integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==,
             }
         engines: { node: ">=18" }
 
@@ -3150,13 +3155,6 @@ packages:
             {
                 integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==,
             }
-
-    is-number@7.0.0:
-        resolution:
-            {
-                integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==,
-            }
-        engines: { node: ">=0.12.0" }
 
     is-plain-obj@4.1.0:
         resolution:
@@ -3402,20 +3400,20 @@ packages:
                 integrity: sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==,
             }
 
-    lint-staged@16.2.7:
+    lint-staged@17.0.7:
         resolution:
             {
-                integrity: sha512-lDIj4RnYmK7/kXMya+qJsmkRFkGolciXjrsZ6PC25GdTfWOAWetR0ZbsNXRAj1EHHImRSalc+whZFg56F5DVow==,
+                integrity: sha512-JrSobt+tW3rH8IOMi8tDZd3foorM5yPEkLD/V2NxobgHrFfHWGee4MOLVuZeScgxftEwbHrPHIFA/ZL+nUJeuA==,
             }
-        engines: { node: ">=20.17" }
+        engines: { node: ">=22.22.1" }
         hasBin: true
 
-    listr2@9.0.5:
+    listr2@10.2.1:
         resolution:
             {
-                integrity: sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==,
+                integrity: sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q==,
             }
-        engines: { node: ">=20.0.0" }
+        engines: { node: ">=22.13.0" }
 
     locate-path@6.0.0:
         resolution:
@@ -3845,13 +3843,6 @@ packages:
                 integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==,
             }
 
-    micromatch@4.0.8:
-        resolution:
-            {
-                integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==,
-            }
-        engines: { node: ">=8.6" }
-
     mimic-function@5.0.1:
         resolution:
             {
@@ -3889,13 +3880,6 @@ packages:
             {
                 integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==,
             }
-
-    nano-spawn@2.0.0:
-        resolution:
-            {
-                integrity: sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw==,
-            }
-        engines: { node: ">=20.17" }
 
     nanoid@3.3.12:
         resolution:
@@ -4030,27 +4014,12 @@ packages:
                 integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==,
             }
 
-    picomatch@2.3.1:
-        resolution:
-            {
-                integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==,
-            }
-        engines: { node: ">=8.6" }
-
     picomatch@4.0.4:
         resolution:
             {
                 integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==,
             }
         engines: { node: ">=12" }
-
-    pidtree@0.6.0:
-        resolution:
-            {
-                integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==,
-            }
-        engines: { node: ">=0.10" }
-        hasBin: true
 
     pkg-types@1.3.1:
         resolution:
@@ -4418,6 +4387,13 @@ packages:
             }
         engines: { node: ">=18" }
 
+    slice-ansi@8.0.0:
+        resolution:
+            {
+                integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==,
+            }
+        engines: { node: ">=20" }
+
     source-map-js@1.2.1:
         resolution:
             {
@@ -4494,10 +4470,10 @@ packages:
             }
         engines: { node: ">=18" }
 
-    string-width@8.1.1:
+    string-width@8.2.1:
         resolution:
             {
-                integrity: sha512-KpqHIdDL9KwYk22wEOg/VIqYbrnLeSApsKT/bSj6Ez7pn3CftUiLAv2Lccpq1ALcpLV9UX1Ppn92npZWu2w/aw==,
+                integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==,
             }
         engines: { node: ">=20" }
 
@@ -4507,10 +4483,10 @@ packages:
                 integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==,
             }
 
-    strip-ansi@7.1.2:
+    strip-ansi@7.2.0:
         resolution:
             {
-                integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==,
+                integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==,
             }
         engines: { node: ">=12" }
 
@@ -4579,13 +4555,6 @@ packages:
                 integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==,
             }
         engines: { node: ">=14.0.0" }
-
-    to-regex-range@5.0.1:
-        resolution:
-            {
-                integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==,
-            }
-        engines: { node: ">=8.0" }
 
     toml@3.0.0:
         resolution:
@@ -5028,6 +4997,13 @@ packages:
             }
         engines: { node: ">=0.10.0" }
 
+    wrap-ansi@10.0.0:
+        resolution:
+            {
+                integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==,
+            }
+        engines: { node: ">=20" }
+
     wrap-ansi@9.0.2:
         resolution:
             {
@@ -5040,14 +5016,6 @@ packages:
             {
                 integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==,
             }
-
-    yaml@2.8.2:
-        resolution:
-            {
-                integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==,
-            }
-        engines: { node: ">= 14.6" }
-        hasBin: true
 
     yaml@2.9.0:
         resolution:
@@ -5614,7 +5582,7 @@ snapshots:
         dependencies:
             quansync: 1.0.0
 
-    "@react-router/dev@7.18.0(@types/node@25.9.3)(lightningcss@1.32.0)(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(tsx@4.22.4)(typescript@5.9.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.2))(yaml@2.9.0)":
+    "@react-router/dev@7.18.0(@types/node@25.9.3)(lightningcss@1.32.0)(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(tsx@4.22.4)(typescript@5.9.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))(yaml@2.9.0)":
         dependencies:
             "@babel/core": 7.29.7
             "@babel/generator": 7.29.7
@@ -5644,7 +5612,7 @@ snapshots:
             semver: 7.8.4
             tinyglobby: 0.2.17
             valibot: 1.4.1(typescript@5.9.3)
-            vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.2)
+            vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
             vite-node: 3.2.4(@types/node@25.9.3)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
         optionalDependencies:
             typescript: 5.9.3
@@ -6201,11 +6169,11 @@ snapshots:
         dependencies:
             "@vanilla-extract/css": 1.20.1
 
-    "@vanilla-extract/vite-plugin@5.2.2(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.2))(yaml@2.9.0)":
+    "@vanilla-extract/vite-plugin@5.2.2(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))(yaml@2.9.0)":
         dependencies:
             "@vanilla-extract/compiler": 0.7.0(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
             "@vanilla-extract/integration": 8.0.10
-            vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.2)
+            vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
         transitivePeerDependencies:
             - "@types/node"
             - "@vitejs/devtools"
@@ -6222,10 +6190,10 @@ snapshots:
             - tsx
             - yaml
 
-    "@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.2))":
+    "@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))":
         dependencies:
             "@rolldown/pluginutils": 1.0.1
-            vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.2)
+            vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
 
     "@vitest/coverage-v8@4.1.9(vitest@4.1.9)":
         dependencies:
@@ -6305,17 +6273,17 @@ snapshots:
 
     ansis@4.3.1: {}
 
-    ardo@3.5.0(@types/node@25.9.3)(esbuild@0.28.1)(lightningcss@1.32.0)(lucide-react@1.20.0(react@19.2.7))(rollup@4.62.0)(tsx@4.22.4)(typescript@5.9.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.2))(yaml@2.9.0):
+    ardo@3.5.0(@types/node@25.9.3)(esbuild@0.28.1)(lightningcss@1.32.0)(lucide-react@1.20.0(react@19.2.7))(rollup@4.62.0)(tsx@4.22.4)(typescript@5.9.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))(yaml@2.9.0):
         dependencies:
             "@mdx-js/rollup": 3.1.1(rollup@4.62.0)
-            "@react-router/dev": 7.18.0(@types/node@25.9.3)(lightningcss@1.32.0)(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(tsx@4.22.4)(typescript@5.9.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.2))(yaml@2.9.0)
+            "@react-router/dev": 7.18.0(@types/node@25.9.3)(lightningcss@1.32.0)(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(tsx@4.22.4)(typescript@5.9.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))(yaml@2.9.0)
             "@resvg/resvg-js": 2.6.2
             "@shikijs/rehype": 4.2.0
             "@vanilla-extract/css": 1.20.1
             "@vanilla-extract/esbuild-plugin": 2.3.22(esbuild@0.28.1)
             "@vanilla-extract/recipes": 0.5.7(@vanilla-extract/css@1.20.1)
-            "@vanilla-extract/vite-plugin": 5.2.2(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.2))(yaml@2.9.0)
-            "@vitejs/plugin-react": 6.0.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.2))
+            "@vanilla-extract/vite-plugin": 5.2.2(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))(yaml@2.9.0)
+            "@vitejs/plugin-react": 6.0.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))
             gray-matter: 4.0.3
             hast-util-to-jsx-runtime: 2.3.6
             minisearch: 7.2.0
@@ -6335,7 +6303,7 @@ snapshots:
             typedoc: 0.28.19(typescript@5.9.3)
             unified: 11.0.5
             unist-util-visit: 5.1.0
-            vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.2)
+            vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
         optionalDependencies:
             lucide-react: 1.20.0(react@19.2.7)
         transitivePeerDependencies:
@@ -6408,10 +6376,6 @@ snapshots:
         dependencies:
             balanced-match: 4.0.4
 
-    braces@3.0.3:
-        dependencies:
-            fill-range: 7.1.1
-
     browserslist@4.28.2:
         dependencies:
             baseline-browser-mapping: 2.10.37
@@ -6446,18 +6410,26 @@ snapshots:
         dependencies:
             restore-cursor: 5.1.0
 
-    cli-truncate@5.1.1:
+    cli-truncate@5.2.0:
         dependencies:
-            slice-ansi: 7.1.2
-            string-width: 8.1.1
+            slice-ansi: 8.0.0
+            string-width: 8.2.1
 
     collapse-white-space@2.1.0: {}
+
+    color-convert@2.0.1:
+        dependencies:
+            color-name: 1.1.4
+
+    color-name@1.1.4: {}
 
     colorette@2.0.20: {}
 
     comma-separated-tokens@2.0.3: {}
 
     commander@14.0.3: {}
+
+    concat-map@0.0.1: {}
 
     confbox@0.1.8: {}
 
@@ -6745,10 +6717,6 @@ snapshots:
         dependencies:
             flat-cache: 4.0.1
 
-    fill-range@7.1.1:
-        dependencies:
-            to-regex-range: 5.0.1
-
     find-up-simple@1.0.1: {}
 
     find-up@5.0.0:
@@ -6770,7 +6738,7 @@ snapshots:
 
     gensync@1.0.0-beta.2: {}
 
-    get-east-asian-width@1.4.0: {}
+    get-east-asian-width@1.6.0: {}
 
     get-tsconfig@5.0.0-beta.5:
         dependencies:
@@ -6923,15 +6891,13 @@ snapshots:
 
     is-fullwidth-code-point@5.1.0:
         dependencies:
-            get-east-asian-width: 1.4.0
+            get-east-asian-width: 1.6.0
 
     is-glob@4.0.3:
         dependencies:
             is-extglob: 2.1.1
 
     is-hexadecimal@2.0.1: {}
-
-    is-number@7.0.0: {}
 
     is-plain-obj@4.1.0: {}
 
@@ -7039,24 +7005,22 @@ snapshots:
         dependencies:
             uc.micro: 2.1.0
 
-    lint-staged@16.2.7:
+    lint-staged@17.0.7:
         dependencies:
-            commander: 14.0.3
-            listr2: 9.0.5
-            micromatch: 4.0.8
-            nano-spawn: 2.0.0
-            pidtree: 0.6.0
+            listr2: 10.2.1
+            picomatch: 4.0.4
             string-argv: 0.3.2
-            yaml: 2.8.2
+            tinyexec: 1.2.4
+        optionalDependencies:
+            yaml: 2.9.0
 
-    listr2@9.0.5:
+    listr2@10.2.1:
         dependencies:
-            cli-truncate: 5.1.1
-            colorette: 2.0.20
+            cli-truncate: 5.2.0
             eventemitter3: 5.0.4
             log-update: 6.1.0
             rfdc: 1.4.1
-            wrap-ansi: 9.0.2
+            wrap-ansi: 10.0.0
 
     locate-path@6.0.0:
         dependencies:
@@ -7069,7 +7033,7 @@ snapshots:
             ansi-escapes: 7.3.0
             cli-cursor: 5.0.0
             slice-ansi: 7.1.2
-            strip-ansi: 7.1.2
+            strip-ansi: 7.2.0
             wrap-ansi: 9.0.2
 
     longest-streak@3.1.0: {}
@@ -7566,11 +7530,6 @@ snapshots:
         transitivePeerDependencies:
             - supports-color
 
-    micromatch@4.0.8:
-        dependencies:
-            braces: 3.0.3
-            picomatch: 2.3.1
-
     mimic-function@5.0.1: {}
 
     minimatch@10.2.5:
@@ -7589,8 +7548,6 @@ snapshots:
     modern-ahocorasick@1.1.0: {}
 
     ms@2.1.3: {}
-
-    nano-spawn@2.0.0: {}
 
     nanoid@3.3.12: {}
 
@@ -7667,11 +7624,7 @@ snapshots:
 
     picocolors@1.1.1: {}
 
-    picomatch@2.3.1: {}
-
     picomatch@4.0.4: {}
-
-    pidtree@0.6.0: {}
 
     pkg-types@1.3.1:
         dependencies:
@@ -7993,6 +7946,11 @@ snapshots:
             ansi-styles: 6.2.3
             is-fullwidth-code-point: 5.1.0
 
+    slice-ansi@8.0.0:
+        dependencies:
+            ansi-styles: 6.2.3
+            is-fullwidth-code-point: 5.1.0
+
     source-map-js@1.2.1: {}
 
     source-map@0.7.6: {}
@@ -8024,20 +7982,20 @@ snapshots:
     string-width@7.2.0:
         dependencies:
             emoji-regex: 10.6.0
-            get-east-asian-width: 1.4.0
-            strip-ansi: 7.1.2
+            get-east-asian-width: 1.6.0
+            strip-ansi: 7.2.0
 
-    string-width@8.1.1:
+    string-width@8.2.1:
         dependencies:
-            get-east-asian-width: 1.4.0
-            strip-ansi: 7.1.2
+            get-east-asian-width: 1.6.0
+            strip-ansi: 7.2.0
 
     stringify-entities@4.0.4:
         dependencies:
             character-entities-html4: 2.1.0
             character-entities-legacy: 3.0.0
 
-    strip-ansi@7.1.2:
+    strip-ansi@7.2.0:
         dependencies:
             ansi-regex: 6.2.2
 
@@ -8069,10 +8027,6 @@ snapshots:
             picomatch: 4.0.4
 
     tinyrainbow@3.1.0: {}
-
-    to-regex-range@5.0.1:
-        dependencies:
-            is-number: 7.0.0
 
     toml@3.0.0: {}
 
@@ -8304,20 +8258,6 @@ snapshots:
             tsx: 4.22.4
             yaml: 2.9.0
 
-    vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.2):
-        dependencies:
-            lightningcss: 1.32.0
-            picomatch: 4.0.4
-            postcss: 8.5.15
-            rolldown: 1.0.3
-            tinyglobby: 0.2.17
-        optionalDependencies:
-            "@types/node": 25.9.3
-            esbuild: 0.28.1
-            fsevents: 2.3.3
-            tsx: 4.22.4
-            yaml: 2.8.2
-
     vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0):
         dependencies:
             lightningcss: 1.32.0
@@ -8373,15 +8313,19 @@ snapshots:
 
     word-wrap@1.2.5: {}
 
+    wrap-ansi@10.0.0:
+        dependencies:
+            ansi-styles: 6.2.3
+            string-width: 8.2.1
+            strip-ansi: 7.2.0
+
     wrap-ansi@9.0.2:
         dependencies:
             ansi-styles: 6.2.3
             string-width: 7.2.0
-            strip-ansi: 7.1.2
+            strip-ansi: 7.2.0
 
     yallist@3.1.1: {}
-
-    yaml@2.8.2: {}
 
     yaml@2.9.0: {}
 


### PR DESCRIPTION
## Dependency group
- Packages: `lint-staged` 16.2.7 -> 17.0.7
- Why grouped: single major update with its own Git hook and CLI behavior surface.

## Upstream changes that matter here
- lint-staged 17 raises the runtime floor to Node >=22.22.1 and keeps the Git requirement at a modern baseline.
- YAML config support is now optional. This repository uses the root `package.json` lint-staged config, so no YAML migration is needed.
- The CLI internals moved to Node `parseArgs` and the task matcher/runtime stack now uses newer matcher/process helpers.
- Source: https://github.com/lint-staged/lint-staged/releases/tag/v17.0.7

## Local impact and code changes
- Existing usage checked: root `package.json` lint-staged config, package scripts, and docs workspace manifests.
- Required migration: none.
- Beneficial adoption: none; the current config remains valid under v17.

## Validation
- `pnpm exec lint-staged --version`: 17.0.7
- `pnpm install --frozen-lockfile`: passed
- `pnpm exec lint-staged`: passed with git write access; earlier sandbox-only failures were index-lock restrictions, not lint-staged behavior
- `pnpm run verify`: format, lint, check, coverage, and build passed; sandbox DNS blocked the external `pnpm dlx publint` step
- `pnpm run package:check`: passed with network access
- `pnpm --filter docs build`: passed
- Rebased onto current `origin/main`; pre-push ran frozen install, TypeScript, ESLint, and Prettier successfully

## Risk
- Git-hook behavior risk. The repo uses the supported package.json config path, so the main review question is whether Node >=22.22.1 is acceptable for local contributor tooling.