### PR TITLE
[codex] Update TypeScript to v6

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -20,7 +20,7 @@
 		"@react-router/dev": "^7.18.0",
 		"@types/react": "^19.2.17",
 		"@types/react-dom": "^19.2.3",
-		"typescript": "^5.9.3",
+		"typescript": "^6.0.3",
 		"vite": "^8.0.16"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 		"prettier": "^3.8.4",
 		"tsdown": "^0.22.3",
 		"tsx": "^4.22.4",
-		"typescript": "^5.9.3",
+		"typescript": "^6.0.3",
 		"typescript-eslint": "^8.61.1",
 		"vitest": "^4.1.9"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,16 +33,16 @@ importers:
                 version: 3.8.4
             tsdown:
                 specifier: ^0.22.3
-                version: 0.22.3(tsx@4.22.4)(typescript@5.9.3)
+                version: 0.22.3(tsx@4.22.4)(typescript@6.0.3)
             tsx:
                 specifier: ^4.22.4
                 version: 4.22.4
             typescript:
-                specifier: ^5.9.3
-                version: 5.9.3
+                specifier: ^6.0.3
+                version: 6.0.3
             typescript-eslint:
                 specifier: ^8.61.1
-                version: 8.61.1(eslint@10.5.0)(typescript@5.9.3)
+                version: 8.61.1(eslint@10.5.0)(typescript@6.0.3)
             vitest:
                 specifier: ^4.1.9
                 version: 4.1.9(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))
@@ -51,7 +51,7 @@ importers:
         dependencies:
             ardo:
                 specifier: ^3.5.0
-                version: 3.5.0(@types/node@25.9.3)(esbuild@0.28.1)(lightningcss@1.32.0)(lucide-react@1.20.0(react@19.2.7))(rollup@4.62.0)(tsx@4.22.4)(typescript@5.9.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))(yaml@2.9.0)
+                version: 3.5.0(@types/node@25.9.3)(esbuild@0.28.1)(lightningcss@1.32.0)(lucide-react@1.20.0(react@19.2.7))(rollup@4.62.0)(tsx@4.22.4)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))(yaml@2.9.0)
             isbot:
                 specifier: ^5.1.43
                 version: 5.1.43
@@ -70,7 +70,7 @@ importers:
         devDependencies:
             "@react-router/dev":
                 specifier: ^7.18.0
-                version: 7.18.0(@types/node@25.9.3)(lightningcss@1.32.0)(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(tsx@4.22.4)(typescript@5.9.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))(yaml@2.9.0)
+                version: 7.18.0(@types/node@25.9.3)(lightningcss@1.32.0)(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(tsx@4.22.4)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))(yaml@2.9.0)
             "@types/react":
                 specifier: ^19.2.17
                 version: 19.2.17
@@ -78,8 +78,8 @@ importers:
                 specifier: ^19.2.3
                 version: 19.2.3(@types/react@19.2.17)
             typescript:
-                specifier: ^5.9.3
-                version: 5.9.3
+                specifier: ^6.0.3
+                version: 6.0.3
             vite:
                 specifier: ^8.0.16
                 version: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
@@ -2393,42 +2393,10 @@ packages:
                 integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==,
             }
 
-    color-convert@2.0.1:
-        resolution:
-            {
-                integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==,
-            }
-        engines: { node: ">=7.0.0" }
-
-    color-name@1.1.4:
-        resolution:
-            {
-                integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==,
-            }
-
-    colorette@2.0.20:
-        resolution:
-            {
-                integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==,
-            }
-
     comma-separated-tokens@2.0.3:
         resolution:
             {
                 integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==,
-            }
-
-    commander@14.0.3:
-        resolution:
-            {
-                integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==,
-            }
-        engines: { node: ">=20" }
-
-    concat-map@0.0.1:
-        resolution:
-            {
-                integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==,
             }
 
     confbox@0.1.8:
@@ -4682,10 +4650,10 @@ packages:
             eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
             typescript: ">=4.8.4 <6.1.0"
 
-    typescript@5.9.3:
+    typescript@6.0.3:
         resolution:
             {
-                integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==,
+                integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==,
             }
         engines: { node: ">=14.17" }
         hasBin: true
@@ -5582,7 +5550,7 @@ snapshots:
         dependencies:
             quansync: 1.0.0
 
-    "@react-router/dev@7.18.0(@types/node@25.9.3)(lightningcss@1.32.0)(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(tsx@4.22.4)(typescript@5.9.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))(yaml@2.9.0)":
+    "@react-router/dev@7.18.0(@types/node@25.9.3)(lightningcss@1.32.0)(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(tsx@4.22.4)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))(yaml@2.9.0)":
         dependencies:
             "@babel/core": 7.29.7
             "@babel/generator": 7.29.7
@@ -5591,7 +5559,7 @@ snapshots:
             "@babel/preset-typescript": 7.29.7(@babel/core@7.29.7)
             "@babel/traverse": 7.29.7
             "@babel/types": 7.29.7
-            "@react-router/node": 7.18.0(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)
+            "@react-router/node": 7.18.0(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)
             "@remix-run/node-fetch-server": 0.13.3
             arg: 5.0.2
             babel-dead-code-elimination: 1.0.12
@@ -5611,11 +5579,11 @@ snapshots:
             react-router: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
             semver: 7.8.4
             tinyglobby: 0.2.17
-            valibot: 1.4.1(typescript@5.9.3)
+            valibot: 1.4.1(typescript@6.0.3)
             vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
             vite-node: 3.2.4(@types/node@25.9.3)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
         optionalDependencies:
-            typescript: 5.9.3
+            typescript: 6.0.3
         transitivePeerDependencies:
             - "@types/node"
             - babel-plugin-macros
@@ -5631,12 +5599,12 @@ snapshots:
             - tsx
             - yaml
 
-    "@react-router/node@7.18.0(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)":
+    "@react-router/node@7.18.0(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)":
         dependencies:
             "@mjackson/node-fetch-server": 0.2.0
             react-router: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
         optionalDependencies:
-            typescript: 5.9.3
+            typescript: 6.0.3
 
     "@remix-run/node-fetch-server@0.13.3": {}
 
@@ -6001,40 +5969,40 @@ snapshots:
 
     "@types/unist@3.0.3": {}
 
-    "@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0)(typescript@5.9.3)":
+    "@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)(typescript@6.0.3)":
         dependencies:
             "@eslint-community/regexpp": 4.12.2
-            "@typescript-eslint/parser": 8.61.1(eslint@10.5.0)(typescript@5.9.3)
+            "@typescript-eslint/parser": 8.61.1(eslint@10.5.0)(typescript@6.0.3)
             "@typescript-eslint/scope-manager": 8.61.1
-            "@typescript-eslint/type-utils": 8.61.1(eslint@10.5.0)(typescript@5.9.3)
-            "@typescript-eslint/utils": 8.61.1(eslint@10.5.0)(typescript@5.9.3)
+            "@typescript-eslint/type-utils": 8.61.1(eslint@10.5.0)(typescript@6.0.3)
+            "@typescript-eslint/utils": 8.61.1(eslint@10.5.0)(typescript@6.0.3)
             "@typescript-eslint/visitor-keys": 8.61.1
             eslint: 10.5.0
             ignore: 7.0.5
             natural-compare: 1.4.0
-            ts-api-utils: 2.5.0(typescript@5.9.3)
-            typescript: 5.9.3
+            ts-api-utils: 2.5.0(typescript@6.0.3)
+            typescript: 6.0.3
         transitivePeerDependencies:
             - supports-color
 
-    "@typescript-eslint/parser@8.61.1(eslint@10.5.0)(typescript@5.9.3)":
+    "@typescript-eslint/parser@8.61.1(eslint@10.5.0)(typescript@6.0.3)":
         dependencies:
             "@typescript-eslint/scope-manager": 8.61.1
             "@typescript-eslint/types": 8.61.1
-            "@typescript-eslint/typescript-estree": 8.61.1(typescript@5.9.3)
+            "@typescript-eslint/typescript-estree": 8.61.1(typescript@6.0.3)
             "@typescript-eslint/visitor-keys": 8.61.1
             debug: 4.4.3
             eslint: 10.5.0
-            typescript: 5.9.3
+            typescript: 6.0.3
         transitivePeerDependencies:
             - supports-color
 
-    "@typescript-eslint/project-service@8.61.1(typescript@5.9.3)":
+    "@typescript-eslint/project-service@8.61.1(typescript@6.0.3)":
         dependencies:
-            "@typescript-eslint/tsconfig-utils": 8.61.1(typescript@5.9.3)
+            "@typescript-eslint/tsconfig-utils": 8.61.1(typescript@6.0.3)
             "@typescript-eslint/types": 8.61.1
             debug: 4.4.3
-            typescript: 5.9.3
+            typescript: 6.0.3
         transitivePeerDependencies:
             - supports-color
 
@@ -6043,47 +6011,47 @@ snapshots:
             "@typescript-eslint/types": 8.61.1
             "@typescript-eslint/visitor-keys": 8.61.1
 
-    "@typescript-eslint/tsconfig-utils@8.61.1(typescript@5.9.3)":
+    "@typescript-eslint/tsconfig-utils@8.61.1(typescript@6.0.3)":
         dependencies:
-            typescript: 5.9.3
+            typescript: 6.0.3
 
-    "@typescript-eslint/type-utils@8.61.1(eslint@10.5.0)(typescript@5.9.3)":
+    "@typescript-eslint/type-utils@8.61.1(eslint@10.5.0)(typescript@6.0.3)":
         dependencies:
             "@typescript-eslint/types": 8.61.1
-            "@typescript-eslint/typescript-estree": 8.61.1(typescript@5.9.3)
-            "@typescript-eslint/utils": 8.61.1(eslint@10.5.0)(typescript@5.9.3)
+            "@typescript-eslint/typescript-estree": 8.61.1(typescript@6.0.3)
+            "@typescript-eslint/utils": 8.61.1(eslint@10.5.0)(typescript@6.0.3)
             debug: 4.4.3
             eslint: 10.5.0
-            ts-api-utils: 2.5.0(typescript@5.9.3)
-            typescript: 5.9.3
+            ts-api-utils: 2.5.0(typescript@6.0.3)
+            typescript: 6.0.3
         transitivePeerDependencies:
             - supports-color
 
     "@typescript-eslint/types@8.61.1": {}
 
-    "@typescript-eslint/typescript-estree@8.61.1(typescript@5.9.3)":
+    "@typescript-eslint/typescript-estree@8.61.1(typescript@6.0.3)":
         dependencies:
-            "@typescript-eslint/project-service": 8.61.1(typescript@5.9.3)
-            "@typescript-eslint/tsconfig-utils": 8.61.1(typescript@5.9.3)
+            "@typescript-eslint/project-service": 8.61.1(typescript@6.0.3)
+            "@typescript-eslint/tsconfig-utils": 8.61.1(typescript@6.0.3)
             "@typescript-eslint/types": 8.61.1
             "@typescript-eslint/visitor-keys": 8.61.1
             debug: 4.4.3
             minimatch: 10.2.5
             semver: 7.8.4
             tinyglobby: 0.2.17
-            ts-api-utils: 2.5.0(typescript@5.9.3)
-            typescript: 5.9.3
+            ts-api-utils: 2.5.0(typescript@6.0.3)
+            typescript: 6.0.3
         transitivePeerDependencies:
             - supports-color
 
-    "@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3)":
+    "@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@6.0.3)":
         dependencies:
             "@eslint-community/eslint-utils": 4.9.1(eslint@10.5.0)
             "@typescript-eslint/scope-manager": 8.61.1
             "@typescript-eslint/types": 8.61.1
-            "@typescript-eslint/typescript-estree": 8.61.1(typescript@5.9.3)
+            "@typescript-eslint/typescript-estree": 8.61.1(typescript@6.0.3)
             eslint: 10.5.0
-            typescript: 5.9.3
+            typescript: 6.0.3
         transitivePeerDependencies:
             - supports-color
 
@@ -6273,10 +6241,10 @@ snapshots:
 
     ansis@4.3.1: {}
 
-    ardo@3.5.0(@types/node@25.9.3)(esbuild@0.28.1)(lightningcss@1.32.0)(lucide-react@1.20.0(react@19.2.7))(rollup@4.62.0)(tsx@4.22.4)(typescript@5.9.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))(yaml@2.9.0):
+    ardo@3.5.0(@types/node@25.9.3)(esbuild@0.28.1)(lightningcss@1.32.0)(lucide-react@1.20.0(react@19.2.7))(rollup@4.62.0)(tsx@4.22.4)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))(yaml@2.9.0):
         dependencies:
             "@mdx-js/rollup": 3.1.1(rollup@4.62.0)
-            "@react-router/dev": 7.18.0(@types/node@25.9.3)(lightningcss@1.32.0)(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(tsx@4.22.4)(typescript@5.9.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))(yaml@2.9.0)
+            "@react-router/dev": 7.18.0(@types/node@25.9.3)(lightningcss@1.32.0)(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(tsx@4.22.4)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))(yaml@2.9.0)
             "@resvg/resvg-js": 2.6.2
             "@shikijs/rehype": 4.2.0
             "@vanilla-extract/css": 1.20.1
@@ -6300,7 +6268,7 @@ snapshots:
             remark-rehype: 11.1.2
             shiki: 4.2.0
             tailwindcss: 4.3.1
-            typedoc: 0.28.19(typescript@5.9.3)
+            typedoc: 0.28.19(typescript@6.0.3)
             unified: 11.0.5
             unist-util-visit: 5.1.0
             vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
@@ -6417,19 +6385,7 @@ snapshots:
 
     collapse-white-space@2.1.0: {}
 
-    color-convert@2.0.1:
-        dependencies:
-            color-name: 1.1.4
-
-    color-name@1.1.4: {}
-
-    colorette@2.0.20: {}
-
     comma-separated-tokens@2.0.3: {}
-
-    commander@14.0.3: {}
-
-    concat-map@0.0.1: {}
 
     confbox@0.1.8: {}
 
@@ -7818,7 +7774,7 @@ snapshots:
 
     rfdc@1.4.1: {}
 
-    rolldown-plugin-dts@0.26.0(rolldown@1.1.1)(typescript@5.9.3):
+    rolldown-plugin-dts@0.26.0(rolldown@1.1.1)(typescript@6.0.3):
         dependencies:
             "@babel/generator": 8.0.0
             "@babel/helper-validator-identifier": 8.0.0
@@ -7830,7 +7786,7 @@ snapshots:
             obug: 2.1.3
             rolldown: 1.1.1
         optionalDependencies:
-            typescript: 5.9.3
+            typescript: 6.0.3
         transitivePeerDependencies:
             - oxc-resolver
 
@@ -8036,11 +7992,11 @@ snapshots:
 
     trough@2.2.0: {}
 
-    ts-api-utils@2.5.0(typescript@5.9.3):
+    ts-api-utils@2.5.0(typescript@6.0.3):
         dependencies:
-            typescript: 5.9.3
+            typescript: 6.0.3
 
-    tsdown@0.22.3(tsx@4.22.4)(typescript@5.9.3):
+    tsdown@0.22.3(tsx@4.22.4)(typescript@6.0.3):
         dependencies:
             ansis: 4.3.1
             cac: 7.0.0
@@ -8051,7 +8007,7 @@ snapshots:
             obug: 2.1.3
             picomatch: 4.0.4
             rolldown: 1.1.1
-            rolldown-plugin-dts: 0.26.0(rolldown@1.1.1)(typescript@5.9.3)
+            rolldown-plugin-dts: 0.26.0(rolldown@1.1.1)(typescript@6.0.3)
             semver: 7.8.4
             tinyexec: 1.2.4
             tinyglobby: 0.2.17
@@ -8059,7 +8015,7 @@ snapshots:
             unconfig-core: 7.5.0
         optionalDependencies:
             tsx: 4.22.4
-            typescript: 5.9.3
+            typescript: 6.0.3
         transitivePeerDependencies:
             - "@ts-macro/tsc"
             - "@typescript/native-preview"
@@ -8085,27 +8041,27 @@ snapshots:
         dependencies:
             tagged-tag: 1.0.0
 
-    typedoc@0.28.19(typescript@5.9.3):
+    typedoc@0.28.19(typescript@6.0.3):
         dependencies:
             "@gerrit0/mini-shiki": 3.23.0
             lunr: 2.3.9
             markdown-it: 14.2.0
             minimatch: 10.2.5
-            typescript: 5.9.3
+            typescript: 6.0.3
             yaml: 2.9.0
 
-    typescript-eslint@8.61.1(eslint@10.5.0)(typescript@5.9.3):
+    typescript-eslint@8.61.1(eslint@10.5.0)(typescript@6.0.3):
         dependencies:
-            "@typescript-eslint/eslint-plugin": 8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0)(typescript@5.9.3)
-            "@typescript-eslint/parser": 8.61.1(eslint@10.5.0)(typescript@5.9.3)
-            "@typescript-eslint/typescript-estree": 8.61.1(typescript@5.9.3)
-            "@typescript-eslint/utils": 8.61.1(eslint@10.5.0)(typescript@5.9.3)
+            "@typescript-eslint/eslint-plugin": 8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)(typescript@6.0.3)
+            "@typescript-eslint/parser": 8.61.1(eslint@10.5.0)(typescript@6.0.3)
+            "@typescript-eslint/typescript-estree": 8.61.1(typescript@6.0.3)
+            "@typescript-eslint/utils": 8.61.1(eslint@10.5.0)(typescript@6.0.3)
             eslint: 10.5.0
-            typescript: 5.9.3
+            typescript: 6.0.3
         transitivePeerDependencies:
             - supports-color
 
-    typescript@5.9.3: {}
+    typescript@6.0.3: {}
 
     uc.micro@2.1.0: {}
 
@@ -8177,9 +8133,9 @@ snapshots:
         dependencies:
             punycode: 2.3.1
 
-    valibot@1.4.1(typescript@5.9.3):
+    valibot@1.4.1(typescript@6.0.3):
         optionalDependencies:
-            typescript: 5.9.3
+            typescript: 6.0.3
 
     validate-npm-package-license@3.0.4:
         dependencies:


### PR DESCRIPTION
## Dependency group
- Packages: `typescript` 5.9.3 -> 6.0.3 in the root package and docs workspace
- Why grouped: the compiler version is shared by root typechecking/build output, `tsdown` declaration generation, TypeDoc, and the React Router docs build.

## Upstream changes that matter here
- TypeScript 6.0 is the bridge release between the 5.x compiler line and the native TypeScript 7 work.
- The release includes stricter checks around generic function expressions/JSX, updated DOM/lib types, import-assertion deprecation coverage, and migration diagnostics such as `stableTypeOrdering`.
- Legacy edges removed or tightened in 6.0 were checked locally: no `outFile`, no `/// <reference no-default-lib>`, no legacy namespace `module` declarations, no `tsc file.ts` scripts, and no old import assertions.
- Sources: https://devblogs.microsoft.com/typescript/announcing-typescript-6-0/ and https://github.com/microsoft/TypeScript/releases/tag/v6.0.3

## Local impact and code changes
- Existing usage checked: root `tsconfig.json`, docs `tsconfig.json`, package scripts, declaration generation, TypeDoc/docs build, and JSON import attributes.
- Required migration: none. Existing configs already pin `target`/`lib` explicitly and docs already use `with { type: "json" }`.
- Beneficial adoption: none. I did not enable `stableTypeOrdering`; upstream documents it as a TS7 migration aid with a compile-time cost, so it is better left out of this update.

## Validation
- `pnpm install --frozen-lockfile`: passed
- `pnpm run check`: passed
- `pnpm run build`: passed
- `pnpm --filter docs build`: passed, including TypeDoc generation
- `pnpm run verify`: format, lint, check, coverage, and build passed; sandbox DNS blocked the external `pnpm dlx publint` step
- `pnpm run package:check`: passed with network access
- Rebased onto current `origin/main`; pre-push ran frozen install, TypeScript, ESLint, and Prettier successfully

## Risk
- Compiler and generated declaration risk. Direct peers were checked: `typescript-eslint` supports `<6.1.0`, `tsdown` supports `^6.0.0`, and TypeDoc supports the 6.0 line.