### PR TITLE
chore(deps): update docs stack

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -9,18 +9,18 @@
 		"preview": "vite preview"
 	},
 	"dependencies": {
-		"ardo": "^3.5.0",
-		"isbot": "^5.1.43",
-		"lucide-react": "^1.20.0",
+		"ardo": "^3.6.1",
+		"isbot": "^5.1.44",
+		"lucide-react": "^1.23.0",
 		"react": "^19.2.7",
 		"react-dom": "^19.2.7",
-		"react-router": "^7.18.0"
+		"react-router": "^8.1.0"
 	},
 	"devDependencies": {
-		"@react-router/dev": "^7.18.0",
+		"@react-router/dev": "^8.1.0",
 		"@types/react": "^19.2.17",
 		"@types/react-dom": "^19.2.3",
 		"typescript": "^6.0.3",
-		"vite": "^8.0.16"
+		"vite": "^8.1.3"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,19 +45,19 @@ importers:
                 version: 8.61.1(eslint@10.5.0)(typescript@6.0.3)
             vitest:
                 specifier: ^4.1.9
-                version: 4.1.9(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))
+                version: 4.1.9(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(vite@8.1.3(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))
 
     docs:
         dependencies:
             ardo:
-                specifier: ^3.5.0
-                version: 3.5.0(@types/node@25.9.3)(esbuild@0.28.1)(lightningcss@1.32.0)(lucide-react@1.20.0(react@19.2.7))(rollup@4.62.0)(tsx@4.22.4)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))(yaml@2.9.0)
+                specifier: ^3.6.1
+                version: 3.6.1(@types/node@26.1.0)(esbuild@0.28.1)(lucide-react@1.23.0(react@19.2.7))(rollup@4.62.0)(tsx@4.22.4)(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))(yaml@2.9.0)
             isbot:
-                specifier: ^5.1.43
-                version: 5.1.43
+                specifier: ^5.1.44
+                version: 5.1.44
             lucide-react:
-                specifier: ^1.20.0
-                version: 1.20.0(react@19.2.7)
+                specifier: ^1.23.0
+                version: 1.23.0(react@19.2.7)
             react:
                 specifier: ^19.2.7
                 version: 19.2.7
@@ -65,12 +65,12 @@ importers:
                 specifier: ^19.2.7
                 version: 19.2.7(react@19.2.7)
             react-router:
-                specifier: ^7.18.0
-                version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+                specifier: ^8.1.0
+                version: 8.1.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
         devDependencies:
             "@react-router/dev":
-                specifier: ^7.18.0
-                version: 7.18.0(@types/node@25.9.3)(lightningcss@1.32.0)(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(tsx@4.22.4)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))(yaml@2.9.0)
+                specifier: ^8.1.0
+                version: 8.1.0(react-router@8.1.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))
             "@types/react":
                 specifier: ^19.2.17
                 version: 19.2.17
@@ -81,8 +81,8 @@ importers:
                 specifier: ^6.0.3
                 version: 6.0.3
             vite:
-                specifier: ^8.0.16
-                version: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
+                specifier: ^8.1.3
+                version: 8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
 
 packages:
     "@babel/code-frame@7.29.7":
@@ -348,22 +348,16 @@ packages:
             }
         engines: { node: ">=18" }
 
-    "@emnapi/core@1.10.0":
-        resolution:
-            {
-                integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==,
-            }
-
     "@emnapi/core@1.11.0":
         resolution:
             {
                 integrity: sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==,
             }
 
-    "@emnapi/runtime@1.10.0":
+    "@emnapi/core@1.11.1":
         resolution:
             {
-                integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==,
+                integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==,
             }
 
     "@emnapi/runtime@1.11.0":
@@ -372,10 +366,10 @@ packages:
                 integrity: sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==,
             }
 
-    "@emnapi/wasi-threads@1.2.1":
+    "@emnapi/runtime@1.11.1":
         resolution:
             {
-                integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==,
+                integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==,
             }
 
     "@emnapi/wasi-threads@1.2.2":
@@ -390,15 +384,6 @@ packages:
                 integrity: sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==,
             }
 
-    "@esbuild/aix-ppc64@0.27.7":
-        resolution:
-            {
-                integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==,
-            }
-        engines: { node: ">=18" }
-        cpu: [ppc64]
-        os: [aix]
-
     "@esbuild/aix-ppc64@0.28.1":
         resolution:
             {
@@ -408,15 +393,6 @@ packages:
         cpu: [ppc64]
         os: [aix]
 
-    "@esbuild/android-arm64@0.27.7":
-        resolution:
-            {
-                integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==,
-            }
-        engines: { node: ">=18" }
-        cpu: [arm64]
-        os: [android]
-
     "@esbuild/android-arm64@0.28.1":
         resolution:
             {
@@ -424,15 +400,6 @@ packages:
             }
         engines: { node: ">=18" }
         cpu: [arm64]
-        os: [android]
-
-    "@esbuild/android-arm@0.27.7":
-        resolution:
-            {
-                integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==,
-            }
-        engines: { node: ">=18" }
-        cpu: [arm]
         os: [android]
 
     "@esbuild/android-arm@0.28.1":
@@ -444,15 +411,6 @@ packages:
         cpu: [arm]
         os: [android]
 
-    "@esbuild/android-x64@0.27.7":
-        resolution:
-            {
-                integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==,
-            }
-        engines: { node: ">=18" }
-        cpu: [x64]
-        os: [android]
-
     "@esbuild/android-x64@0.28.1":
         resolution:
             {
@@ -462,15 +420,6 @@ packages:
         cpu: [x64]
         os: [android]
 
-    "@esbuild/darwin-arm64@0.27.7":
-        resolution:
-            {
-                integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==,
-            }
-        engines: { node: ">=18" }
-        cpu: [arm64]
-        os: [darwin]
-
     "@esbuild/darwin-arm64@0.28.1":
         resolution:
             {
@@ -478,15 +427,6 @@ packages:
             }
         engines: { node: ">=18" }
         cpu: [arm64]
-        os: [darwin]
-
-    "@esbuild/darwin-x64@0.27.7":
-        resolution:
-            {
-                integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==,
-            }
-        engines: { node: ">=18" }
-        cpu: [x64]
         os: [darwin]
 
     "@esbuild/darwin-x64@0.28.1":
@@ -498,15 +438,6 @@ packages:
         cpu: [x64]
         os: [darwin]
 
-    "@esbuild/freebsd-arm64@0.27.7":
-        resolution:
-            {
-                integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==,
-            }
-        engines: { node: ">=18" }
-        cpu: [arm64]
-        os: [freebsd]
-
     "@esbuild/freebsd-arm64@0.28.1":
         resolution:
             {
@@ -514,15 +445,6 @@ packages:
             }
         engines: { node: ">=18" }
         cpu: [arm64]
-        os: [freebsd]
-
-    "@esbuild/freebsd-x64@0.27.7":
-        resolution:
-            {
-                integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==,
-            }
-        engines: { node: ">=18" }
-        cpu: [x64]
         os: [freebsd]
 
     "@esbuild/freebsd-x64@0.28.1":
@@ -534,15 +456,6 @@ packages:
         cpu: [x64]
         os: [freebsd]
 
-    "@esbuild/linux-arm64@0.27.7":
-        resolution:
-            {
-                integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==,
-            }
-        engines: { node: ">=18" }
-        cpu: [arm64]
-        os: [linux]
-
     "@esbuild/linux-arm64@0.28.1":
         resolution:
             {
@@ -550,15 +463,6 @@ packages:
             }
         engines: { node: ">=18" }
         cpu: [arm64]
-        os: [linux]
-
-    "@esbuild/linux-arm@0.27.7":
-        resolution:
-            {
-                integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==,
-            }
-        engines: { node: ">=18" }
-        cpu: [arm]
         os: [linux]
 
     "@esbuild/linux-arm@0.28.1":
@@ -570,15 +474,6 @@ packages:
         cpu: [arm]
         os: [linux]
 
-    "@esbuild/linux-ia32@0.27.7":
-        resolution:
-            {
-                integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==,
-            }
-        engines: { node: ">=18" }
-        cpu: [ia32]
-        os: [linux]
-
     "@esbuild/linux-ia32@0.28.1":
         resolution:
             {
@@ -586,15 +481,6 @@ packages:
             }
         engines: { node: ">=18" }
         cpu: [ia32]
-        os: [linux]
-
-    "@esbuild/linux-loong64@0.27.7":
-        resolution:
-            {
-                integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==,
-            }
-        engines: { node: ">=18" }
-        cpu: [loong64]
         os: [linux]
 
     "@esbuild/linux-loong64@0.28.1":
@@ -606,15 +492,6 @@ packages:
         cpu: [loong64]
         os: [linux]
 
-    "@esbuild/linux-mips64el@0.27.7":
-        resolution:
-            {
-                integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==,
-            }
-        engines: { node: ">=18" }
-        cpu: [mips64el]
-        os: [linux]
-
     "@esbuild/linux-mips64el@0.28.1":
         resolution:
             {
@@ -622,15 +499,6 @@ packages:
             }
         engines: { node: ">=18" }
         cpu: [mips64el]
-        os: [linux]
-
-    "@esbuild/linux-ppc64@0.27.7":
-        resolution:
-            {
-                integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==,
-            }
-        engines: { node: ">=18" }
-        cpu: [ppc64]
         os: [linux]
 
     "@esbuild/linux-ppc64@0.28.1":
@@ -642,15 +510,6 @@ packages:
         cpu: [ppc64]
         os: [linux]
 
-    "@esbuild/linux-riscv64@0.27.7":
-        resolution:
-            {
-                integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==,
-            }
-        engines: { node: ">=18" }
-        cpu: [riscv64]
-        os: [linux]
-
     "@esbuild/linux-riscv64@0.28.1":
         resolution:
             {
@@ -658,15 +517,6 @@ packages:
             }
         engines: { node: ">=18" }
         cpu: [riscv64]
-        os: [linux]
-
-    "@esbuild/linux-s390x@0.27.7":
-        resolution:
-            {
-                integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==,
-            }
-        engines: { node: ">=18" }
-        cpu: [s390x]
         os: [linux]
 
     "@esbuild/linux-s390x@0.28.1":
@@ -678,15 +528,6 @@ packages:
         cpu: [s390x]
         os: [linux]
 
-    "@esbuild/linux-x64@0.27.7":
-        resolution:
-            {
-                integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==,
-            }
-        engines: { node: ">=18" }
-        cpu: [x64]
-        os: [linux]
-
     "@esbuild/linux-x64@0.28.1":
         resolution:
             {
@@ -696,15 +537,6 @@ packages:
         cpu: [x64]
         os: [linux]
 
-    "@esbuild/netbsd-arm64@0.27.7":
-        resolution:
-            {
-                integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==,
-            }
-        engines: { node: ">=18" }
-        cpu: [arm64]
-        os: [netbsd]
-
     "@esbuild/netbsd-arm64@0.28.1":
         resolution:
             {
@@ -712,15 +544,6 @@ packages:
             }
         engines: { node: ">=18" }
         cpu: [arm64]
-        os: [netbsd]
-
-    "@esbuild/netbsd-x64@0.27.7":
-        resolution:
-            {
-                integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==,
-            }
-        engines: { node: ">=18" }
-        cpu: [x64]
         os: [netbsd]
 
     "@esbuild/netbsd-x64@0.28.1":
@@ -732,15 +555,6 @@ packages:
         cpu: [x64]
         os: [netbsd]
 
-    "@esbuild/openbsd-arm64@0.27.7":
-        resolution:
-            {
-                integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==,
-            }
-        engines: { node: ">=18" }
-        cpu: [arm64]
-        os: [openbsd]
-
     "@esbuild/openbsd-arm64@0.28.1":
         resolution:
             {
@@ -748,15 +562,6 @@ packages:
             }
         engines: { node: ">=18" }
         cpu: [arm64]
-        os: [openbsd]
-
-    "@esbuild/openbsd-x64@0.27.7":
-        resolution:
-            {
-                integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==,
-            }
-        engines: { node: ">=18" }
-        cpu: [x64]
         os: [openbsd]
 
     "@esbuild/openbsd-x64@0.28.1":
@@ -768,15 +573,6 @@ packages:
         cpu: [x64]
         os: [openbsd]
 
-    "@esbuild/openharmony-arm64@0.27.7":
-        resolution:
-            {
-                integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==,
-            }
-        engines: { node: ">=18" }
-        cpu: [arm64]
-        os: [openharmony]
-
     "@esbuild/openharmony-arm64@0.28.1":
         resolution:
             {
@@ -785,15 +581,6 @@ packages:
         engines: { node: ">=18" }
         cpu: [arm64]
         os: [openharmony]
-
-    "@esbuild/sunos-x64@0.27.7":
-        resolution:
-            {
-                integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==,
-            }
-        engines: { node: ">=18" }
-        cpu: [x64]
-        os: [sunos]
 
     "@esbuild/sunos-x64@0.28.1":
         resolution:
@@ -804,15 +591,6 @@ packages:
         cpu: [x64]
         os: [sunos]
 
-    "@esbuild/win32-arm64@0.27.7":
-        resolution:
-            {
-                integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==,
-            }
-        engines: { node: ">=18" }
-        cpu: [arm64]
-        os: [win32]
-
     "@esbuild/win32-arm64@0.28.1":
         resolution:
             {
@@ -822,15 +600,6 @@ packages:
         cpu: [arm64]
         os: [win32]
 
-    "@esbuild/win32-ia32@0.27.7":
-        resolution:
-            {
-                integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==,
-            }
-        engines: { node: ">=18" }
-        cpu: [ia32]
-        os: [win32]
-
     "@esbuild/win32-ia32@0.28.1":
         resolution:
             {
@@ -838,15 +607,6 @@ packages:
             }
         engines: { node: ">=18" }
         cpu: [ia32]
-        os: [win32]
-
-    "@esbuild/win32-x64@0.27.7":
-        resolution:
-            {
-                integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==,
-            }
-        engines: { node: ">=18" }
-        cpu: [x64]
         os: [win32]
 
     "@esbuild/win32-x64@0.28.1":
@@ -1007,12 +767,6 @@ packages:
         peerDependencies:
             rollup: ">=2"
 
-    "@mjackson/node-fetch-server@0.2.0":
-        resolution:
-            {
-                integrity: sha512-EMlH1e30yzmTpGLQjlFmaDAjyOeZhng1/XCd7DExR8PNAnG/G1tyruZxEoUe11ClnwGhGrtsdnyyUx1frSzjng==,
-            }
-
     "@napi-rs/wasm-runtime@1.1.5":
         resolution:
             {
@@ -1022,16 +776,25 @@ packages:
             "@emnapi/core": ^1.7.1
             "@emnapi/runtime": ^1.7.1
 
-    "@oxc-project/types@0.133.0":
+    "@napi-rs/wasm-runtime@1.1.6":
         resolution:
             {
-                integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==,
+                integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==,
             }
+        peerDependencies:
+            "@emnapi/core": ^1.7.1
+            "@emnapi/runtime": ^1.7.1
 
     "@oxc-project/types@0.135.0":
         resolution:
             {
                 integrity: sha512-wR+xRdFkUBMvcAjBJ2q2kcZM6d+DKu2NgoOyxZgYwZdLhmiv6+rnO8PZ/P68kMiZtIKm+pW7zyEJ4kSOs0vo+Q==,
+            }
+
+    "@oxc-project/types@0.138.0":
+        resolution:
+            {
+                integrity: sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==,
             }
 
     "@quansync/fs@1.0.0":
@@ -1040,21 +803,21 @@ packages:
                 integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==,
             }
 
-    "@react-router/dev@7.18.0":
+    "@react-router/dev@8.1.0":
         resolution:
             {
-                integrity: sha512-GVTFvul0xlZHZyVXyRpiJv54Xfyj4eDOAlGYrzi7kDmN7n40rsrUqX+hvU0fy/41SCDMtckht59R3iGR94703g==,
+                integrity: sha512-0R7g3hPm+vXjfOzA6oInZ3KI/N9hxrtibtue3s1pdHcSPrfRFU2jgmC5I/W0gCJ9wtszLKqisHRet2vzY8USoA==,
             }
-        engines: { node: ">=20.0.0" }
+        engines: { node: ">=22.22.0" }
         hasBin: true
         peerDependencies:
-            "@react-router/serve": ^7.18.0
-            "@vitejs/plugin-rsc": ~0.5.21
-            react-router: ^7.18.0
-            react-server-dom-webpack: ^19.2.3
+            "@react-router/serve": ^8.1.0
+            "@vitejs/plugin-rsc": ~0.5.26
+            react-router: ^8.1.0
+            react-server-dom-webpack: ^19.2.7
             typescript: ^5.1.0 || ^6.0.0
-            vite: ^5.1.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
-            wrangler: ^3.28.2 || ^4.0.0
+            vite: ^7.0.0 || ^8.0.0
+            wrangler: ^4.0.0
         peerDependenciesMeta:
             "@react-router/serve":
                 optional: true
@@ -1067,14 +830,14 @@ packages:
             wrangler:
                 optional: true
 
-    "@react-router/node@7.18.0":
+    "@react-router/node@8.1.0":
         resolution:
             {
-                integrity: sha512-pRXJahLrdVfuVbaTpWsZ89mBuGiYH3Z4y+y1UidwxmJFKk6NjMyUvkJl3FjDWdD+nSlgFPSESUZS0hF560MUUQ==,
+                integrity: sha512-KgdcDTp+rDFybx4qBaGxBpKEBCSjBT+bmRXRziD3A9TOlQ1AlaqK1sSttYtgA/t4HEgoDsKVa7OO9jaZAacLgg==,
             }
-        engines: { node: ">=20.0.0" }
+        engines: { node: ">=22.22.0" }
         peerDependencies:
-            react-router: 7.18.0
+            react-router: 8.1.0
             typescript: ^5.1.0 || ^6.0.0
         peerDependenciesMeta:
             typescript:
@@ -1205,15 +968,6 @@ packages:
             }
         engines: { node: ">= 10" }
 
-    "@rolldown/binding-android-arm64@1.0.3":
-        resolution:
-            {
-                integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [android]
-
     "@rolldown/binding-android-arm64@1.1.1":
         resolution:
             {
@@ -1223,14 +977,14 @@ packages:
         cpu: [arm64]
         os: [android]
 
-    "@rolldown/binding-darwin-arm64@1.0.3":
+    "@rolldown/binding-android-arm64@1.1.4":
         resolution:
             {
-                integrity: sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==,
+                integrity: sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==,
             }
         engines: { node: ^20.19.0 || >=22.12.0 }
         cpu: [arm64]
-        os: [darwin]
+        os: [android]
 
     "@rolldown/binding-darwin-arm64@1.1.1":
         resolution:
@@ -1241,13 +995,13 @@ packages:
         cpu: [arm64]
         os: [darwin]
 
-    "@rolldown/binding-darwin-x64@1.0.3":
+    "@rolldown/binding-darwin-arm64@1.1.4":
         resolution:
             {
-                integrity: sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==,
+                integrity: sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==,
             }
         engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
+        cpu: [arm64]
         os: [darwin]
 
     "@rolldown/binding-darwin-x64@1.1.1":
@@ -1259,14 +1013,14 @@ packages:
         cpu: [x64]
         os: [darwin]
 
-    "@rolldown/binding-freebsd-x64@1.0.3":
+    "@rolldown/binding-darwin-x64@1.1.4":
         resolution:
             {
-                integrity: sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==,
+                integrity: sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==,
             }
         engines: { node: ^20.19.0 || >=22.12.0 }
         cpu: [x64]
-        os: [freebsd]
+        os: [darwin]
 
     "@rolldown/binding-freebsd-x64@1.1.1":
         resolution:
@@ -1277,14 +1031,14 @@ packages:
         cpu: [x64]
         os: [freebsd]
 
-    "@rolldown/binding-linux-arm-gnueabihf@1.0.3":
+    "@rolldown/binding-freebsd-x64@1.1.4":
         resolution:
             {
-                integrity: sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==,
+                integrity: sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==,
             }
         engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm]
-        os: [linux]
+        cpu: [x64]
+        os: [freebsd]
 
     "@rolldown/binding-linux-arm-gnueabihf@1.1.1":
         resolution:
@@ -1295,15 +1049,14 @@ packages:
         cpu: [arm]
         os: [linux]
 
-    "@rolldown/binding-linux-arm64-gnu@1.0.3":
+    "@rolldown/binding-linux-arm-gnueabihf@1.1.4":
         resolution:
             {
-                integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==,
+                integrity: sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==,
             }
         engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
+        cpu: [arm]
         os: [linux]
-        libc: [glibc]
 
     "@rolldown/binding-linux-arm64-gnu@1.1.1":
         resolution:
@@ -1315,15 +1068,15 @@ packages:
         os: [linux]
         libc: [glibc]
 
-    "@rolldown/binding-linux-arm64-musl@1.0.3":
+    "@rolldown/binding-linux-arm64-gnu@1.1.4":
         resolution:
             {
-                integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==,
+                integrity: sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==,
             }
         engines: { node: ^20.19.0 || >=22.12.0 }
         cpu: [arm64]
         os: [linux]
-        libc: [musl]
+        libc: [glibc]
 
     "@rolldown/binding-linux-arm64-musl@1.1.1":
         resolution:
@@ -1335,15 +1088,15 @@ packages:
         os: [linux]
         libc: [musl]
 
-    "@rolldown/binding-linux-ppc64-gnu@1.0.3":
+    "@rolldown/binding-linux-arm64-musl@1.1.4":
         resolution:
             {
-                integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==,
+                integrity: sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==,
             }
         engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [ppc64]
+        cpu: [arm64]
         os: [linux]
-        libc: [glibc]
+        libc: [musl]
 
     "@rolldown/binding-linux-ppc64-gnu@1.1.1":
         resolution:
@@ -1355,13 +1108,13 @@ packages:
         os: [linux]
         libc: [glibc]
 
-    "@rolldown/binding-linux-s390x-gnu@1.0.3":
+    "@rolldown/binding-linux-ppc64-gnu@1.1.4":
         resolution:
             {
-                integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==,
+                integrity: sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==,
             }
         engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [s390x]
+        cpu: [ppc64]
         os: [linux]
         libc: [glibc]
 
@@ -1375,13 +1128,13 @@ packages:
         os: [linux]
         libc: [glibc]
 
-    "@rolldown/binding-linux-x64-gnu@1.0.3":
+    "@rolldown/binding-linux-s390x-gnu@1.1.4":
         resolution:
             {
-                integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==,
+                integrity: sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==,
             }
         engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
+        cpu: [s390x]
         os: [linux]
         libc: [glibc]
 
@@ -1395,15 +1148,15 @@ packages:
         os: [linux]
         libc: [glibc]
 
-    "@rolldown/binding-linux-x64-musl@1.0.3":
+    "@rolldown/binding-linux-x64-gnu@1.1.4":
         resolution:
             {
-                integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==,
+                integrity: sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==,
             }
         engines: { node: ^20.19.0 || >=22.12.0 }
         cpu: [x64]
         os: [linux]
-        libc: [musl]
+        libc: [glibc]
 
     "@rolldown/binding-linux-x64-musl@1.1.1":
         resolution:
@@ -1415,14 +1168,15 @@ packages:
         os: [linux]
         libc: [musl]
 
-    "@rolldown/binding-openharmony-arm64@1.0.3":
+    "@rolldown/binding-linux-x64-musl@1.1.4":
         resolution:
             {
-                integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==,
+                integrity: sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==,
             }
         engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [openharmony]
+        cpu: [x64]
+        os: [linux]
+        libc: [musl]
 
     "@rolldown/binding-openharmony-arm64@1.1.1":
         resolution:
@@ -1433,13 +1187,14 @@ packages:
         cpu: [arm64]
         os: [openharmony]
 
-    "@rolldown/binding-wasm32-wasi@1.0.3":
+    "@rolldown/binding-openharmony-arm64@1.1.4":
         resolution:
             {
-                integrity: sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==,
+                integrity: sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==,
             }
         engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [wasm32]
+        cpu: [arm64]
+        os: [openharmony]
 
     "@rolldown/binding-wasm32-wasi@1.1.1":
         resolution:
@@ -1449,14 +1204,13 @@ packages:
         engines: { node: ^20.19.0 || >=22.12.0 }
         cpu: [wasm32]
 
-    "@rolldown/binding-win32-arm64-msvc@1.0.3":
+    "@rolldown/binding-wasm32-wasi@1.1.4":
         resolution:
             {
-                integrity: sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==,
+                integrity: sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==,
             }
         engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [win32]
+        cpu: [wasm32]
 
     "@rolldown/binding-win32-arm64-msvc@1.1.1":
         resolution:
@@ -1467,19 +1221,28 @@ packages:
         cpu: [arm64]
         os: [win32]
 
-    "@rolldown/binding-win32-x64-msvc@1.0.3":
+    "@rolldown/binding-win32-arm64-msvc@1.1.4":
         resolution:
             {
-                integrity: sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==,
+                integrity: sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==,
             }
         engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
+        cpu: [arm64]
         os: [win32]
 
     "@rolldown/binding-win32-x64-msvc@1.1.1":
         resolution:
             {
                 integrity: sha512-MUvC/HLXVjzkQkWiExdVTEEWf0py+GfWm8WKSZsekG3ih6a21iy0BHPF07X3JIf3ifoklZXTIaHTLPBgH1C3dw==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        cpu: [x64]
+        os: [win32]
+
+    "@rolldown/binding-win32-x64-msvc@1.1.4":
+        resolution:
+            {
+                integrity: sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==,
             }
         engines: { node: ^20.19.0 || >=22.12.0 }
         cpu: [x64]
@@ -1716,17 +1479,17 @@ packages:
         cpu: [x64]
         os: [win32]
 
-    "@shikijs/core@4.2.0":
+    "@shikijs/core@4.3.1":
         resolution:
             {
-                integrity: sha512-Hc87Ab1Ld/vEbZRCbwx344I5v+4RU8CVToUTRkqXL1+TjbuOp9U5Xa0M23V4GEWHxVn+yO5otb+HkQVm3ptWQQ==,
+                integrity: sha512-ANMDxuaPsNMdDC1m4vfvhlDmJweMwkE5XitTwrq2rWHx5jM+dlm4MmHt2PP6t0uejfR77SuhrhJ0zEijIF/uhA==,
             }
         engines: { node: ">=20" }
 
-    "@shikijs/engine-javascript@4.2.0":
+    "@shikijs/engine-javascript@4.3.1":
         resolution:
             {
-                integrity: sha512-fjETeq1k5ffyXqRgS6+3hpvqseLalp1kjNfRbXpUgWR8FpZ1CmQfiNHovc5lncYjt/Vg5JK/WJEmLahjwMa0og==,
+                integrity: sha512-JBItcnPuYq7jVJdZo/vMj94r+szT7XEjHFX+mvFDGSEIbVAXAGyHAHzhbWzpGOwYidCZrErJLLgn2PVeiokHnQ==,
             }
         engines: { node: ">=20" }
 
@@ -1736,10 +1499,10 @@ packages:
                 integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==,
             }
 
-    "@shikijs/engine-oniguruma@4.2.0":
+    "@shikijs/engine-oniguruma@4.3.1":
         resolution:
             {
-                integrity: sha512-hTorK1dffPkpbMUk6Z+828PgRo7d07HbnizoP0hNPFjhxMHctj0Px/qoHeGMYafc6ju+u9iMldN4JbVzNQM++g==,
+                integrity: sha512-OXyNMzg0pews+msMj4cHeqT4xiYKKvbnn6VbdAXxfoFl3SSx4fJTc8FadECuc5/H9p3BzhNAoAUXKwAu9rWYhg==,
             }
         engines: { node: ">=20" }
 
@@ -1749,24 +1512,24 @@ packages:
                 integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==,
             }
 
-    "@shikijs/langs@4.2.0":
+    "@shikijs/langs@4.3.1":
         resolution:
             {
-                integrity: sha512-bwrVRlJ0wUhZxAbVdvBbv2TTC9yLsh4C/IO5Ofz0T8MQntgDvyVnkbjw9vi50r1kx7RCIJdnJnjZAwmAsXFLZQ==,
+                integrity: sha512-m0l9nsDqgBHvbZbk7A0/kXz/impK3uB/c6rAn6Gpg/uPtdZRQ+alsN/17MU5thb68XTj/4DxkZAotrM0GGSpDQ==,
             }
         engines: { node: ">=20" }
 
-    "@shikijs/primitive@4.2.0":
+    "@shikijs/primitive@4.3.1":
         resolution:
             {
-                integrity: sha512-NOq+DtUkVBJtZMVXL5A0vI0Xk8nvDYaXetFHSJFlOqjDZIVhIPRYFdGkSoElDqNuegikcc3A76SNUa8dTqtAYA==,
+                integrity: sha512-CXQRQOYy1leqQ8ceTeJdmXv/bsUY++6QyLpXJ94LZAAYj5X2SKRdc5ipguv4NPyGVKItB2PPwUpRNe0Sjh5S1A==,
             }
         engines: { node: ">=20" }
 
-    "@shikijs/rehype@4.2.0":
+    "@shikijs/rehype@4.3.1":
         resolution:
             {
-                integrity: sha512-ST3EWye/dwF1gWskczJNBnwFtDzEQ9ceytXZtyc/GfwR5V0qJrkoSGZO55O3SAKDDsXkTDcsfwd9pVe7ROlAHg==,
+                integrity: sha512-oshrlfUF3VPUJfnp5K1lLwsS/SRBKrIxONpdWebSKZXdBE3UsZnxgqpvRUA8UsofS7vmjFOCAHIT71ECbmOxTw==,
             }
         engines: { node: ">=20" }
 
@@ -1776,10 +1539,10 @@ packages:
                 integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==,
             }
 
-    "@shikijs/themes@4.2.0":
+    "@shikijs/themes@4.3.1":
         resolution:
             {
-                integrity: sha512-RX8IHYeLv8Cu2W6ruc3RxUqWn0IYCqSrMBzi/uRGAmfyDNOnNO5BF/Px7o97n4XTpmFTo5GbRaazuOWj+2ak2w==,
+                integrity: sha512-dgpoJ4WqNi2yTmizQHBJ5zcX6j2lE6icN/0yt4l1kkf16jrY/pwPLoTb1ETsWMz0OBLf9ZNvwmxft+cH+N9qSA==,
             }
         engines: { node: ">=20" }
 
@@ -1789,10 +1552,10 @@ packages:
                 integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==,
             }
 
-    "@shikijs/types@4.2.0":
+    "@shikijs/types@4.3.1":
         resolution:
             {
-                integrity: sha512-VT/MKtlpOhEPZloSH3Pb9WCZEBDoQVMa9jedp5UAwmJOar1DVc9DRODAxmYPW9M93IK4ryuqRejFfmlvlVDemw==,
+                integrity: sha512-CHFxE0jztBIZRHH6gxXE7DXUCFXjReEGxZ/j0rfSLGKZuwp2xBYycEP14875DSa9KLL/6700oxIq6oO6ef9K2g==,
             }
         engines: { node: ">=20" }
 
@@ -1812,6 +1575,12 @@ packages:
         resolution:
             {
                 integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==,
+            }
+
+    "@tybys/wasm-util@0.10.3":
+        resolution:
+            {
+                integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==,
             }
 
     "@types/chai@5.2.3":
@@ -1890,6 +1659,12 @@ packages:
         resolution:
             {
                 integrity: sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==,
+            }
+
+    "@types/node@26.1.0":
+        resolution:
+            {
+                integrity: sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==,
             }
 
     "@types/normalize-package-data@2.4.4":
@@ -2013,10 +1788,10 @@ packages:
             }
         engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
-    "@ungap/structured-clone@1.3.1":
+    "@ungap/structured-clone@1.3.2":
         resolution:
             {
-                integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==,
+                integrity: sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==,
             }
 
     "@vanilla-extract/babel-plugin-debug-ids@1.2.2":
@@ -2025,16 +1800,16 @@ packages:
                 integrity: sha512-MeDWGICAF9zA/OZLOKwhoRlsUW+fiMwnfuOAqFVohL31Agj7Q/RBWAYweqjHLgFBCsdnr6XIfwjJnmb2znEWxw==,
             }
 
-    "@vanilla-extract/compiler@0.7.0":
+    "@vanilla-extract/compiler@0.7.1":
         resolution:
             {
-                integrity: sha512-rZQ40HVmsxfGLjoflwwsaUBLfpbpKDoZC19oiDA0FHq4LdrYtyVbFkc0MfqkNo/qBCvaZfsRezCqk0QQxCqZ8w==,
+                integrity: sha512-mOokbA2k1Lx3BO1/Qa9rpSWiIWeOHBt4aRHX0e5WMDu53//ifojeZJAvdXj/YkZI8z2AruxXYaLX6YlL8jfzyQ==,
             }
 
-    "@vanilla-extract/css@1.20.1":
+    "@vanilla-extract/css@1.21.1":
         resolution:
             {
-                integrity: sha512-5I9RNo5uZW9tsBnqrWzJqELegOqTHBrZyDFnES0gR9gJJHBB9dom1N0bwITM9tKwBcfKrTX4a6DHVeQdJ2ubQA==,
+                integrity: sha512-T6z6oeT+o0OwqukE6kLs9w5ooB75b8NPRadyU9pPTml83l40TPN+mscPt2OQ9P9cYfwEBMfsfivwiJujs2mzmg==,
             }
 
     "@vanilla-extract/esbuild-plugin@2.3.22":
@@ -2068,18 +1843,18 @@ packages:
         peerDependencies:
             "@vanilla-extract/css": ^1.0.0
 
-    "@vanilla-extract/vite-plugin@5.2.2":
+    "@vanilla-extract/vite-plugin@5.2.4":
         resolution:
             {
-                integrity: sha512-AUyB4fDR2b/Mo0lcXhhlf6RxnDPYwFMyKKopalJ4BwQNKYzZSoTwHJ1PLPO9SKhpz7lzXc0Z18GHQZOewzl3YA==,
+                integrity: sha512-KXm+Hghpr7/BNIPirsSVD7otMDCwjj9vfgc02CmtYoJ5t4shxQU0QbCRHc9YxlVvAeGvZfE2TmGkvhw2N/L/aw==,
             }
         peerDependencies:
             vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
-    "@vitejs/plugin-react@6.0.2":
+    "@vitejs/plugin-react@6.0.3":
         resolution:
             {
-                integrity: sha512-DlSMqo4WhThw4vB8Mpn0Woe9J+Jfq1geJ61AKW0QEgLzGMNwtIMdxbDUzLxcun8W7NbJO0e2Jg/Nxm3cCSVzzg==,
+                integrity: sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==,
             }
         engines: { node: ^20.19.0 || >=22.12.0 }
         peerDependencies:
@@ -2204,23 +1979,17 @@ packages:
             }
         engines: { node: ">=14" }
 
-    ardo@3.5.0:
+    ardo@3.6.1:
         resolution:
             {
-                integrity: sha512-hGV2xZ3Z+rssh1spIGFxB0qCoEPx0PUJisCp4ulYVsaPOLc+B4G0bV3AmE5OHNSHNmCxc/el0DO3EG4Kei3P6g==,
+                integrity: sha512-8Lxkg9ohs68OQmnj2xe3uokSHpE4cw1B2MA1bdipz5j0r8yB6b2bW5sk9tO9T8wp59nGU80ScK/lXsaMEc8h5g==,
             }
         peerDependencies:
             lucide-react: ">=0.400.0 <2.0.0"
-            vite: ^6.0.0 || ^7.0.0 || ^8.0.0-beta.0
+            vite: ^7.0.0 || ^8.0.0
         peerDependenciesMeta:
             lucide-react:
                 optional: true
-
-    arg@5.0.2:
-        resolution:
-            {
-                integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==,
-            }
 
     argparse@1.0.10:
         resolution:
@@ -2280,10 +2049,10 @@ packages:
             }
         engines: { node: 18 || 20 || >=22 }
 
-    baseline-browser-mapping@2.10.37:
+    baseline-browser-mapping@2.10.42:
         resolution:
             {
-                integrity: sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==,
+                integrity: sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==,
             }
         engines: { node: ">=6.0.0" }
         hasBin: true
@@ -2301,20 +2070,13 @@ packages:
             }
         engines: { node: 18 || 20 || >=22 }
 
-    browserslist@4.28.2:
+    browserslist@4.28.4:
         resolution:
             {
-                integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==,
+                integrity: sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==,
             }
         engines: { node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7 }
         hasBin: true
-
-    cac@6.7.14:
-        resolution:
-            {
-                integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==,
-            }
-        engines: { node: ">=8" }
 
     cac@7.0.0:
         resolution:
@@ -2323,10 +2085,10 @@ packages:
             }
         engines: { node: ">=20.19.0" }
 
-    caniuse-lite@1.0.30001799:
+    caniuse-lite@1.0.30001802:
         resolution:
             {
-                integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==,
+                integrity: sha512-vmv8ub2xwTNmljSKf82mtCk5JH7hC+YgzLj3P5zotvA0tPQ9016tdNNOG8WRca1IxOnhSsivB+J0z5FeE5LOUw==,
             }
 
     ccount@2.0.1:
@@ -2366,12 +2128,12 @@ packages:
                 integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==,
             }
 
-    chokidar@4.0.3:
+    chokidar@5.0.0:
         resolution:
             {
-                integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==,
+                integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==,
             }
-        engines: { node: ">= 14.16.0" }
+        engines: { node: ">= 20.19.0" }
 
     cli-cursor@5.0.0:
         resolution:
@@ -2417,12 +2179,11 @@ packages:
                 integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==,
             }
 
-    cookie@1.1.1:
+    cookie-es@3.1.1:
         resolution:
             {
-                integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==,
+                integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==,
             }
-        engines: { node: ">=18" }
 
     cross-spawn@7.0.6:
         resolution:
@@ -2530,10 +2291,10 @@ packages:
             oxc-resolver:
                 optional: true
 
-    electron-to-chromium@1.5.374:
+    electron-to-chromium@1.5.387:
         resolution:
             {
-                integrity: sha512-HCF5i7izveksHSGqa7mhDh6tr3Uz9Dar2RAjwuh69bw3QGPVObjQIgLwQWeO/Rxp9/r0KdboKy9RbpQDl97fjg==,
+                integrity: sha512-TaxwufTFDufvPEoXdhwVrA3UdFWBeWGkYoJ1K8ldF1xe6gKfth6iRNS5lTQ5JPNOHdGQm8PT1QYKUqFLCiUefQ==,
             }
 
     emoji-regex@10.6.0:
@@ -2570,16 +2331,16 @@ packages:
             }
         engines: { node: ">=18" }
 
-    es-module-lexer@1.7.0:
-        resolution:
-            {
-                integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==,
-            }
-
     es-module-lexer@2.1.0:
         resolution:
             {
                 integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==,
+            }
+
+    es-module-lexer@2.3.0:
+        resolution:
+            {
+                integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==,
             }
 
     esast-util-from-estree@2.0.0:
@@ -2593,14 +2354,6 @@ packages:
             {
                 integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==,
             }
-
-    esbuild@0.27.7:
-        resolution:
-            {
-                integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==,
-            }
-        engines: { node: ">=18" }
-        hasBin: true
 
     esbuild@0.28.1:
         resolution:
@@ -2784,12 +2537,12 @@ packages:
                 integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==,
             }
 
-    exit-hook@2.2.1:
+    exit-hook@5.1.0:
         resolution:
             {
-                integrity: sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==,
+                integrity: sha512-INjr2xyxHo7bhAqf5ong++GZPPnpcuBcaXUKt03yf7Fie9yWD7FapL4teOU0+awQazGs5ucBh7xWs/AD+6nhog==,
             }
-        engines: { node: ">=6" }
+        engines: { node: ">=20" }
 
     expect-type@1.3.0:
         resolution:
@@ -2798,10 +2551,10 @@ packages:
             }
         engines: { node: ">=12.0.0" }
 
-    exsolve@1.0.8:
+    exsolve@1.1.0:
         resolution:
             {
-                integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==,
+                integrity: sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==,
             }
 
     extend-shallow@2.0.1:
@@ -3131,10 +2884,10 @@ packages:
             }
         engines: { node: ">=12" }
 
-    isbot@5.1.43:
+    isbot@5.1.44:
         resolution:
             {
-                integrity: sha512-drJhFmibra4LO6Wd7D3Oi6UICRK9244vSZkmxzhlZP0TTdwCA2ueK4PEkUkzPYeuqug9+cqqdWPgihjk5+83Cg==,
+                integrity: sha512-PGEHtwMnKbZpeSEXW2Utx+/JWed7dp6DiH0WWg33vGSDA7RUvpUeJSVlLrVkQ1RCpvDOUc/eH9ql7VsdbBZ8pA==,
             }
         engines: { node: ">=18" }
 
@@ -3183,19 +2936,11 @@ packages:
                 integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==,
             }
 
-    js-yaml@3.14.2:
+    js-yaml@3.15.0:
         resolution:
             {
-                integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==,
+                integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==,
             }
-        hasBin: true
-
-    jsesc@3.0.2:
-        resolution:
-            {
-                integrity: sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==,
-            }
-        engines: { node: ">=6" }
         hasBin: true
 
     jsesc@3.1.0:
@@ -3362,10 +3107,10 @@ packages:
             }
         engines: { node: ">= 12.0.0" }
 
-    linkify-it@5.0.1:
+    linkify-it@5.0.2:
         resolution:
             {
-                integrity: sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==,
+                integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==,
             }
 
     lint-staged@17.0.7:
@@ -3428,10 +3173,10 @@ packages:
                 integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==,
             }
 
-    lucide-react@1.20.0:
+    lucide-react@1.23.0:
         resolution:
             {
-                integrity: sha512-jhXLeC/7m0/tjL1nzMdKk6x256zWA6AtbhTVreHOiKPoeX2d6MK4FbyIQPpVq0E6iPWBisyy1TW+pEge/uMEuQ==,
+                integrity: sha512-38BpJcD0JhFosxHApP/BYsBetLpQFRoTRzEzstM/XCc3jsAG7wqaY1lgVwxiUe3xqYE+lNxo2PkCmYwXWrwwIw==,
             }
         peerDependencies:
             react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -3468,10 +3213,10 @@ packages:
             }
         engines: { node: ">=16" }
 
-    markdown-it@14.2.0:
+    markdown-it@14.3.0:
         resolution:
             {
-                integrity: sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==,
+                integrity: sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==,
             }
         hasBin: true
 
@@ -3849,10 +3594,10 @@ packages:
                 integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==,
             }
 
-    nanoid@3.3.12:
+    nanoid@3.3.15:
         resolution:
             {
-                integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==,
+                integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==,
             }
         engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
         hasBin: true
@@ -3863,10 +3608,10 @@ packages:
                 integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==,
             }
 
-    node-releases@2.0.47:
+    node-releases@2.0.50:
         resolution:
             {
-                integrity: sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==,
+                integrity: sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==,
             }
         engines: { node: ">=18" }
 
@@ -3924,10 +3669,10 @@ packages:
             }
         engines: { node: ">=10" }
 
-    p-map@7.0.4:
+    p-map@7.0.5:
         resolution:
             {
-                integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==,
+                integrity: sha512-e8vJF4XdVkzqqSHguEMz41mQO1wKwxKm5ENrUJQUu9kLDCtn83cxbyHZcszr4QC5zEA7WffRRC4gsTecC7J9oA==,
             }
         engines: { node: ">=18" }
 
@@ -3964,12 +3709,6 @@ packages:
             }
         engines: { node: ">=8" }
 
-    pathe@1.1.2:
-        resolution:
-            {
-                integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==,
-            }
-
     pathe@2.0.3:
         resolution:
             {
@@ -3989,6 +3728,13 @@ packages:
             }
         engines: { node: ">=12" }
 
+    picomatch@4.0.5:
+        resolution:
+            {
+                integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==,
+            }
+        engines: { node: ">=12" }
+
     pkg-types@1.3.1:
         resolution:
             {
@@ -4001,10 +3747,10 @@ packages:
                 integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==,
             }
 
-    postcss@8.5.15:
+    postcss@8.5.16:
         resolution:
             {
-                integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==,
+                integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==,
             }
         engines: { node: ^10 || ^12 || >=14 }
 
@@ -4019,6 +3765,14 @@ packages:
         resolution:
             {
                 integrity: sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==,
+            }
+        engines: { node: ">=14" }
+        hasBin: true
+
+    prettier@3.9.4:
+        resolution:
+            {
+                integrity: sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==,
             }
         engines: { node: ">=14" }
         hasBin: true
@@ -4057,22 +3811,22 @@ packages:
         peerDependencies:
             react: ^19.2.7
 
-    react-refresh@0.14.2:
+    react-refresh@0.18.0:
         resolution:
             {
-                integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==,
+                integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==,
             }
         engines: { node: ">=0.10.0" }
 
-    react-router@7.18.0:
+    react-router@8.1.0:
         resolution:
             {
-                integrity: sha512-pTTGt8J+ji1NOmYnjzT+bAJy/1zD+Jp4ziO6cL7T3ZLvXKtusO7BpFqlRXitqpcPVqllsIXFHRMt+2/k3Xn6HQ==,
+                integrity: sha512-Mdfi61uObuvWNN9OhChOC0HV6YWOIfKRzEWOvCHRSuQg8IM+Nv10edaM/2HE8ZixBpUTdQbruyWqC3sDkkh9vw==,
             }
-        engines: { node: ">=20.0.0" }
+        engines: { node: ">=22.22.0" }
         peerDependencies:
-            react: ">=18"
-            react-dom: ">=18"
+            react: ">=19.2.7"
+            react-dom: ">=19.2.7"
         peerDependenciesMeta:
             react-dom:
                 optional: true
@@ -4098,12 +3852,12 @@ packages:
             }
         engines: { node: ">=20" }
 
-    readdirp@4.1.2:
+    readdirp@5.0.0:
         resolution:
             {
-                integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==,
+                integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==,
             }
-        engines: { node: ">= 14.18.0" }
+        engines: { node: ">= 20.19.0" }
 
     recma-build-jsx@1.0.0:
         resolution:
@@ -4256,18 +4010,18 @@ packages:
             vue-tsc:
                 optional: true
 
-    rolldown@1.0.3:
-        resolution:
-            {
-                integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        hasBin: true
-
     rolldown@1.1.1:
         resolution:
             {
                 integrity: sha512-IN750c0p+s3jqJIsFLRZrQazmbAB1kkQDTtQjSt/gbS2ywLhlv4R5Shazer0FZKmuo/BsO3/w2UoYnUjuOZqHg==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        hasBin: true
+
+    rolldown@1.1.4:
+        resolution:
+            {
+                integrity: sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==,
             }
         engines: { node: ^20.19.0 || >=22.12.0 }
         hasBin: true
@@ -4308,11 +4062,13 @@ packages:
         engines: { node: ">=10" }
         hasBin: true
 
-    set-cookie-parser@2.7.2:
+    semver@7.8.5:
         resolution:
             {
-                integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==,
+                integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==,
             }
+        engines: { node: ">=10" }
+        hasBin: true
 
     shebang-command@2.0.0:
         resolution:
@@ -4328,10 +4084,10 @@ packages:
             }
         engines: { node: ">=8" }
 
-    shiki@4.2.0:
+    shiki@4.3.1:
         resolution:
             {
-                integrity: sha512-hjNax6o/ylDy9lefQEaSDtzaT3iVNtZ3WmpQnbuQNoG4xvnSKf2kSKbihZVO4JRG1TTMejs7CmNRYlWgAL66pQ==,
+                integrity: sha512-oR+qDVi2OjX1tmDpyv+3KviX01KzO6Af+0NNnKnsp9491UEGz2YpxTuJboS/6VhYpTdqzmuJBuiTlrAWWJAssw==,
             }
         engines: { node: ">=20" }
 
@@ -4491,10 +4247,10 @@ packages:
             }
         engines: { node: ">=20" }
 
-    tailwindcss@4.3.1:
+    tailwindcss@4.3.2:
         resolution:
             {
-                integrity: sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==,
+                integrity: sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==,
             }
 
     tinybench@2.9.0:
@@ -4623,17 +4379,17 @@ packages:
             }
         engines: { node: ">=16" }
 
-    type-fest@5.7.0:
+    type-fest@5.8.0:
         resolution:
             {
-                integrity: sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==,
+                integrity: sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==,
             }
         engines: { node: ">=20" }
 
-    typedoc@0.28.19:
+    typedoc@0.28.20:
         resolution:
             {
-                integrity: sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==,
+                integrity: sha512-uSKqkh8Cr48vllnEy+jdaAgOeR6Y+QCBW7usgUsKj7gJEfR7stw9U/fE49LBnj2tPRKPY0c0EBJSWe9Appmplg==,
             }
         engines: { node: ">= 18", pnpm: ">= 10" }
         hasBin: true
@@ -4680,6 +4436,12 @@ packages:
         resolution:
             {
                 integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==,
+            }
+
+    undici-types@8.3.0:
+        resolution:
+            {
+                integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==,
             }
 
     unicorn-magic@0.4.0:
@@ -4752,10 +4514,10 @@ packages:
                 integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==,
             }
 
-    valibot@1.4.1:
+    valibot@1.4.2:
         resolution:
             {
-                integrity: sha512-klCmFTz2jeDluy9RwX+F884TCiogtdBJ/YaxSx1EOBYXa3NXNWj8kR1jjN8rzluwojJVWWaHJ4r1U5LfICnM3g==,
+                integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==,
             }
         peerDependencies:
             typescript: ">=5"
@@ -4787,14 +4549,6 @@ packages:
                 integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==,
             }
 
-    vite-node@3.2.4:
-        resolution:
-            {
-                integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==,
-            }
-        engines: { node: ^18.0.0 || ^20.0.0 || >=22.0.0 }
-        hasBin: true
-
     vite-node@6.0.0:
         resolution:
             {
@@ -4803,59 +4557,16 @@ packages:
         engines: { node: ^20.19.0 || >=22.12.0 }
         hasBin: true
 
-    vite@7.3.5:
+    vite@8.1.3:
         resolution:
             {
-                integrity: sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==,
+                integrity: sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==,
             }
         engines: { node: ^20.19.0 || >=22.12.0 }
         hasBin: true
         peerDependencies:
             "@types/node": ^20.19.0 || >=22.12.0
-            jiti: ">=1.21.0"
-            less: ^4.0.0
-            lightningcss: ^1.21.0
-            sass: ^1.70.0
-            sass-embedded: ^1.70.0
-            stylus: ">=0.54.8"
-            sugarss: ^5.0.0
-            terser: ^5.16.0
-            tsx: ^4.8.1
-            yaml: ^2.4.2
-        peerDependenciesMeta:
-            "@types/node":
-                optional: true
-            jiti:
-                optional: true
-            less:
-                optional: true
-            lightningcss:
-                optional: true
-            sass:
-                optional: true
-            sass-embedded:
-                optional: true
-            stylus:
-                optional: true
-            sugarss:
-                optional: true
-            terser:
-                optional: true
-            tsx:
-                optional: true
-            yaml:
-                optional: true
-
-    vite@8.0.16:
-        resolution:
-            {
-                integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        hasBin: true
-        peerDependencies:
-            "@types/node": ^20.19.0 || >=22.12.0
-            "@vitejs/devtools": ^0.1.18
+            "@vitejs/devtools": ^0.3.0
             esbuild: ^0.27.0 || ^0.28.0
             jiti: ">=1.21.0"
             less: ^4.0.0
@@ -5041,7 +4752,7 @@ snapshots:
             "@babel/types": 7.29.7
             "@jridgewell/gen-mapping": 0.3.13
             "@jridgewell/trace-mapping": 0.3.31
-            jsesc: 3.0.2
+            jsesc: 3.1.0
 
     "@babel/generator@8.0.0":
         dependencies:
@@ -5060,7 +4771,7 @@ snapshots:
         dependencies:
             "@babel/compat-data": 7.29.7
             "@babel/helper-validator-option": 7.29.7
-            browserslist: 4.28.2
+            browserslist: 4.28.4
             lru-cache: 5.1.1
             semver: 6.3.1
 
@@ -5219,20 +4930,15 @@ snapshots:
 
     "@bcoe/v8-coverage@1.0.2": {}
 
-    "@emnapi/core@1.10.0":
-        dependencies:
-            "@emnapi/wasi-threads": 1.2.1
-            tslib: 2.8.1
-        optional: true
-
     "@emnapi/core@1.11.0":
         dependencies:
             "@emnapi/wasi-threads": 1.2.2
             tslib: 2.8.1
         optional: true
 
-    "@emnapi/runtime@1.10.0":
+    "@emnapi/core@1.11.1":
         dependencies:
+            "@emnapi/wasi-threads": 1.2.2
             tslib: 2.8.1
         optional: true
 
@@ -5241,7 +4947,7 @@ snapshots:
             tslib: 2.8.1
         optional: true
 
-    "@emnapi/wasi-threads@1.2.1":
+    "@emnapi/runtime@1.11.1":
         dependencies:
             tslib: 2.8.1
         optional: true
@@ -5253,157 +4959,79 @@ snapshots:
 
     "@emotion/hash@0.9.2": {}
 
-    "@esbuild/aix-ppc64@0.27.7":
-        optional: true
-
     "@esbuild/aix-ppc64@0.28.1":
-        optional: true
-
-    "@esbuild/android-arm64@0.27.7":
         optional: true
 
     "@esbuild/android-arm64@0.28.1":
         optional: true
 
-    "@esbuild/android-arm@0.27.7":
-        optional: true
-
     "@esbuild/android-arm@0.28.1":
-        optional: true
-
-    "@esbuild/android-x64@0.27.7":
         optional: true
 
     "@esbuild/android-x64@0.28.1":
         optional: true
 
-    "@esbuild/darwin-arm64@0.27.7":
-        optional: true
-
     "@esbuild/darwin-arm64@0.28.1":
-        optional: true
-
-    "@esbuild/darwin-x64@0.27.7":
         optional: true
 
     "@esbuild/darwin-x64@0.28.1":
         optional: true
 
-    "@esbuild/freebsd-arm64@0.27.7":
-        optional: true
-
     "@esbuild/freebsd-arm64@0.28.1":
-        optional: true
-
-    "@esbuild/freebsd-x64@0.27.7":
         optional: true
 
     "@esbuild/freebsd-x64@0.28.1":
         optional: true
 
-    "@esbuild/linux-arm64@0.27.7":
-        optional: true
-
     "@esbuild/linux-arm64@0.28.1":
-        optional: true
-
-    "@esbuild/linux-arm@0.27.7":
         optional: true
 
     "@esbuild/linux-arm@0.28.1":
         optional: true
 
-    "@esbuild/linux-ia32@0.27.7":
-        optional: true
-
     "@esbuild/linux-ia32@0.28.1":
-        optional: true
-
-    "@esbuild/linux-loong64@0.27.7":
         optional: true
 
     "@esbuild/linux-loong64@0.28.1":
         optional: true
 
-    "@esbuild/linux-mips64el@0.27.7":
-        optional: true
-
     "@esbuild/linux-mips64el@0.28.1":
-        optional: true
-
-    "@esbuild/linux-ppc64@0.27.7":
         optional: true
 
     "@esbuild/linux-ppc64@0.28.1":
         optional: true
 
-    "@esbuild/linux-riscv64@0.27.7":
-        optional: true
-
     "@esbuild/linux-riscv64@0.28.1":
-        optional: true
-
-    "@esbuild/linux-s390x@0.27.7":
         optional: true
 
     "@esbuild/linux-s390x@0.28.1":
         optional: true
 
-    "@esbuild/linux-x64@0.27.7":
-        optional: true
-
     "@esbuild/linux-x64@0.28.1":
-        optional: true
-
-    "@esbuild/netbsd-arm64@0.27.7":
         optional: true
 
     "@esbuild/netbsd-arm64@0.28.1":
         optional: true
 
-    "@esbuild/netbsd-x64@0.27.7":
-        optional: true
-
     "@esbuild/netbsd-x64@0.28.1":
-        optional: true
-
-    "@esbuild/openbsd-arm64@0.27.7":
         optional: true
 
     "@esbuild/openbsd-arm64@0.28.1":
         optional: true
 
-    "@esbuild/openbsd-x64@0.27.7":
-        optional: true
-
     "@esbuild/openbsd-x64@0.28.1":
-        optional: true
-
-    "@esbuild/openharmony-arm64@0.27.7":
         optional: true
 
     "@esbuild/openharmony-arm64@0.28.1":
         optional: true
 
-    "@esbuild/sunos-x64@0.27.7":
-        optional: true
-
     "@esbuild/sunos-x64@0.28.1":
-        optional: true
-
-    "@esbuild/win32-arm64@0.27.7":
         optional: true
 
     "@esbuild/win32-arm64@0.28.1":
         optional: true
 
-    "@esbuild/win32-ia32@0.27.7":
-        optional: true
-
     "@esbuild/win32-ia32@0.28.1":
-        optional: true
-
-    "@esbuild/win32-x64@0.27.7":
         optional: true
 
     "@esbuild/win32-x64@0.28.1":
@@ -5526,15 +5154,6 @@ snapshots:
         transitivePeerDependencies:
             - supports-color
 
-    "@mjackson/node-fetch-server@0.2.0": {}
-
-    "@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)":
-        dependencies:
-            "@emnapi/core": 1.10.0
-            "@emnapi/runtime": 1.10.0
-            "@tybys/wasm-util": 0.10.2
-        optional: true
-
     "@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)":
         dependencies:
             "@emnapi/core": 1.11.0
@@ -5542,15 +5161,22 @@ snapshots:
             "@tybys/wasm-util": 0.10.2
         optional: true
 
-    "@oxc-project/types@0.133.0": {}
+    "@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)":
+        dependencies:
+            "@emnapi/core": 1.11.1
+            "@emnapi/runtime": 1.11.1
+            "@tybys/wasm-util": 0.10.3
+        optional: true
 
     "@oxc-project/types@0.135.0": {}
+
+    "@oxc-project/types@0.138.0": {}
 
     "@quansync/fs@1.0.0":
         dependencies:
             quansync: 1.0.0
 
-    "@react-router/dev@7.18.0(@types/node@25.9.3)(lightningcss@1.32.0)(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(tsx@4.22.4)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))(yaml@2.9.0)":
+    "@react-router/dev@8.1.0(react-router@8.1.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))":
         dependencies:
             "@babel/core": 7.29.7
             "@babel/generator": 7.29.7
@@ -5559,50 +5185,37 @@ snapshots:
             "@babel/preset-typescript": 7.29.7(@babel/core@7.29.7)
             "@babel/traverse": 7.29.7
             "@babel/types": 7.29.7
-            "@react-router/node": 7.18.0(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)
+            "@react-router/node": 8.1.0(react-router@8.1.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)
             "@remix-run/node-fetch-server": 0.13.3
-            arg: 5.0.2
             babel-dead-code-elimination: 1.0.12
-            chokidar: 4.0.3
+            chokidar: 5.0.0
             dedent: 1.7.2
-            es-module-lexer: 1.7.0
-            exit-hook: 2.2.1
-            isbot: 5.1.43
-            jsesc: 3.0.2
+            es-module-lexer: 2.3.0
+            exit-hook: 5.1.0
+            isbot: 5.1.44
+            jsesc: 3.1.0
             lodash: 4.18.1
-            p-map: 7.0.4
-            pathe: 1.1.2
+            p-map: 7.0.5
+            pathe: 2.0.3
             picocolors: 1.1.1
             pkg-types: 2.3.1
-            prettier: 3.8.4
-            react-refresh: 0.14.2
-            react-router: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-            semver: 7.8.4
+            prettier: 3.9.4
+            react-refresh: 0.18.0
+            react-router: 8.1.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+            semver: 7.8.5
             tinyglobby: 0.2.17
-            valibot: 1.4.1(typescript@6.0.3)
-            vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
-            vite-node: 3.2.4(@types/node@25.9.3)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
+            valibot: 1.4.2(typescript@6.0.3)
+            vite: 8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
         optionalDependencies:
             typescript: 6.0.3
         transitivePeerDependencies:
-            - "@types/node"
             - babel-plugin-macros
-            - jiti
-            - less
-            - lightningcss
-            - sass
-            - sass-embedded
-            - stylus
-            - sugarss
             - supports-color
-            - terser
-            - tsx
-            - yaml
 
-    "@react-router/node@7.18.0(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)":
+    "@react-router/node@8.1.0(react-router@8.1.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)":
         dependencies:
-            "@mjackson/node-fetch-server": 0.2.0
-            react-router: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+            "@remix-run/node-fetch-server": 0.13.3
+            react-router: 8.1.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
         optionalDependencies:
             typescript: 6.0.3
 
@@ -5659,83 +5272,76 @@ snapshots:
             "@resvg/resvg-js-win32-ia32-msvc": 2.6.2
             "@resvg/resvg-js-win32-x64-msvc": 2.6.2
 
-    "@rolldown/binding-android-arm64@1.0.3":
-        optional: true
-
     "@rolldown/binding-android-arm64@1.1.1":
         optional: true
 
-    "@rolldown/binding-darwin-arm64@1.0.3":
+    "@rolldown/binding-android-arm64@1.1.4":
         optional: true
 
     "@rolldown/binding-darwin-arm64@1.1.1":
         optional: true
 
-    "@rolldown/binding-darwin-x64@1.0.3":
+    "@rolldown/binding-darwin-arm64@1.1.4":
         optional: true
 
     "@rolldown/binding-darwin-x64@1.1.1":
         optional: true
 
-    "@rolldown/binding-freebsd-x64@1.0.3":
+    "@rolldown/binding-darwin-x64@1.1.4":
         optional: true
 
     "@rolldown/binding-freebsd-x64@1.1.1":
         optional: true
 
-    "@rolldown/binding-linux-arm-gnueabihf@1.0.3":
+    "@rolldown/binding-freebsd-x64@1.1.4":
         optional: true
 
     "@rolldown/binding-linux-arm-gnueabihf@1.1.1":
         optional: true
 
-    "@rolldown/binding-linux-arm64-gnu@1.0.3":
+    "@rolldown/binding-linux-arm-gnueabihf@1.1.4":
         optional: true
 
     "@rolldown/binding-linux-arm64-gnu@1.1.1":
         optional: true
 
-    "@rolldown/binding-linux-arm64-musl@1.0.3":
+    "@rolldown/binding-linux-arm64-gnu@1.1.4":
         optional: true
 
     "@rolldown/binding-linux-arm64-musl@1.1.1":
         optional: true
 
-    "@rolldown/binding-linux-ppc64-gnu@1.0.3":
+    "@rolldown/binding-linux-arm64-musl@1.1.4":
         optional: true
 
     "@rolldown/binding-linux-ppc64-gnu@1.1.1":
         optional: true
 
-    "@rolldown/binding-linux-s390x-gnu@1.0.3":
+    "@rolldown/binding-linux-ppc64-gnu@1.1.4":
         optional: true
 
     "@rolldown/binding-linux-s390x-gnu@1.1.1":
         optional: true
 
-    "@rolldown/binding-linux-x64-gnu@1.0.3":
+    "@rolldown/binding-linux-s390x-gnu@1.1.4":
         optional: true
 
     "@rolldown/binding-linux-x64-gnu@1.1.1":
         optional: true
 
-    "@rolldown/binding-linux-x64-musl@1.0.3":
+    "@rolldown/binding-linux-x64-gnu@1.1.4":
         optional: true
 
     "@rolldown/binding-linux-x64-musl@1.1.1":
         optional: true
 
-    "@rolldown/binding-openharmony-arm64@1.0.3":
+    "@rolldown/binding-linux-x64-musl@1.1.4":
         optional: true
 
     "@rolldown/binding-openharmony-arm64@1.1.1":
         optional: true
 
-    "@rolldown/binding-wasm32-wasi@1.0.3":
-        dependencies:
-            "@emnapi/core": 1.10.0
-            "@emnapi/runtime": 1.10.0
-            "@napi-rs/wasm-runtime": 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    "@rolldown/binding-openharmony-arm64@1.1.4":
         optional: true
 
     "@rolldown/binding-wasm32-wasi@1.1.1":
@@ -5745,16 +5351,23 @@ snapshots:
             "@napi-rs/wasm-runtime": 1.1.5(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)
         optional: true
 
-    "@rolldown/binding-win32-arm64-msvc@1.0.3":
+    "@rolldown/binding-wasm32-wasi@1.1.4":
+        dependencies:
+            "@emnapi/core": 1.11.1
+            "@emnapi/runtime": 1.11.1
+            "@napi-rs/wasm-runtime": 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
         optional: true
 
     "@rolldown/binding-win32-arm64-msvc@1.1.1":
         optional: true
 
-    "@rolldown/binding-win32-x64-msvc@1.0.3":
+    "@rolldown/binding-win32-arm64-msvc@1.1.4":
         optional: true
 
     "@rolldown/binding-win32-x64-msvc@1.1.1":
+        optional: true
+
+    "@rolldown/binding-win32-x64-msvc@1.1.4":
         optional: true
 
     "@rolldown/pluginutils@1.0.1": {}
@@ -5763,7 +5376,7 @@ snapshots:
         dependencies:
             "@types/estree": 1.0.9
             estree-walker: 2.0.2
-            picomatch: 4.0.4
+            picomatch: 4.0.5
         optionalDependencies:
             rollup: 4.62.0
 
@@ -5842,17 +5455,17 @@ snapshots:
     "@rollup/rollup-win32-x64-msvc@4.62.0":
         optional: true
 
-    "@shikijs/core@4.2.0":
+    "@shikijs/core@4.3.1":
         dependencies:
-            "@shikijs/primitive": 4.2.0
-            "@shikijs/types": 4.2.0
+            "@shikijs/primitive": 4.3.1
+            "@shikijs/types": 4.3.1
             "@shikijs/vscode-textmate": 10.0.2
             "@types/hast": 3.0.4
             hast-util-to-html: 9.0.5
 
-    "@shikijs/engine-javascript@4.2.0":
+    "@shikijs/engine-javascript@4.3.1":
         dependencies:
-            "@shikijs/types": 4.2.0
+            "@shikijs/types": 4.3.1
             "@shikijs/vscode-textmate": 10.0.2
             oniguruma-to-es: 4.3.6
 
@@ -5861,31 +5474,31 @@ snapshots:
             "@shikijs/types": 3.23.0
             "@shikijs/vscode-textmate": 10.0.2
 
-    "@shikijs/engine-oniguruma@4.2.0":
+    "@shikijs/engine-oniguruma@4.3.1":
         dependencies:
-            "@shikijs/types": 4.2.0
+            "@shikijs/types": 4.3.1
             "@shikijs/vscode-textmate": 10.0.2
 
     "@shikijs/langs@3.23.0":
         dependencies:
             "@shikijs/types": 3.23.0
 
-    "@shikijs/langs@4.2.0":
+    "@shikijs/langs@4.3.1":
         dependencies:
-            "@shikijs/types": 4.2.0
+            "@shikijs/types": 4.3.1
 
-    "@shikijs/primitive@4.2.0":
+    "@shikijs/primitive@4.3.1":
         dependencies:
-            "@shikijs/types": 4.2.0
+            "@shikijs/types": 4.3.1
             "@shikijs/vscode-textmate": 10.0.2
             "@types/hast": 3.0.4
 
-    "@shikijs/rehype@4.2.0":
+    "@shikijs/rehype@4.3.1":
         dependencies:
-            "@shikijs/types": 4.2.0
+            "@shikijs/types": 4.3.1
             "@types/hast": 3.0.4
             hast-util-to-string: 3.0.1
-            shiki: 4.2.0
+            shiki: 4.3.1
             unified: 11.0.5
             unist-util-visit: 5.1.0
 
@@ -5893,16 +5506,16 @@ snapshots:
         dependencies:
             "@shikijs/types": 3.23.0
 
-    "@shikijs/themes@4.2.0":
+    "@shikijs/themes@4.3.1":
         dependencies:
-            "@shikijs/types": 4.2.0
+            "@shikijs/types": 4.3.1
 
     "@shikijs/types@3.23.0":
         dependencies:
             "@shikijs/vscode-textmate": 10.0.2
             "@types/hast": 3.0.4
 
-    "@shikijs/types@4.2.0":
+    "@shikijs/types@4.3.1":
         dependencies:
             "@shikijs/vscode-textmate": 10.0.2
             "@types/hast": 3.0.4
@@ -5912,6 +5525,11 @@ snapshots:
     "@standard-schema/spec@1.1.0": {}
 
     "@tybys/wasm-util@0.10.2":
+        dependencies:
+            tslib: 2.8.1
+        optional: true
+
+    "@tybys/wasm-util@0.10.3":
         dependencies:
             tslib: 2.8.1
         optional: true
@@ -5954,6 +5572,10 @@ snapshots:
     "@types/node@25.9.3":
         dependencies:
             undici-types: 7.24.6
+
+    "@types/node@26.1.0":
+        dependencies:
+            undici-types: 8.3.0
 
     "@types/normalize-package-data@2.4.4": {}
 
@@ -6037,7 +5659,7 @@ snapshots:
             "@typescript-eslint/visitor-keys": 8.61.1
             debug: 4.4.3
             minimatch: 10.2.5
-            semver: 7.8.4
+            semver: 7.8.5
             tinyglobby: 0.2.17
             ts-api-utils: 2.5.0(typescript@6.0.3)
             typescript: 6.0.3
@@ -6060,7 +5682,7 @@ snapshots:
             "@typescript-eslint/types": 8.61.1
             eslint-visitor-keys: 5.0.1
 
-    "@ungap/structured-clone@1.3.1": {}
+    "@ungap/structured-clone@1.3.2": {}
 
     "@vanilla-extract/babel-plugin-debug-ids@1.2.2":
         dependencies:
@@ -6068,12 +5690,12 @@ snapshots:
         transitivePeerDependencies:
             - supports-color
 
-    "@vanilla-extract/compiler@0.7.0(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)":
+    "@vanilla-extract/compiler@0.7.1(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)":
         dependencies:
-            "@vanilla-extract/css": 1.20.1
+            "@vanilla-extract/css": 1.21.1
             "@vanilla-extract/integration": 8.0.10
-            vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
-            vite-node: 6.0.0(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
+            vite: 8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
+            vite-node: 6.0.0(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
         transitivePeerDependencies:
             - "@types/node"
             - "@vitejs/devtools"
@@ -6090,7 +5712,7 @@ snapshots:
             - tsx
             - yaml
 
-    "@vanilla-extract/css@1.20.1":
+    "@vanilla-extract/css@1.21.1":
         dependencies:
             "@emotion/hash": 0.9.2
             "@vanilla-extract/private": 1.0.9
@@ -6120,7 +5742,7 @@ snapshots:
             "@babel/core": 7.29.7
             "@babel/plugin-syntax-typescript": 7.29.7(@babel/core@7.29.7)
             "@vanilla-extract/babel-plugin-debug-ids": 1.2.2
-            "@vanilla-extract/css": 1.20.1
+            "@vanilla-extract/css": 1.21.1
             dedent: 1.7.2
             esbuild: 0.28.1
             eval: 0.1.8
@@ -6133,15 +5755,15 @@ snapshots:
 
     "@vanilla-extract/private@1.0.9": {}
 
-    "@vanilla-extract/recipes@0.5.7(@vanilla-extract/css@1.20.1)":
+    "@vanilla-extract/recipes@0.5.7(@vanilla-extract/css@1.21.1)":
         dependencies:
-            "@vanilla-extract/css": 1.20.1
+            "@vanilla-extract/css": 1.21.1
 
-    "@vanilla-extract/vite-plugin@5.2.2(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))(yaml@2.9.0)":
+    "@vanilla-extract/vite-plugin@5.2.4(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.4)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))(yaml@2.9.0)":
         dependencies:
-            "@vanilla-extract/compiler": 0.7.0(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
+            "@vanilla-extract/compiler": 0.7.1(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
             "@vanilla-extract/integration": 8.0.10
-            vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
+            vite: 8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
         transitivePeerDependencies:
             - "@types/node"
             - "@vitejs/devtools"
@@ -6158,10 +5780,10 @@ snapshots:
             - tsx
             - yaml
 
-    "@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))":
+    "@vitejs/plugin-react@6.0.3(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))":
         dependencies:
             "@rolldown/pluginutils": 1.0.1
-            vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
+            vite: 8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
 
     "@vitest/coverage-v8@4.1.9(vitest@4.1.9)":
         dependencies:
@@ -6175,7 +5797,7 @@ snapshots:
             obug: 2.1.3
             std-env: 4.1.0
             tinyrainbow: 3.1.0
-            vitest: 4.1.9(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))
+            vitest: 4.1.9(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(vite@8.1.3(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))
 
     "@vitest/expect@4.1.9":
         dependencies:
@@ -6186,13 +5808,13 @@ snapshots:
             chai: 6.2.2
             tinyrainbow: 3.1.0
 
-    "@vitest/mocker@4.1.9(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))":
+    "@vitest/mocker@4.1.9(vite@8.1.3(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))":
         dependencies:
             "@vitest/spy": 4.1.9
             estree-walker: 3.0.3
             magic-string: 0.30.21
         optionalDependencies:
-            vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
+            vite: 8.1.3(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
 
     "@vitest/pretty-format@4.1.9":
         dependencies:
@@ -6241,23 +5863,23 @@ snapshots:
 
     ansis@4.3.1: {}
 
-    ardo@3.5.0(@types/node@25.9.3)(esbuild@0.28.1)(lightningcss@1.32.0)(lucide-react@1.20.0(react@19.2.7))(rollup@4.62.0)(tsx@4.22.4)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))(yaml@2.9.0):
+    ardo@3.6.1(@types/node@26.1.0)(esbuild@0.28.1)(lucide-react@1.23.0(react@19.2.7))(rollup@4.62.0)(tsx@4.22.4)(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))(yaml@2.9.0):
         dependencies:
             "@mdx-js/rollup": 3.1.1(rollup@4.62.0)
-            "@react-router/dev": 7.18.0(@types/node@25.9.3)(lightningcss@1.32.0)(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(tsx@4.22.4)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))(yaml@2.9.0)
+            "@react-router/dev": 8.1.0(react-router@8.1.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))
             "@resvg/resvg-js": 2.6.2
-            "@shikijs/rehype": 4.2.0
-            "@vanilla-extract/css": 1.20.1
+            "@shikijs/rehype": 4.3.1
+            "@vanilla-extract/css": 1.21.1
             "@vanilla-extract/esbuild-plugin": 2.3.22(esbuild@0.28.1)
-            "@vanilla-extract/recipes": 0.5.7(@vanilla-extract/css@1.20.1)
-            "@vanilla-extract/vite-plugin": 5.2.2(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))(yaml@2.9.0)
-            "@vitejs/plugin-react": 6.0.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))
+            "@vanilla-extract/recipes": 0.5.7(@vanilla-extract/css@1.21.1)
+            "@vanilla-extract/vite-plugin": 5.2.4(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.4)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))(yaml@2.9.0)
+            "@vitejs/plugin-react": 6.0.3(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))
             gray-matter: 4.0.3
             hast-util-to-jsx-runtime: 2.3.6
             minisearch: 7.2.0
             react: 19.2.7
             react-dom: 19.2.7(react@19.2.7)
-            react-router: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+            react-router: 8.1.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
             read-package-up: 12.0.0
             rehype-parse: 9.0.1
             rehype-stringify: 10.0.1
@@ -6266,14 +5888,14 @@ snapshots:
             remark-mdx-frontmatter: 5.2.0
             remark-parse: 11.0.0
             remark-rehype: 11.1.2
-            shiki: 4.2.0
-            tailwindcss: 4.3.1
-            typedoc: 0.28.19(typescript@6.0.3)
+            shiki: 4.3.1
+            tailwindcss: 4.3.2
+            typedoc: 0.28.20(typescript@6.0.3)
             unified: 11.0.5
             unist-util-visit: 5.1.0
-            vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
+            vite: 8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
         optionalDependencies:
-            lucide-react: 1.20.0(react@19.2.7)
+            lucide-react: 1.23.0(react@19.2.7)
         transitivePeerDependencies:
             - "@react-router/serve"
             - "@rolldown/plugin-babel"
@@ -6285,7 +5907,6 @@ snapshots:
             - esbuild
             - jiti
             - less
-            - lightningcss
             - react-server-dom-webpack
             - rollup
             - sass
@@ -6298,8 +5919,6 @@ snapshots:
             - typescript
             - wrangler
             - yaml
-
-    arg@5.0.2: {}
 
     argparse@1.0.10:
         dependencies:
@@ -6336,7 +5955,7 @@ snapshots:
 
     balanced-match@4.0.4: {}
 
-    baseline-browser-mapping@2.10.37: {}
+    baseline-browser-mapping@2.10.42: {}
 
     birpc@4.0.0: {}
 
@@ -6344,19 +5963,17 @@ snapshots:
         dependencies:
             balanced-match: 4.0.4
 
-    browserslist@4.28.2:
+    browserslist@4.28.4:
         dependencies:
-            baseline-browser-mapping: 2.10.37
-            caniuse-lite: 1.0.30001799
-            electron-to-chromium: 1.5.374
-            node-releases: 2.0.47
-            update-browserslist-db: 1.2.3(browserslist@4.28.2)
-
-    cac@6.7.14: {}
+            baseline-browser-mapping: 2.10.42
+            caniuse-lite: 1.0.30001802
+            electron-to-chromium: 1.5.387
+            node-releases: 2.0.50
+            update-browserslist-db: 1.2.3(browserslist@4.28.4)
 
     cac@7.0.0: {}
 
-    caniuse-lite@1.0.30001799: {}
+    caniuse-lite@1.0.30001802: {}
 
     ccount@2.0.1: {}
 
@@ -6370,9 +5987,9 @@ snapshots:
 
     character-reference-invalid@2.0.1: {}
 
-    chokidar@4.0.3:
+    chokidar@5.0.0:
         dependencies:
-            readdirp: 4.1.2
+            readdirp: 5.0.0
 
     cli-cursor@5.0.0:
         dependencies:
@@ -6393,7 +6010,7 @@ snapshots:
 
     convert-source-map@2.0.0: {}
 
-    cookie@1.1.1: {}
+    cookie-es@3.1.1: {}
 
     cross-spawn@7.0.6:
         dependencies:
@@ -6433,7 +6050,7 @@ snapshots:
 
     dts-resolver@3.0.0: {}
 
-    electron-to-chromium@1.5.374: {}
+    electron-to-chromium@1.5.387: {}
 
     emoji-regex@10.6.0: {}
 
@@ -6445,9 +6062,9 @@ snapshots:
 
     environment@1.1.0: {}
 
-    es-module-lexer@1.7.0: {}
-
     es-module-lexer@2.1.0: {}
+
+    es-module-lexer@2.3.0: {}
 
     esast-util-from-estree@2.0.0:
         dependencies:
@@ -6462,35 +6079,6 @@ snapshots:
             acorn: 8.17.0
             esast-util-from-estree: 2.0.0
             vfile-message: 4.0.3
-
-    esbuild@0.27.7:
-        optionalDependencies:
-            "@esbuild/aix-ppc64": 0.27.7
-            "@esbuild/android-arm": 0.27.7
-            "@esbuild/android-arm64": 0.27.7
-            "@esbuild/android-x64": 0.27.7
-            "@esbuild/darwin-arm64": 0.27.7
-            "@esbuild/darwin-x64": 0.27.7
-            "@esbuild/freebsd-arm64": 0.27.7
-            "@esbuild/freebsd-x64": 0.27.7
-            "@esbuild/linux-arm": 0.27.7
-            "@esbuild/linux-arm64": 0.27.7
-            "@esbuild/linux-ia32": 0.27.7
-            "@esbuild/linux-loong64": 0.27.7
-            "@esbuild/linux-mips64el": 0.27.7
-            "@esbuild/linux-ppc64": 0.27.7
-            "@esbuild/linux-riscv64": 0.27.7
-            "@esbuild/linux-s390x": 0.27.7
-            "@esbuild/linux-x64": 0.27.7
-            "@esbuild/netbsd-arm64": 0.27.7
-            "@esbuild/netbsd-x64": 0.27.7
-            "@esbuild/openbsd-arm64": 0.27.7
-            "@esbuild/openbsd-x64": 0.27.7
-            "@esbuild/openharmony-arm64": 0.27.7
-            "@esbuild/sunos-x64": 0.27.7
-            "@esbuild/win32-arm64": 0.27.7
-            "@esbuild/win32-ia32": 0.27.7
-            "@esbuild/win32-x64": 0.27.7
 
     esbuild@0.28.1:
         optionalDependencies:
@@ -6638,16 +6226,16 @@ snapshots:
 
     eval@0.1.8:
         dependencies:
-            "@types/node": 25.9.3
+            "@types/node": 26.1.0
             require-like: 0.1.2
 
     eventemitter3@5.0.4: {}
 
-    exit-hook@2.2.1: {}
+    exit-hook@5.1.0: {}
 
     expect-type@1.3.0: {}
 
-    exsolve@1.0.8: {}
+    exsolve@1.1.0: {}
 
     extend-shallow@2.0.1:
         dependencies:
@@ -6665,9 +6253,9 @@ snapshots:
         dependencies:
             format: 0.2.2
 
-    fdir@6.5.0(picomatch@4.0.4):
+    fdir@6.5.0(picomatch@4.0.5):
         optionalDependencies:
-            picomatch: 4.0.4
+            picomatch: 4.0.5
 
     file-entry-cache@8.0.0:
         dependencies:
@@ -6706,7 +6294,7 @@ snapshots:
 
     gray-matter@4.0.3:
         dependencies:
-            js-yaml: 3.14.2
+            js-yaml: 3.15.0
             kind-of: 6.0.3
             section-matter: 1.0.0
             strip-bom-string: 1.0.0
@@ -6857,7 +6445,7 @@ snapshots:
 
     is-plain-obj@4.1.0: {}
 
-    isbot@5.1.43: {}
+    isbot@5.1.44: {}
 
     isexe@2.0.0: {}
 
@@ -6880,12 +6468,10 @@ snapshots:
 
     js-tokens@4.0.0: {}
 
-    js-yaml@3.14.2:
+    js-yaml@3.15.0:
         dependencies:
             argparse: 1.0.10
             esprima: 4.0.1
-
-    jsesc@3.0.2: {}
 
     jsesc@3.1.0: {}
 
@@ -6957,7 +6543,7 @@ snapshots:
             lightningcss-win32-arm64-msvc: 1.32.0
             lightningcss-win32-x64-msvc: 1.32.0
 
-    linkify-it@5.0.1:
+    linkify-it@5.0.2:
         dependencies:
             uc.micro: 2.1.0
 
@@ -7002,7 +6588,7 @@ snapshots:
         dependencies:
             yallist: 3.1.1
 
-    lucide-react@1.20.0(react@19.2.7):
+    lucide-react@1.23.0(react@19.2.7):
         dependencies:
             react: 19.2.7
 
@@ -7020,15 +6606,15 @@ snapshots:
 
     make-dir@4.0.0:
         dependencies:
-            semver: 7.8.4
+            semver: 7.8.5
 
     markdown-extensions@2.0.0: {}
 
-    markdown-it@14.2.0:
+    markdown-it@14.3.0:
         dependencies:
             argparse: 2.0.1
             entities: 4.5.0
-            linkify-it: 5.0.1
+            linkify-it: 5.0.2
             mdurl: 2.0.0
             punycode.js: 2.3.1
             uc.micro: 2.1.0
@@ -7185,7 +6771,7 @@ snapshots:
         dependencies:
             "@types/hast": 3.0.4
             "@types/mdast": 4.0.4
-            "@ungap/structured-clone": 1.3.1
+            "@ungap/structured-clone": 1.3.2
             devlop: 1.1.0
             micromark-util-sanitize-uri: 2.0.1
             trim-lines: 3.0.1
@@ -7505,16 +7091,16 @@ snapshots:
 
     ms@2.1.3: {}
 
-    nanoid@3.3.12: {}
+    nanoid@3.3.15: {}
 
     natural-compare@1.4.0: {}
 
-    node-releases@2.0.47: {}
+    node-releases@2.0.50: {}
 
     normalize-package-data@8.0.0:
         dependencies:
             hosted-git-info: 9.0.3
-            semver: 7.8.4
+            semver: 7.8.5
             validate-npm-package-license: 3.0.4
 
     obug@2.1.3: {}
@@ -7548,7 +7134,7 @@ snapshots:
         dependencies:
             p-limit: 3.1.0
 
-    p-map@7.0.4: {}
+    p-map@7.0.5: {}
 
     parse-entities@4.0.2:
         dependencies:
@@ -7574,13 +7160,13 @@ snapshots:
 
     path-key@3.1.1: {}
 
-    pathe@1.1.2: {}
-
     pathe@2.0.3: {}
 
     picocolors@1.1.1: {}
 
     picomatch@4.0.4: {}
+
+    picomatch@4.0.5: {}
 
     pkg-types@1.3.1:
         dependencies:
@@ -7591,18 +7177,20 @@ snapshots:
     pkg-types@2.3.1:
         dependencies:
             confbox: 0.2.4
-            exsolve: 1.0.8
+            exsolve: 1.1.0
             pathe: 2.0.3
 
-    postcss@8.5.15:
+    postcss@8.5.16:
         dependencies:
-            nanoid: 3.3.12
+            nanoid: 3.3.15
             picocolors: 1.1.1
             source-map-js: 1.2.1
 
     prelude-ls@1.2.1: {}
 
     prettier@3.8.4: {}
+
+    prettier@3.9.4: {}
 
     property-information@7.2.0: {}
 
@@ -7617,13 +7205,12 @@ snapshots:
             react: 19.2.7
             scheduler: 0.27.0
 
-    react-refresh@0.14.2: {}
+    react-refresh@0.18.0: {}
 
-    react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    react-router@8.1.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
         dependencies:
-            cookie: 1.1.1
+            cookie-es: 3.1.1
             react: 19.2.7
-            set-cookie-parser: 2.7.2
         optionalDependencies:
             react-dom: 19.2.7(react@19.2.7)
 
@@ -7633,17 +7220,17 @@ snapshots:
         dependencies:
             find-up-simple: 1.0.1
             read-pkg: 10.1.0
-            type-fest: 5.7.0
+            type-fest: 5.8.0
 
     read-pkg@10.1.0:
         dependencies:
             "@types/normalize-package-data": 2.4.4
             normalize-package-data: 8.0.0
             parse-json: 8.3.0
-            type-fest: 5.7.0
+            type-fest: 5.8.0
             unicorn-magic: 0.4.0
 
-    readdirp@4.1.2: {}
+    readdirp@5.0.0: {}
 
     recma-build-jsx@1.0.0:
         dependencies:
@@ -7790,27 +7377,6 @@ snapshots:
         transitivePeerDependencies:
             - oxc-resolver
 
-    rolldown@1.0.3:
-        dependencies:
-            "@oxc-project/types": 0.133.0
-            "@rolldown/pluginutils": 1.0.1
-        optionalDependencies:
-            "@rolldown/binding-android-arm64": 1.0.3
-            "@rolldown/binding-darwin-arm64": 1.0.3
-            "@rolldown/binding-darwin-x64": 1.0.3
-            "@rolldown/binding-freebsd-x64": 1.0.3
-            "@rolldown/binding-linux-arm-gnueabihf": 1.0.3
-            "@rolldown/binding-linux-arm64-gnu": 1.0.3
-            "@rolldown/binding-linux-arm64-musl": 1.0.3
-            "@rolldown/binding-linux-ppc64-gnu": 1.0.3
-            "@rolldown/binding-linux-s390x-gnu": 1.0.3
-            "@rolldown/binding-linux-x64-gnu": 1.0.3
-            "@rolldown/binding-linux-x64-musl": 1.0.3
-            "@rolldown/binding-openharmony-arm64": 1.0.3
-            "@rolldown/binding-wasm32-wasi": 1.0.3
-            "@rolldown/binding-win32-arm64-msvc": 1.0.3
-            "@rolldown/binding-win32-x64-msvc": 1.0.3
-
     rolldown@1.1.1:
         dependencies:
             "@oxc-project/types": 0.135.0
@@ -7831,6 +7397,27 @@ snapshots:
             "@rolldown/binding-wasm32-wasi": 1.1.1
             "@rolldown/binding-win32-arm64-msvc": 1.1.1
             "@rolldown/binding-win32-x64-msvc": 1.1.1
+
+    rolldown@1.1.4:
+        dependencies:
+            "@oxc-project/types": 0.138.0
+            "@rolldown/pluginutils": 1.0.1
+        optionalDependencies:
+            "@rolldown/binding-android-arm64": 1.1.4
+            "@rolldown/binding-darwin-arm64": 1.1.4
+            "@rolldown/binding-darwin-x64": 1.1.4
+            "@rolldown/binding-freebsd-x64": 1.1.4
+            "@rolldown/binding-linux-arm-gnueabihf": 1.1.4
+            "@rolldown/binding-linux-arm64-gnu": 1.1.4
+            "@rolldown/binding-linux-arm64-musl": 1.1.4
+            "@rolldown/binding-linux-ppc64-gnu": 1.1.4
+            "@rolldown/binding-linux-s390x-gnu": 1.1.4
+            "@rolldown/binding-linux-x64-gnu": 1.1.4
+            "@rolldown/binding-linux-x64-musl": 1.1.4
+            "@rolldown/binding-openharmony-arm64": 1.1.4
+            "@rolldown/binding-wasm32-wasi": 1.1.4
+            "@rolldown/binding-win32-arm64-msvc": 1.1.4
+            "@rolldown/binding-win32-x64-msvc": 1.1.4
 
     rollup@4.62.0:
         dependencies:
@@ -7874,7 +7461,7 @@ snapshots:
 
     semver@7.8.4: {}
 
-    set-cookie-parser@2.7.2: {}
+    semver@7.8.5: {}
 
     shebang-command@2.0.0:
         dependencies:
@@ -7882,14 +7469,14 @@ snapshots:
 
     shebang-regex@3.0.0: {}
 
-    shiki@4.2.0:
+    shiki@4.3.1:
         dependencies:
-            "@shikijs/core": 4.2.0
-            "@shikijs/engine-javascript": 4.2.0
-            "@shikijs/engine-oniguruma": 4.2.0
-            "@shikijs/langs": 4.2.0
-            "@shikijs/themes": 4.2.0
-            "@shikijs/types": 4.2.0
+            "@shikijs/core": 4.3.1
+            "@shikijs/engine-javascript": 4.3.1
+            "@shikijs/engine-oniguruma": 4.3.1
+            "@shikijs/langs": 4.3.1
+            "@shikijs/themes": 4.3.1
+            "@shikijs/types": 4.3.1
             "@shikijs/vscode-textmate": 10.0.2
             "@types/hast": 3.0.4
 
@@ -7971,7 +7558,7 @@ snapshots:
 
     tagged-tag@1.0.0: {}
 
-    tailwindcss@4.3.1: {}
+    tailwindcss@4.3.2: {}
 
     tinybench@2.9.0: {}
 
@@ -7979,8 +7566,8 @@ snapshots:
 
     tinyglobby@0.2.17:
         dependencies:
-            fdir: 6.5.0(picomatch@4.0.4)
-            picomatch: 4.0.4
+            fdir: 6.5.0(picomatch@4.0.5)
+            picomatch: 4.0.5
 
     tinyrainbow@3.1.0: {}
 
@@ -8037,15 +7624,15 @@ snapshots:
 
     type-fest@4.41.0: {}
 
-    type-fest@5.7.0:
+    type-fest@5.8.0:
         dependencies:
             tagged-tag: 1.0.0
 
-    typedoc@0.28.19(typescript@6.0.3):
+    typedoc@0.28.20(typescript@6.0.3):
         dependencies:
             "@gerrit0/mini-shiki": 3.23.0
             lunr: 2.3.9
-            markdown-it: 14.2.0
+            markdown-it: 14.3.0
             minimatch: 10.2.5
             typescript: 6.0.3
             yaml: 2.9.0
@@ -8073,6 +7660,8 @@ snapshots:
             quansync: 1.0.0
 
     undici-types@7.24.6: {}
+
+    undici-types@8.3.0: {}
 
     unicorn-magic@0.4.0: {}
 
@@ -8123,9 +7712,9 @@ snapshots:
             unist-util-is: 6.0.1
             unist-util-visit-parents: 6.0.2
 
-    update-browserslist-db@1.2.3(browserslist@4.28.2):
+    update-browserslist-db@1.2.3(browserslist@4.28.4):
         dependencies:
-            browserslist: 4.28.2
+            browserslist: 4.28.4
             escalade: 3.2.0
             picocolors: 1.1.1
 
@@ -8133,7 +7722,7 @@ snapshots:
         dependencies:
             punycode: 2.3.1
 
-    valibot@1.4.1(typescript@6.0.3):
+    valibot@1.4.2(typescript@6.0.3):
         optionalDependencies:
             typescript: 6.0.3
 
@@ -8157,34 +7746,13 @@ snapshots:
             "@types/unist": 3.0.3
             vfile-message: 4.0.3
 
-    vite-node@3.2.4(@types/node@25.9.3)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0):
-        dependencies:
-            cac: 6.7.14
-            debug: 4.4.3
-            es-module-lexer: 1.7.0
-            pathe: 2.0.3
-            vite: 7.3.5(@types/node@25.9.3)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
-        transitivePeerDependencies:
-            - "@types/node"
-            - jiti
-            - less
-            - lightningcss
-            - sass
-            - sass-embedded
-            - stylus
-            - sugarss
-            - supports-color
-            - terser
-            - tsx
-            - yaml
-
-    vite-node@6.0.0(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0):
+    vite-node@6.0.0(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0):
         dependencies:
             cac: 7.0.0
-            es-module-lexer: 2.1.0
+            es-module-lexer: 2.3.0
             obug: 2.1.3
             pathe: 2.0.3
-            vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
+            vite: 8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
         transitivePeerDependencies:
             - "@types/node"
             - "@vitejs/devtools"
@@ -8199,27 +7767,12 @@ snapshots:
             - tsx
             - yaml
 
-    vite@7.3.5(@types/node@25.9.3)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0):
-        dependencies:
-            esbuild: 0.27.7
-            fdir: 6.5.0(picomatch@4.0.4)
-            picomatch: 4.0.4
-            postcss: 8.5.15
-            rollup: 4.62.0
-            tinyglobby: 0.2.17
-        optionalDependencies:
-            "@types/node": 25.9.3
-            fsevents: 2.3.3
-            lightningcss: 1.32.0
-            tsx: 4.22.4
-            yaml: 2.9.0
-
-    vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0):
+    vite@8.1.3(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0):
         dependencies:
             lightningcss: 1.32.0
-            picomatch: 4.0.4
-            postcss: 8.5.15
-            rolldown: 1.0.3
+            picomatch: 4.0.5
+            postcss: 8.5.16
+            rolldown: 1.1.4
             tinyglobby: 0.2.17
         optionalDependencies:
             "@types/node": 25.9.3
@@ -8228,10 +7781,24 @@ snapshots:
             tsx: 4.22.4
             yaml: 2.9.0
 
-    vitest@4.1.9(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)):
+    vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0):
+        dependencies:
+            lightningcss: 1.32.0
+            picomatch: 4.0.5
+            postcss: 8.5.16
+            rolldown: 1.1.4
+            tinyglobby: 0.2.17
+        optionalDependencies:
+            "@types/node": 26.1.0
+            esbuild: 0.28.1
+            fsevents: 2.3.3
+            tsx: 4.22.4
+            yaml: 2.9.0
+
+    vitest@4.1.9(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(vite@8.1.3(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)):
         dependencies:
             "@vitest/expect": 4.1.9
-            "@vitest/mocker": 4.1.9(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))
+            "@vitest/mocker": 4.1.9(vite@8.1.3(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))
             "@vitest/pretty-format": 4.1.9
             "@vitest/runner": 4.1.9
             "@vitest/snapshot": 4.1.9
@@ -8248,7 +7815,7 @@ snapshots:
             tinyexec: 1.2.4
             tinyglobby: 0.2.17
             tinyrainbow: 3.1.0
-            vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
+            vite: 8.1.3(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
             why-is-node-running: 2.3.0
         optionalDependencies:
             "@types/node": 25.9.3


### PR DESCRIPTION
## What

Updates the docs dependency group:

- `@react-router/dev` 7.18.0 -> 8.1.0
- `ardo` 3.5.0 -> 3.6.1
- `isbot` 5.1.43 -> 5.1.44
- `lucide-react` 1.20.0 -> 1.23.0
- `react-router` 7.18.0 -> 8.1.0
- `vite` 8.0.16 -> 8.1.3

## Why

These packages share the docs build surface: Ardo owns the docs Vite plugin and UI primitives, React Router owns the docs routing/build pipeline, Lucide supplies the homepage icons used by the docs app, `isbot` is used by the docs server entry, and Vite is the docs build tool.

## Upstream changes that matter here

- Ardo 3.6.0 adds new UI components plus build-time SEO/link outputs, and includes accessibility fixes for search, mobile drawer, and tabs: https://github.com/sebastian-software/ardo/releases/tag/ardo-v3.6.0
- Ardo 3.6.1 fixes footer HTML rendering: https://github.com/sebastian-software/ardo/releases/tag/ardo-v3.6.1
- React Router 8.1.0 is now explicit in the docs workspace so Ardo and the app use the same major version instead of keeping a hidden v7/v8 split: https://github.com/remix-run/react-router/releases/tag/react-router%408.1.0
- Vite 8.1.3 keeps the same Node support shape this repo already targets (`^20.19.0 || >=22.12.0`), so the docs build remains inside the repo's Node 22/24 CI range: https://github.com/vitejs/vite/releases/tag/v8.1.3
- `lucide-react` and `isbot` do not require local API changes for the usages in this repo; their npm metadata still matches the existing React and user-agent detection usage:
  - https://www.npmjs.com/package/lucide-react/v/1.23.0
  - https://www.npmjs.com/package/isbot/v/5.1.44

## Local impact and code changes

- Existing usage checked: `ardo/vite`, `ardo/ui`, `virtual:ardo/config`, `lucide-react` icon imports, `isbot(userAgent)`, and `vite defineConfig`.
- React Router usage checked: `react-router.config.ts`, `entry.client.tsx`, `entry.server.tsx`, `root.tsx`, and `Link` imports in the home route.
- Required migrations: none.
- Beneficial adoption: none in this PR; the new Ardo components are not needed by the current docs pages.
- Follow-up from review: Greptile flagged that Ardo 3.6.1 already pulled React Router 8 internally. The docs workspace now declares React Router 8.1.0 directly, and `pnpm why` reports one version each for `react-router` and `@react-router/dev`.

## Validation

- `CI=true corepack pnpm run verify`: passed after aligning React Router to 8.1.0.
- Push hook also ran `tsc --noEmit`, `eslint src/`, and `prettier --check src/`: passed.

## Checklist

- [x] Tests added or updated
- [x] `npm run check` passes
- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
