### PR TITLE
fix(api): keep CSV ISO datetimes timezone-stable

### DIFF
--- a/src/api/aoa.test.ts
+++ b/src/api/aoa.test.ts
@@ -71,7 +71,11 @@ describe("sheetToArray", () => {
 				["2024-01-01T17:00:00"],
 			]);
 		} finally {
-			process.env.TZ = originalTimezone;
+			if (originalTimezone === undefined) {
+				delete process.env.TZ;
+			} else {
+				process.env.TZ = originalTimezone;
+			}
 		}
 	});
 });

--- a/src/api/csv.test.ts
+++ b/src/api/csv.test.ts
@@ -69,6 +69,26 @@ describe("csv.ts: advanced CSV features", () => {
 		);
 	});
 
+	it("sheetToCsv keeps default ISO datetime output timezone-stable", () => {
+		const originalTimezone = process.env.TZ;
+		process.env.TZ = "Europe/Berlin";
+		try {
+			const ws = arrayToSheet([
+				["Date", "Text"],
+				[{ t: "n", v: 45292.5, z: "m/d/yy h:mm" }, "hello"],
+			]);
+
+			expect(sheetToCsv(ws, { dateOutput: "iso", strip: true, blankrows: false })).toBe(
+				"Date,Text\n2024-01-01T12:00:00,hello",
+			);
+			expect(sheetToCsv(ws, { dateOutput: "iso", UTC: false, strip: true, blankrows: false })).toBe(
+				"Date,Text\n2024-01-01T13:00:00,hello",
+			);
+		} finally {
+			process.env.TZ = originalTimezone;
+		}
+	});
+
 	it("sheetToCsv quotes commas", () => {
 		const ws = arrayToSheet([["A,B"]]);
 		const csv = sheetToCsv(ws);

--- a/src/api/csv.test.ts
+++ b/src/api/csv.test.ts
@@ -85,7 +85,11 @@ describe("csv.ts: advanced CSV features", () => {
 				"Date,Text\n2024-01-01T13:00:00,hello",
 			);
 		} finally {
-			process.env.TZ = originalTimezone;
+			if (originalTimezone === undefined) {
+				delete process.env.TZ;
+			} else {
+				process.env.TZ = originalTimezone;
+			}
 		}
 	});
 

--- a/src/api/format.test.ts
+++ b/src/api/format.test.ts
@@ -67,7 +67,11 @@ describe("api/format", () => {
 				}),
 			).toBe("2024-01-01T17:00:00");
 		} finally {
-			process.env.TZ = originalTimezone;
+			if (originalTimezone === undefined) {
+				delete process.env.TZ;
+			} else {
+				process.env.TZ = originalTimezone;
+			}
 		}
 	});
 

--- a/src/api/format.ts
+++ b/src/api/format.ts
@@ -57,7 +57,7 @@ function inferDateKind(date: Date, options?: any): DateTimeFormatKind {
 }
 
 function normalizeDateOutput(date: Date, options?: any): Date {
-	return options?.UTC === true ? date : utcToLocal(date);
+	return options?.UTC === false ? utcToLocal(date) : date;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -528,6 +528,8 @@ export interface Sheet2CSVOpts {
 	dateNF?: NumberFormat;
 	/** If "iso", emit date/datetime cells as machine-readable ISO-like strings */
 	dateOutput?: "iso";
+	/** If true, interpret dates as UTC */
+	UTC?: boolean;
 	/** If true, use 1904 date system for date serial numbers */
 	date1904?: boolean;
 }


### PR DESCRIPTION
Fixes #78.

## Summary
- keep `dateOutput: "iso"` timezone-stable by default for shared worksheet export formatting
- preserve explicit `UTC: false` local-time output behavior
- expose `UTC` on `Sheet2CSVOpts`
- add a Europe/Berlin regression for `sheetToCsv` datetime serials

## Validation
- `pnpm test src/api/csv.test.ts src/api/aoa.test.ts src/api/format.test.ts`
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run check`
- `pnpm test`