### PR TITLE
feat(api): add ISO date output for worksheet exports

### DIFF
--- a/src/api/aoa.test.ts
+++ b/src/api/aoa.test.ts
@@ -32,6 +32,14 @@ describe("sheetToArray", () => {
 		]);
 	});
 
+	it("keeps default Date object output for date-formatted numeric cells", () => {
+		const ws = arrayToSheet([["Date"], [{ t: "n", v: 45292, z: "m/d/yy" }]]);
+
+		const rows = sheetToArray(ws);
+
+		expect(rows[1][0]).toBeInstanceOf(Date);
+	});
+
 	it("emits ISO strings for date and datetime formats", () => {
 		const ws = arrayToSheet([
 			["Date", "DateTime", "Time"],
@@ -50,6 +58,21 @@ describe("sheetToArray", () => {
 			["Date", "DateTime", "Time"],
 			["2024-01-01", "2024-01-01T12:00:00", "12:00"],
 		]);
+	});
+
+	it("emits local ISO strings once when UTC is false", () => {
+		const originalTimezone = process.env.TZ;
+		process.env.TZ = "Etc/GMT-5";
+		try {
+			const ws = arrayToSheet([["DateTime"], [{ t: "n", v: 45292.5, z: "m/d/yy h:mm" }]]);
+
+			expect(sheetToArray(ws, { dateOutput: "iso", UTC: false })).toStrictEqual([
+				["DateTime"],
+				["2024-01-01T17:00:00"],
+			]);
+		} finally {
+			process.env.TZ = originalTimezone;
+		}
 	});
 });
 

--- a/src/api/aoa.test.ts
+++ b/src/api/aoa.test.ts
@@ -15,6 +15,42 @@ describe("sheetToArray", () => {
 			["Bob", 25],
 		]);
 	});
+
+	it("keeps time-only number formats as raw values by default", () => {
+		const ws = arrayToSheet([
+			["Time", "Text"],
+			[{ t: "n", v: 0.5, z: "h:mm" }, "hello"],
+		]);
+
+		expect(sheetToArray(ws)).toStrictEqual([
+			["Time", "Text"],
+			[0.5, "hello"],
+		]);
+		expect(sheetToArray(ws, { raw: false, UTC: true })).toStrictEqual([
+			["Time", "Text"],
+			["12:00", "hello"],
+		]);
+	});
+
+	it("emits ISO strings for date and datetime formats", () => {
+		const ws = arrayToSheet([
+			["Date", "DateTime", "Time"],
+			[
+				{ t: "n", v: 45292, z: "m/d/yy" },
+				{ t: "n", v: 45292.5, z: "m/d/yy h:mm" },
+				{ t: "n", v: 0.5, z: "h:mm" },
+			],
+		]);
+
+		expect(sheetToArray(ws, { dateOutput: "iso", UTC: true })).toStrictEqual([
+			["Date", "DateTime", "Time"],
+			["2024-01-01", "2024-01-01T12:00:00", 0.5],
+		]);
+		expect(sheetToArray(ws, { raw: false, dateOutput: "iso", UTC: true })).toStrictEqual([
+			["Date", "DateTime", "Time"],
+			["2024-01-01", "2024-01-01T12:00:00", "12:00"],
+		]);
+	});
 });
 
 describe("aoa.ts — addArrayToSheet edge cases", () => {

--- a/src/api/csv.test.ts
+++ b/src/api/csv.test.ts
@@ -51,6 +51,24 @@ describe("csv.ts: advanced CSV features", () => {
 		expect(csv).toBe("1.23456789");
 	});
 
+	it("sheetToCsv with ISO date output", () => {
+		const ws = arrayToSheet([
+			["Date", "DateTime", "Time"],
+			[
+				{ t: "n", v: 45292, z: "m/d/yy" },
+				{ t: "n", v: 45292.5, z: "m/d/yy h:mm" },
+				{ t: "n", v: 0.5, z: "h:mm" },
+			],
+		]);
+
+		expect(sheetToCsv(ws, { dateOutput: "iso", UTC: true })).toBe(
+			"Date,DateTime,Time\n2024-01-01,2024-01-01T12:00:00,12:00",
+		);
+		expect(sheetToCsv(ws, { dateOutput: "iso", rawNumbers: true, UTC: true })).toBe(
+			"Date,DateTime,Time\n2024-01-01,2024-01-01T12:00:00,0.5",
+		);
+	});
+
 	it("sheetToCsv quotes commas", () => {
 		const ws = arrayToSheet([["A,B"]]);
 		const csv = sheetToCsv(ws);

--- a/src/api/csv.ts
+++ b/src/api/csv.ts
@@ -1,7 +1,7 @@
 import type { WorkSheet, Sheet2CSVOpts, Range } from "../types.js";
 import { encodeCol, safeDecodeRange, getCell } from "../utils/cell.js";
 import { clampLargeExportRange } from "../utils/export-range.js";
-import { formatCell } from "./format.js";
+import { formatCellForOutput, getCellDateTimeFormatKind } from "./format.js";
 import { arrayToSheet } from "./aoa.js";
 
 /** Regex to match double-quote characters for CSV escaping (doubled inside quoted fields) */
@@ -58,7 +58,14 @@ function buildCsvRow(
 			txt = "";
 		} else if (val.v != null) {
 			isempty = false;
-			txt = "" + (options.rawNumbers && val.t === "n" ? val.v : formatCell(val, null, options));
+			const fmtKind = getCellDateTimeFormatKind(val, options);
+			const useDateOutput =
+				options.dateOutput === "iso" && (val.t === "d" || fmtKind === "date" || fmtKind === "datetime");
+			txt =
+				"" +
+				(options.rawNumbers && val.t === "n" && !useDateOutput
+					? val.v
+					: formatCellForOutput(val, null, options));
 			txt = escapeFormulaText(txt, options);
 			// Check each character: if the text contains the field separator,
 			// record separator, LF (10), CR (13), or double-quote (34), wrap in quotes

--- a/src/api/format.test.ts
+++ b/src/api/format.test.ts
@@ -56,6 +56,21 @@ describe("api/format", () => {
 		).toBe("2024-01-01T12:00:00");
 	});
 
+	it("formats local ISO strings once when UTC is false", () => {
+		const originalTimezone = process.env.TZ;
+		process.env.TZ = "Etc/GMT-5";
+		try {
+			expect(
+				formatCellForOutput({ t: "n", v: 45292.5, z: "m/d/yy h:mm" }, null, {
+					dateOutput: "iso",
+					UTC: false,
+				}),
+			).toBe("2024-01-01T17:00:00");
+		} finally {
+			process.env.TZ = originalTimezone;
+		}
+	});
+
 	it("infers ISO output shape for Date objects without explicit formats", () => {
 		expect(
 			formatCellForOutput({ t: "d", v: new Date("2024-01-01T00:00:00Z") }, null, {
@@ -69,5 +84,14 @@ describe("api/format", () => {
 				UTC: true,
 			}),
 		).toBe("2024-01-01T12:34:56");
+	});
+
+	it("pads ISO years before 1000 to four digits", () => {
+		expect(
+			formatCellForOutput({ t: "d", v: new Date("0100-03-25T00:00:00.000Z"), z: "yyyy-mm-dd" }, null, {
+				dateOutput: "iso",
+				UTC: true,
+			}),
+		).toBe("0100-03-25");
 	});
 });

--- a/src/api/format.test.ts
+++ b/src/api/format.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { formatCell } from "../index.js";
+import { formatCellForOutput, getCellDateTimeFormatKind } from "./format.js";
 
 describe("api/format", () => {
 	it("formatCell should return empty for null/stub cells", () => {
@@ -26,5 +27,47 @@ describe("api/format", () => {
 		const cell: any = { t: "d", v: new Date("2024-01-15") };
 		formatCell(cell, null, { dateNF: "yyyy-mm-dd" });
 		expect(cell.z).toBe("yyyy-mm-dd");
+	});
+
+	it("classifies cell formats from XF records and custom format tables", () => {
+		expect(getCellDateTimeFormatKind({ t: "n", v: 45292, XF: { numFmtId: 14 } })).toBe("date");
+		expect(getCellDateTimeFormatKind({ t: "n", v: 45292, XF: { numFmtId: 27 } })).toBe("date");
+		expect(
+			getCellDateTimeFormatKind({ t: "n", v: 45292.5, XF: { numFmtId: 200 } }, { table: { 200: "m/d/yy h:mm" } }),
+		).toBe("datetime");
+		expect(getCellDateTimeFormatKind({ t: "n", v: 42, XF: { numFmtId: 63 } })).toBe("none");
+		expect(getCellDateTimeFormatKind({ t: "n", v: 42 })).toBe("none");
+	});
+
+	it("formats numeric date cells as ISO from XF records", () => {
+		expect(
+			formatCellForOutput({ t: "n", v: 45292, XF: { numFmtId: 14 } }, null, {
+				dateOutput: "iso",
+				dateNF: "yyyy-mm-dd",
+				UTC: true,
+			}),
+		).toBe("2024-01-01");
+		expect(
+			formatCellForOutput({ t: "n", v: 45292.5, XF: { numFmtId: 200 } }, null, {
+				dateOutput: "iso",
+				table: { 200: "m/d/yy h:mm" },
+				UTC: true,
+			}),
+		).toBe("2024-01-01T12:00:00");
+	});
+
+	it("infers ISO output shape for Date objects without explicit formats", () => {
+		expect(
+			formatCellForOutput({ t: "d", v: new Date("2024-01-01T00:00:00Z") }, null, {
+				dateOutput: "iso",
+				UTC: true,
+			}),
+		).toBe("2024-01-01");
+		expect(
+			formatCellForOutput({ t: "d", v: new Date("2024-01-01T12:34:56Z") }, null, {
+				dateOutput: "iso",
+				UTC: true,
+			}),
+		).toBe("2024-01-01T12:34:56");
 	});
 });

--- a/src/api/format.ts
+++ b/src/api/format.ts
@@ -2,7 +2,7 @@ import type { CellObject } from "../types.js";
 import { BErr } from "../types.js";
 import { formatNumber, getDateTimeFormatKind, type DateTimeFormatKind } from "../ssf/format.js";
 import { DEFAULT_FORMAT_MAP, DEFAULT_FORMAT_STRINGS, formatTable } from "../ssf/table.js";
-import { dateToSerialNumber, serialNumberToDate } from "../utils/date.js";
+import { dateToSerialNumber, serialNumberToDate, utcToLocal } from "../utils/date.js";
 
 function resolveNumberFormat(fmt: unknown, options?: any): string | undefined {
 	if (typeof fmt === "string") {
@@ -32,15 +32,15 @@ function pad2(value: number): string {
 	return value < 10 ? "0" + value : "" + value;
 }
 
-function formatDateIso(date: Date, kind: DateTimeFormatKind, options?: any): string {
-	const useUtc = options?.UTC !== false;
-	const year = useUtc ? date.getUTCFullYear() : date.getFullYear();
-	const month = (useUtc ? date.getUTCMonth() : date.getMonth()) + 1;
-	const day = useUtc ? date.getUTCDate() : date.getDate();
-	const hours = useUtc ? date.getUTCHours() : date.getHours();
-	const minutes = useUtc ? date.getUTCMinutes() : date.getMinutes();
-	const seconds = useUtc ? date.getUTCSeconds() : date.getSeconds();
-	const datePart = `${year}-${pad2(month)}-${pad2(day)}`;
+function formatDateIso(date: Date, kind: DateTimeFormatKind): string {
+	const year = date.getUTCFullYear();
+	const month = date.getUTCMonth() + 1;
+	const day = date.getUTCDate();
+	const hours = date.getUTCHours();
+	const minutes = date.getUTCMinutes();
+	const seconds = date.getUTCSeconds();
+	const yearPart = year < 1000 ? String(year).padStart(4, "0") : String(year);
+	const datePart = `${yearPart}-${pad2(month)}-${pad2(day)}`;
 	if (kind === "date") {
 		return datePart;
 	}
@@ -54,6 +54,10 @@ function inferDateKind(date: Date, options?: any): DateTimeFormatKind {
 	const seconds = useUtc ? date.getUTCSeconds() : date.getSeconds();
 	const ms = useUtc ? date.getUTCMilliseconds() : date.getMilliseconds();
 	return hours || minutes || seconds || ms ? "datetime" : "date";
+}
+
+function normalizeDateOutput(date: Date, options?: any): Date {
+	return options?.UTC === true ? date : utcToLocal(date);
 }
 
 /**
@@ -131,15 +135,14 @@ export function formatCellForOutput(cell: CellObject, value?: any, options?: any
 	const kind = getCellDateTimeFormatKind(cell, options);
 	if (cell.t === "n" && typeof cellValue === "number") {
 		if (kind === "date" || kind === "datetime") {
-			return formatDateIso(serialNumberToDate(cellValue, options?.date1904), kind, options);
+			return formatDateIso(normalizeDateOutput(serialNumberToDate(cellValue, options?.date1904), options), kind);
 		}
 		return formatCell(cell, value, options);
 	}
 	if (cellValue instanceof Date) {
 		return formatDateIso(
-			cellValue,
+			normalizeDateOutput(cellValue, options),
 			kind === "none" || kind === "time" ? inferDateKind(cellValue, options) : kind,
-			options,
 		);
 	}
 	return formatCell(cell, value, options);

--- a/src/api/format.ts
+++ b/src/api/format.ts
@@ -1,7 +1,60 @@
 import type { CellObject } from "../types.js";
 import { BErr } from "../types.js";
-import { formatNumber } from "../ssf/format.js";
-import { dateToSerialNumber } from "../utils/date.js";
+import { formatNumber, getDateTimeFormatKind, type DateTimeFormatKind } from "../ssf/format.js";
+import { DEFAULT_FORMAT_MAP, DEFAULT_FORMAT_STRINGS, formatTable } from "../ssf/table.js";
+import { dateToSerialNumber, serialNumberToDate } from "../utils/date.js";
+
+function resolveNumberFormat(fmt: unknown, options?: any): string | undefined {
+	if (typeof fmt === "string") {
+		return fmt === "m/d/yy" && options?.dateNF ? String(options.dateNF) : fmt;
+	}
+	if (typeof fmt !== "number") {
+		return undefined;
+	}
+	if (fmt === 14 && options?.dateNF) {
+		return String(options.dateNF);
+	}
+	const table = options?.table || formatTable;
+	return table[fmt] || table[DEFAULT_FORMAT_MAP[fmt]] || DEFAULT_FORMAT_STRINGS[fmt];
+}
+
+function resolveCellNumberFormat(cell: CellObject, options?: any): string | undefined {
+	return resolveNumberFormat(cell.z ?? cell.XF?.numFmtId, options);
+}
+
+/** Return the date/time classification for a cell's number format. */
+export function getCellDateTimeFormatKind(cell: CellObject, options?: any): DateTimeFormatKind {
+	const fmt = resolveCellNumberFormat(cell, options);
+	return fmt ? getDateTimeFormatKind(fmt) : "none";
+}
+
+function pad2(value: number): string {
+	return value < 10 ? "0" + value : "" + value;
+}
+
+function formatDateIso(date: Date, kind: DateTimeFormatKind, options?: any): string {
+	const useUtc = options?.UTC !== false;
+	const year = useUtc ? date.getUTCFullYear() : date.getFullYear();
+	const month = (useUtc ? date.getUTCMonth() : date.getMonth()) + 1;
+	const day = useUtc ? date.getUTCDate() : date.getDate();
+	const hours = useUtc ? date.getUTCHours() : date.getHours();
+	const minutes = useUtc ? date.getUTCMinutes() : date.getMinutes();
+	const seconds = useUtc ? date.getUTCSeconds() : date.getSeconds();
+	const datePart = `${year}-${pad2(month)}-${pad2(day)}`;
+	if (kind === "date") {
+		return datePart;
+	}
+	return `${datePart}T${pad2(hours)}:${pad2(minutes)}:${pad2(seconds)}`;
+}
+
+function inferDateKind(date: Date, options?: any): DateTimeFormatKind {
+	const useUtc = options?.UTC !== false;
+	const hours = useUtc ? date.getUTCHours() : date.getHours();
+	const minutes = useUtc ? date.getUTCMinutes() : date.getMinutes();
+	const seconds = useUtc ? date.getUTCSeconds() : date.getSeconds();
+	const ms = useUtc ? date.getUTCMilliseconds() : date.getMilliseconds();
+	return hours || minutes || seconds || ms ? "datetime" : "date";
+}
 
 /**
  * Attempt to format a cell value using the cell's number format or XF record.
@@ -61,4 +114,33 @@ export function formatCell(cell: CellObject, value?: any, options?: any): string
 		return safeFormatCell(cell, cell.v);
 	}
 	return safeFormatCell(cell, value);
+}
+
+/**
+ * Format a cell for worksheet export APIs.
+ *
+ * This mirrors `formatCell` by default. With `dateOutput: "iso"`, date and
+ * datetime number formats are rendered as stable ISO-like strings, while
+ * time-only formats keep their display value instead of becoming epoch dates.
+ */
+export function formatCellForOutput(cell: CellObject, value?: any, options?: any): string {
+	if (options?.dateOutput !== "iso") {
+		return formatCell(cell, value, options);
+	}
+	const cellValue = value == null ? cell.v : value;
+	const kind = getCellDateTimeFormatKind(cell, options);
+	if (cell.t === "n" && typeof cellValue === "number") {
+		if (kind === "date" || kind === "datetime") {
+			return formatDateIso(serialNumberToDate(cellValue, options?.date1904), kind, options);
+		}
+		return formatCell(cell, value, options);
+	}
+	if (cellValue instanceof Date) {
+		return formatDateIso(
+			cellValue,
+			kind === "none" || kind === "time" ? inferDateKind(cellValue, options) : kind,
+			options,
+		);
+	}
+	return formatCell(cell, value, options);
 }

--- a/src/api/json.ts
+++ b/src/api/json.ts
@@ -5,7 +5,7 @@ import { dateToSerialNumber, serialNumberToDate, utcToLocal, localToUtc } from "
 import { clampLargeExportRange } from "../utils/export-range.js";
 import { isDateFormat } from "../ssf/format.js";
 import { formatTable } from "../ssf/table.js";
-import { formatCell } from "./format.js";
+import { formatCell, formatCellForOutput, getCellDateTimeFormatKind } from "./format.js";
 
 function setRowValue(row: any, key: any, value: any): void {
 	if (key === "__proto__" || key === "constructor" || key === "prototype") {
@@ -73,15 +73,21 @@ function buildJsonRow(
 			case "s": // string
 			case "b": // boolean
 				break;
-			case "n": // number — may actually represent a date if the format is date-like
-				if (!val.z || !isDateFormat(String(val.z))) {
+			case "n": {
+				// Number may actually represent a date if the format is date-like.
+				if (!options.dateOutput && options.raw !== false) {
+					break;
+				}
+				const fmtKind = getCellDateTimeFormatKind(val, options);
+				if (fmtKind === "none" || fmtKind === "time") {
 					break;
 				}
 				// Number format indicates a date; convert serial number to JS Date
-				cellValue = serialNumberToDate(cellValue as number);
+				cellValue = serialNumberToDate(cellValue as number, options.date1904);
 				if (typeof cellValue === "number") {
 					break;
 				}
+			}
 			/* falls through */
 			case "d": // date
 				if (!(options && (options.UTC || options.raw === false))) {
@@ -104,12 +110,14 @@ function buildJsonRow(
 				}
 			} else {
 				// Use raw value when rawNumbers/raw is set, otherwise format for display
+				const useRaw = val.t === "n" && typeof options.rawNumbers === "boolean" ? options.rawNumbers : raw;
+				const fmtKind = getCellDateTimeFormatKind(val, options);
+				const useDateOutput =
+					options.dateOutput === "iso" && (val.t === "d" || fmtKind === "date" || fmtKind === "datetime");
 				setRowValue(
 					row,
 					headers[colIdx],
-					(val.t === "n" && typeof options.rawNumbers === "boolean" ? options.rawNumbers : raw)
-						? cellValue
-						: formatCell(val, cellValue, options),
+					useDateOutput || !useRaw ? formatCellForOutput(val, cellValue, options) : cellValue,
 				);
 			}
 			if (cellValue != null) {

--- a/src/api/json.ts
+++ b/src/api/json.ts
@@ -75,9 +75,6 @@ function buildJsonRow(
 				break;
 			case "n": {
 				// Number may actually represent a date if the format is date-like.
-				if (!options.dateOutput && options.raw !== false) {
-					break;
-				}
 				const fmtKind = getCellDateTimeFormatKind(val, options);
 				if (fmtKind === "none" || fmtKind === "time") {
 					break;
@@ -90,7 +87,7 @@ function buildJsonRow(
 			}
 			/* falls through */
 			case "d": // date
-				if (!(options && (options.UTC || options.raw === false))) {
+				if (!(options && (options.UTC || options.raw === false || options.dateOutput === "iso"))) {
 					cellValue = utcToLocal(new Date(cellValue));
 				}
 				break;

--- a/src/ssf/format.test.ts
+++ b/src/ssf/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatNumber, parseExcelDateCode, isDateFormat } from "./format.js";
+import { formatNumber, parseExcelDateCode, isDateFormat, getDateTimeFormatKind } from "./format.js";
 
 describe("formatNumber", () => {
 	describe("General format", () => {
@@ -1502,6 +1502,16 @@ describe("SSF: elapsed time formats", () => {
 	it("formats elapsed minutes [mm]:ss", () => {
 		const result = formatNumber("[mm]:ss", 0.5);
 		expect(result).toContain(":");
+	});
+});
+
+describe("SSF: date/time format classification", () => {
+	it("classifies calendar dates, datetimes, and time-only formats", () => {
+		expect(getDateTimeFormatKind("m/d/yy")).toBe("date");
+		expect(getDateTimeFormatKind("m/d/yy h:mm")).toBe("datetime");
+		expect(getDateTimeFormatKind("h:mm")).toBe("time");
+		expect(getDateTimeFormatKind("h:mm:ss AM/PM")).toBe("time");
+		expect(getDateTimeFormatKind("0.00")).toBe("none");
 	});
 });
 

--- a/src/ssf/format.ts
+++ b/src/ssf/format.ts
@@ -1060,20 +1060,36 @@ function SSF_split_fmt(fmt: string): string[] {
 /** Regex to detect absolute time tokens like [h], [mm], [ss] (including Thai equivalents) */
 const SSF_abstime = /\[[HhMmSs\u0E0A\u0E19\u0E17]*\]/;
 
+/** Classification for Excel number formats that include date/time tokens. */
+export type DateTimeFormatKind = "none" | "date" | "time" | "datetime";
+
+function classifyDateTimeTokens(hasDate: boolean, hasTime: boolean, hasMonth: boolean): DateTimeFormatKind {
+	if (hasDate) {
+		return hasTime ? "datetime" : "date";
+	}
+	if (hasTime) {
+		return "time";
+	}
+	return hasMonth ? "date" : "none";
+}
+
 /**
- * Determine if a format string represents a date/time format.
+ * Classify date/time tokens in a format string.
  *
  * Scans the format string for date/time tokens (y, m, d, h, s, etc.) while
  * skipping over quoted strings, escaped characters, numeric placeholders,
- * and color/condition blocks. Returns true as soon as any date/time token is found.
+ * and color/condition blocks.
  *
  * @param fmt - Excel number format string
- * @returns true if the format contains date/time formatting tokens
+ * @returns a classification of the date/time tokens in the format
  */
-export function isDateFormat(fmt: string): boolean {
+export function getDateTimeFormatKind(fmt: string): DateTimeFormatKind {
 	let i = 0;
 	let c = "";
 	let o = "";
+	let hasDate = false;
+	let hasTime = false;
+	let hasMonth = false;
 	while (i < fmt.length) {
 		switch ((c = fmt.charAt(i))) {
 			case "G":
@@ -1102,34 +1118,50 @@ export function isDateFormat(fmt: string): boolean {
 			case "b":
 				// "B1" or "B2" = Buddhist/Hijri calendar modifier => date format
 				if (fmt.charAt(i + 1) === "1" || fmt.charAt(i + 1) === "2") {
-					return true;
+					hasDate = true;
+					i += 2;
+					break;
 				}
 			/* falls through */
-			case "M":
 			case "D":
 			case "Y":
-			case "H":
-			case "S":
 			case "E":
-			case "m":
 			case "d":
 			case "y":
-			case "h":
-			case "s":
 			case "e":
 			case "g":
-				return true;
+				hasDate = true;
+				++i;
+				break;
+			case "M":
+			case "m":
+				hasMonth = true;
+				++i;
+				break;
+			case "H":
+			case "S":
+			case "h":
+			case "s":
+				hasTime = true;
+				++i;
+				break;
 			case "A":
 			case "a":
 			case "\u4E0A": // Chinese "上" (used in AM/PM: 上午/下午)
 				if (fmt.substring(i, i + 3).toUpperCase() === "A/P") {
-					return true;
+					hasTime = true;
+					i += 3;
+					break;
 				}
 				if (fmt.substring(i, i + 5).toUpperCase() === "AM/PM") {
-					return true;
+					hasTime = true;
+					i += 5;
+					break;
 				}
 				if (fmt.substring(i, i + 5).toUpperCase() === "\u4E0A\u5348/\u4E0B\u5348") {
-					return true; // Chinese AM/PM: 上午/下午
+					hasTime = true; // Chinese AM/PM: 上午/下午
+					i += 5;
+					break;
 				}
 				++i;
 				break;
@@ -1140,7 +1172,7 @@ export function isDateFormat(fmt: string): boolean {
 					o += fmt.charAt(i);
 				}
 				if (o.match(SSF_abstime)) {
-					return true;
+					hasTime = true;
 				}
 				break;
 			case ".":
@@ -1191,7 +1223,20 @@ export function isDateFormat(fmt: string): boolean {
 				break;
 		}
 	}
-	return false;
+	return classifyDateTimeTokens(hasDate, hasTime, hasMonth);
+}
+
+/**
+ * Determine if a format string represents a date/time format.
+ *
+ * Scans the format string for date/time tokens while skipping quoted strings,
+ * escaped characters, numeric placeholders, and color/condition blocks.
+ *
+ * @param fmt - Excel number format string
+ * @returns true if the format contains date/time formatting tokens
+ */
+export function isDateFormat(fmt: string): boolean {
+	return getDateTimeFormatKind(fmt) !== "none";
 }
 
 /** Token produced by the format string tokenizer */
@@ -1979,7 +2024,20 @@ export function formatNumber(fmt: string | number, value: any, options?: any): s
 	}
 	// Convert Date objects to serial numbers before formatting
 	if (value instanceof Date) {
-		value = dateToSerialNumber(value, options.date1904);
+		const dateValue = options.UTC
+			? value
+			: new Date(
+					Date.UTC(
+						value.getFullYear(),
+						value.getMonth(),
+						value.getDate(),
+						value.getHours(),
+						value.getMinutes(),
+						value.getSeconds(),
+						value.getMilliseconds(),
+					),
+				);
+		value = dateToSerialNumber(dateValue, options.date1904);
 	}
 	// Select the appropriate format section (positive/negative/zero/text)
 	const chosenFmt = choose_fmt(sfmt, value);

--- a/src/types.ts
+++ b/src/types.ts
@@ -526,6 +526,10 @@ export interface Sheet2CSVOpts {
 	escapeFormulae?: boolean;
 	/** Override date format for date cells */
 	dateNF?: NumberFormat;
+	/** If "iso", emit date/datetime cells as machine-readable ISO-like strings */
+	dateOutput?: "iso";
+	/** If true, use 1904 date system for date serial numbers */
+	date1904?: boolean;
 }
 
 /** Options for converting a worksheet to an HTML table string */
@@ -562,6 +566,10 @@ export interface Sheet2JSONOpts {
 	UTC?: boolean;
 	/** Override date format for date cells */
 	dateNF?: NumberFormat;
+	/** If "iso", emit date/datetime cells as machine-readable ISO-like strings */
+	dateOutput?: "iso";
+	/** If true, use 1904 date system for date serial numbers */
+	date1904?: boolean;
 }
 
 /** Options for creating a worksheet from a 2D array (Array of Arrays) */

--- a/src/utils/date.test.ts
+++ b/src/utils/date.test.ts
@@ -2,26 +2,29 @@ import { describe, it, expect } from "vitest";
 import { dateToSerialNumber, serialNumberToDate, localToUtc, utcToLocal } from "./date.js";
 
 describe("dateToSerialNumber", () => {
-	it("should convert 1900-01-01 to serial 2", () => {
-		// Epoch is 1899-12-30, so 1900-01-01 is 2 days later
+	it("should convert 1900-01-01 to serial 2 with the real-date epoch mapping", () => {
 		const d = new Date(Date.UTC(1900, 0, 1));
 		expect(dateToSerialNumber(d)).toBe(2);
 	});
 
-	it("should add 1 for dates at or after serial 60 (Lotus bug)", () => {
-		// 1900-02-28 is 60 days from epoch; >= 60 triggers the +1 adjustment
-		const d = new Date(Date.UTC(1900, 1, 28));
-		expect(dateToSerialNumber(d)).toBe(61);
+	it("should convert modern dates to Excel serials", () => {
+		const d = new Date(Date.UTC(2024, 0, 1));
+		expect(dateToSerialNumber(d)).toBe(45292);
 	});
 
-	it("should convert 1900-03-01 to serial 62", () => {
+	it("should map the real date at serial 60 to 1900-02-28", () => {
+		const d = new Date(Date.UTC(1900, 1, 28));
+		expect(dateToSerialNumber(d)).toBe(60);
+	});
+
+	it("should convert 1900-03-01 to serial 61", () => {
 		const d = new Date(Date.UTC(1900, 2, 1));
-		expect(dateToSerialNumber(d)).toBe(62);
+		expect(dateToSerialNumber(d)).toBe(61);
 	});
 
 	it("should convert 2023-01-01 correctly", () => {
 		const d = new Date(Date.UTC(2023, 0, 1));
-		expect(dateToSerialNumber(d)).toBe(44928);
+		expect(dateToSerialNumber(d)).toBe(44927);
 	});
 
 	it("should handle 1904 date system", () => {
@@ -42,11 +45,16 @@ describe("serialNumberToDate", () => {
 		expect(d.getUTCDate()).toBe(1);
 	});
 
-	it("should convert serial 44928 to 2023-01-01", () => {
-		const d = serialNumberToDate(44928);
+	it("should convert serial 44927 to 2023-01-01", () => {
+		const d = serialNumberToDate(44927);
 		expect(d.getUTCFullYear()).toBe(2023);
 		expect(d.getUTCMonth()).toBe(0);
 		expect(d.getUTCDate()).toBe(1);
+	});
+
+	it("should convert serial 45292 to 2024-01-01", () => {
+		const d = serialNumberToDate(45292);
+		expect(d.toISOString()).toBe("2024-01-01T00:00:00.000Z");
 	});
 
 	it("should roundtrip with dateToSerialNumber", () => {
@@ -59,11 +67,10 @@ describe("serialNumberToDate", () => {
 	});
 
 	it("should handle 1904 date system", () => {
-		const d = serialNumberToDate(44928, true);
-		// 1904 system adds 1462 days
-		const d1900 = serialNumberToDate(44928);
+		const d = serialNumberToDate(43465, true);
+		const d1900 = serialNumberToDate(44927);
 		const diff = d.getTime() - d1900.getTime();
-		expect(diff).toBe(1462 * 24 * 60 * 60 * 1000);
+		expect(diff).toBe(0);
 	});
 });
 

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,60 +1,45 @@
 /**
  * Convert a JavaScript Date to an Excel serial date number.
  *
- * Excel serial dates count days since 1899-12-30 (the epoch).
- * The 1900 date system intentionally includes a fictitious Feb 29, 1900
- * (serial number 60) to maintain compatibility with Lotus 1-2-3.
- * For serial numbers >= 60, we add 1 to skip over this phantom day.
+ * Excel serial dates in the 1900 date system can be mapped to real JavaScript
+ * dates with the 1899-12-30 epoch. This preserves modern Excel serials such as
+ * 45292 -> 2024-01-01 while avoiding a representational value for Excel's
+ * fictitious 1900-02-29.
  *
  * @param v - JavaScript Date to convert
  * @param date1904 - If true, use the 1904 date system (Mac Excel default), which shifts the epoch by 1462 days
  * @returns Excel serial date number
  */
 export function dateToSerialNumber(v: Date, date1904?: boolean): number {
-	let epoch = v.getTime();
+	const epoch = v.getTime();
 	if (date1904) {
-		// 1904 date system: subtract 1462 days (the offset between 1900-01-01 and 1904-01-01)
-		epoch -= 1462 * 24 * 60 * 60 * 1000;
+		const date1904Epoch = Date.UTC(1904, 0, 1, 0, 0, 0);
+		return (epoch - date1904Epoch) / (24 * 60 * 60 * 1000);
 	}
 	// Excel epoch: 1899-12-30T00:00:00Z (Dec 30, 1899)
 	const dnthresh = Date.UTC(1899, 11, 30, 0, 0, 0);
-	const result = (epoch - dnthresh) / (24 * 60 * 60 * 1000);
-	// Excel intentionally considers 1900-02-29 a valid date (serial 60) — Lotus 1-2-3 bug.
-	// For serial numbers < 60, no adjustment is needed.
-	if (result < 60) {
-		return result;
-	}
-	// For serial numbers >= 60, add 1 to account for the phantom Feb 29, 1900
-	if (result >= 60) {
-		return result + 1;
-	}
-	return result;
+	return (epoch - dnthresh) / (24 * 60 * 60 * 1000);
 }
 
 /**
  * Convert an Excel serial date number to a JavaScript Date.
  *
- * Reverses the conversion done by {@link dateToSerialNumber}, accounting for
- * the 1904 date system offset and the Lotus 1-2-3 leap year bug at serial 60.
+ * Reverses the conversion done by {@link dateToSerialNumber}. The SSF display
+ * formatter represents Excel's fictitious serial 60 separately; this helper
+ * returns real JavaScript Dates for machine-readable conversion paths.
  *
  * @param v - Excel serial date number
  * @param date1904 - If true, use the 1904 date system (adds 1462 days)
  * @returns JavaScript Date corresponding to the serial number
  */
 export function serialNumberToDate(v: number, date1904?: boolean): Date {
-	let date = v;
 	if (date1904) {
-		// 1904 system: add back the 1462-day offset
-		date += 1462;
-	}
-	// Lotus 1-2-3 bug: serial 60 is the fictitious 1900-02-29.
-	// For serial > 60, subtract 1 to compensate for the phantom day.
-	if (date > 60) {
-		--date;
+		const date1904Epoch = Date.UTC(1904, 0, 1, 0, 0, 0);
+		return new Date(date1904Epoch + v * 24 * 60 * 60 * 1000);
 	}
 	// Excel epoch: 1899-12-30T00:00:00Z
 	const dnthresh = Date.UTC(1899, 11, 30, 0, 0, 0);
-	return new Date(dnthresh + date * 24 * 60 * 60 * 1000);
+	return new Date(dnthresh + v * 24 * 60 * 60 * 1000);
 }
 
 /**

--- a/src/xlsx-integration.test.ts
+++ b/src/xlsx-integration.test.ts
@@ -85,6 +85,18 @@ describe("Cell Types", () => {
 		const wb2 = await roundtrip(createWorkbook(ws, "S"));
 		expect(wb2.Sheets.S.A1.v).toBe(44927);
 	});
+
+	it("date serials with date styles read as correct UTC dates with cellDates", async () => {
+		const ws = createSheet();
+		ws.A1 = { t: "n", v: 45292, z: "m/d/yy" };
+		ws["!ref"] = "A1";
+
+		const bytes = await write(createWorkbook(ws, "S"), { cellStyles: true });
+		const wb2 = await read(bytes, { cellDates: true, UTC: true });
+
+		expect(wb2.Sheets.S.A1.t).toBe("d");
+		expect((wb2.Sheets.S.A1.v as Date).toISOString()).toBe("2024-01-01T00:00:00.000Z");
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/src/xlsx/worksheet.test.ts
+++ b/src/xlsx/worksheet.test.ts
@@ -252,6 +252,34 @@ describe("parseWorksheetXml: direct XML parsing", () => {
 		}
 	});
 
+	it("keeps time-only styled numbers numeric with cellDates enabled", () => {
+		const xml = `<?xml version="1.0"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+<sheetData>
+<row r="1"><c r="A1" s="1"><v>0.5</v></c></row>
+</sheetData>
+</worksheet>`;
+		const styles: any = {
+			NumberFmt: {},
+			CellXf: [{ numFmtId: 0 }, { numFmtId: 20 }],
+			Fonts: [],
+			Fills: [],
+			Borders: [],
+		};
+
+		const ws = parseWorksheetXml(
+			xml,
+			{ cellDates: true, cellNF: true },
+			0,
+			undefined,
+			undefined,
+			undefined,
+			styles,
+		);
+
+		expect((ws as any).A1).toMatchObject({ t: "n", v: 0.5, z: "h:mm", w: "12:00" });
+	});
+
 	it("parses worksheet with hyperlinks", () => {
 		const xml = `<?xml version="1.0"?>
 <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"

--- a/src/xlsx/worksheet.ts
+++ b/src/xlsx/worksheet.ts
@@ -11,7 +11,7 @@ import {
 	xmlOptionLimit,
 } from "../xml/limits.js";
 import { safeDecodeRange, encodeRange, encodeCell } from "../utils/cell.js";
-import { formatNumber, isDateFormat } from "../ssf/format.js";
+import { formatNumber, getDateTimeFormatKind } from "../ssf/format.js";
 import { formatTable } from "../ssf/table.js";
 import { dateToSerialNumber, serialNumberToDate } from "../utils/date.js";
 import type { SST } from "./shared-strings.js";
@@ -384,7 +384,8 @@ function parseSheetData(
 					// Convert numeric cells with date formats to Date objects if cellDates is enabled
 					if (opts.cellDates && cell.XF) {
 						const fmtStr = nfmt || formatTable[cell.XF.numFmtId || 0] || "";
-						if (typeof fmtStr === "string" && isDateFormat(fmtStr) && typeof cell.v === "number") {
+						const fmtKind = typeof fmtStr === "string" ? getDateTimeFormatKind(fmtStr) : "none";
+						if (fmtKind !== "none" && fmtKind !== "time" && typeof cell.v === "number") {
 							cell.t = "d";
 							cell.v = serialNumberToDate(cell.v, date1904);
 						}


### PR DESCRIPTION
## What

- Fix Excel serial date conversion so modern serials like `45292` resolve to `2024-01-01` in machine-readable Date paths.
- Distinguish calendar date/datetime formats from time-only formats so `h:mm` stays a time value/display string instead of becoming an epoch date.
- Add `dateOutput: "iso"` for `sheetToCsv`, `sheetToJson`, and `sheetToArray` output paths.

## Why

Closes #72
Closes #73
Closes #74

## Validation

- [x] Tests added or updated
- [x] `pnpm test src/utils/date.test.ts src/ssf/format.test.ts src/api/aoa.test.ts src/api/csv.test.ts src/xlsx-integration.test.ts`
- [x] `pnpm run verify` through format, lint, typecheck, coverage, build, and publint
- [x] `npm pack --silent` + `pnpm dlx @arethetypeswrong/cli xlsx-format-2.3.4.tgz --format table`
- [x] `pnpm run smoke:exports`
- [x] `pnpm --filter docs build`
- [x] Commit messages follow Conventional Commits