### PR TITLE
fix: preserve Unicode when reading XLSX XML parts

### DIFF
--- a/src/unicode-read.test.ts
+++ b/src/unicode-read.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { read, sheetToCsv, write } from "./index.js";
+import { zipWrite } from "./zip/index.js";
+
+const sheetName = "Büro Süd";
+const plainText = "Grüße Straße café 日本語 😀";
+const richXml = "<r><rPr><b/></rPr><t>Crème </t></r><r><t>brûlée 東京 🎵</t></r>";
+
+/** Literal OOXML keeps the reader regression independent of our XML writer. */
+async function unicodeWorkbook(): Promise<Uint8Array> {
+	const main = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+	const rel = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+	const parts: Record<string, string> = {
+		"[Content_Types].xml": `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+<Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+<Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+<Override PartName="/xl/sharedStrings.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml"/>
+</Types>`,
+		"_rels/.rels": `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+<Relationship Id="rId1" Type="${rel}/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>`,
+		"xl/workbook.xml": `<workbook xmlns="${main}" xmlns:r="${rel}">
+<workbookPr codeName="Büro"/>
+<sheets><sheet name="Büro Süd" sheetId="1" r:id="rId1"/></sheets>
+<definedNames><definedName name="Größe">'Büro Süd'!$A$1</definedName></definedNames>
+</workbook>`,
+		"xl/_rels/workbook.xml.rels": `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+<Relationship Id="rId1" Type="${rel}/worksheet" Target="worksheets/sheet1.xml"/>
+<Relationship Id="rId2" Type="${rel}/sharedStrings" Target="sharedStrings.xml"/>
+</Relationships>`,
+		"xl/worksheets/sheet1.xml": `<worksheet xmlns="${main}"><dimension ref="A1:C1"/><sheetData><row r="1">
+<c r="A1" t="s"><v>0</v></c><c r="B1" t="s"><v>1</v></c><c r="C1" t="s"><v>2</v></c>
+</row></sheetData></worksheet>`,
+		"xl/sharedStrings.xml": `<sst xmlns="${main}" count="3" uniqueCount="3">
+<si><t>${plainText}</t></si><si>${richXml}</si><si><t>café &amp; th&#233; _x00FC_</t></si>
+</sst>`,
+	};
+	const encoder = new TextEncoder();
+	return zipWrite({
+		files: Object.fromEntries(Object.entries(parts).map(([path, xml]) => [path, encoder.encode(xml)])),
+	});
+}
+
+describe("Unicode XLSX input", () => {
+	it.each([true, false])("preserves shared strings and rich text with cellHTML=%s", async (cellHTML) => {
+		const wb = await read(await unicodeWorkbook(), { cellHTML, WTF: true });
+		const ws = wb.Sheets[wb.SheetNames[0]];
+		expect(ws.A1.v).toBe(plainText);
+		expect(ws.A1.r).toBe(`<t>${plainText}</t>`);
+		expect(ws.B1.v).toBe("Crème brûlée 東京 🎵");
+		expect(ws.B1.r).toBe(richXml);
+		expect(ws.C1.v).toBe("café & thé ü");
+		if (cellHTML) {
+			expect(ws.A1.h).toBe(plainText);
+			expect(ws.B1.h).toBe('<span style=""><b>Crème </b></span>brûlée 東京 🎵');
+		} else {
+			expect(ws.A1.h).toBeUndefined();
+			expect(ws.B1.h).toBeUndefined();
+		}
+		expect(sheetToCsv(ws)).toBe(`${plainText},Crème brûlée 東京 🎵,café & thé ü`);
+	});
+
+	it("preserves sheet names, workbook code names, and defined names", async () => {
+		const wb = await read(await unicodeWorkbook(), { WTF: true });
+		expect(wb.SheetNames).toStrictEqual([sheetName]);
+		expect(wb.Sheets[sheetName]).toBeDefined();
+		expect(wb.Workbook?.WBProps?.CodeName).toBe("Büro");
+		expect(wb.Workbook?.Names).toStrictEqual([{ Name: "Größe", Ref: "'Büro Süd'!$A$1" }]);
+	});
+
+	it("preserves names in the sheet-only read path", async () => {
+		const wb = await read(await unicodeWorkbook(), { bookSheets: true });
+		expect(wb.SheetNames).toStrictEqual([sheetName]);
+	});
+
+	it.each([true, false])("preserves Unicode on re-export with bookSST=%s", async (bookSST) => {
+		const original = await read(await unicodeWorkbook(), { WTF: true });
+		const wb = await read(await write(original, { bookSST }), { WTF: true });
+		expect(wb.SheetNames).toStrictEqual([sheetName]);
+		expect(sheetToCsv(wb.Sheets[sheetName])).toBe(`${plainText},Crème brûlée 東京 🎵,café & thé ü`);
+	});
+});

--- a/src/utils/buffer.test.ts
+++ b/src/utils/buffer.test.ts
@@ -1,32 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { utf8read, utf8encode, utf8decode, NULL_CHAR_REGEX, CONTROL_CHAR_REGEX } from "./buffer.js";
+import { utf8encode, utf8decode, NULL_CHAR_REGEX, CONTROL_CHAR_REGEX } from "./buffer.js";
 
 describe("utils/buffer", () => {
 	it("utf8encode and utf8decode should roundtrip", () => {
 		const s = "Hello, Wörld! 日本語";
 		expect(utf8decode(utf8encode(s))).toBe(s);
-	});
-
-	it("utf8read should decode ASCII", () => {
-		expect(utf8read("Hello")).toBe("Hello");
-	});
-
-	it("utf8read should decode 2-byte UTF-8", () => {
-		// ö = U+00F6 = 0xC3 0xB6 in UTF-8
-		const binary = String.fromCharCode(0xc3, 0xb6);
-		expect(utf8read(binary)).toBe("ö");
-	});
-
-	it("utf8read should decode 3-byte UTF-8", () => {
-		// 日 = U+65E5 = 0xE6 0x97 0xA5
-		const binary = String.fromCharCode(0xe6, 0x97, 0xa5);
-		expect(utf8read(binary)).toBe("日");
-	});
-
-	it("utf8read should decode 4-byte UTF-8 (surrogate pair)", () => {
-		// 𝄞 (musical symbol G clef) = U+1D11E = 0xF0 0x9D 0x84 0x9E
-		const binary = String.fromCharCode(0xf0, 0x9d, 0x84, 0x9e);
-		expect(utf8read(binary)).toBe("𝄞");
 	});
 
 	it("should export regex patterns", () => {

--- a/src/utils/buffer.ts
+++ b/src/utils/buffer.ts
@@ -19,62 +19,6 @@ export function utf8decode(data: Uint8Array): string {
 	return decoder.decode(data);
 }
 
-/**
- * Decode a UTF-8 binary string (where each character's charCode is a byte value)
- * into a proper JavaScript string.
- *
- * This manually implements UTF-8 decoding for strings that store raw byte values
- * as character codes (common in legacy binary formats).
- *
- * UTF-8 byte patterns:
- *   - 0xxxxxxx (0-127): single-byte ASCII
- *   - 110xxxxx 10xxxxxx (192-223): two-byte sequence
- *   - 1110xxxx 10xxxxxx 10xxxxxx (224-239): three-byte sequence
- *   - 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx (240-247): four-byte sequence (produces surrogate pair)
- *
- * @param orig - Binary string with byte values as char codes
- * @returns Properly decoded JavaScript string
- */
-export function utf8read(orig: string): string {
-	let out = "";
-	let i = 0;
-	let byte1 = 0;
-	let byte2 = 0;
-	let byte3 = 0;
-	let byte4 = 0;
-	let codePoint = 0;
-	while (i < orig.length) {
-		byte1 = orig.charCodeAt(i++);
-		if (byte1 < 128) {
-			// Single-byte ASCII character
-			out += String.fromCharCode(byte1);
-			continue;
-		}
-		byte2 = orig.charCodeAt(i++);
-		if (byte1 > 191 && byte1 < 224) {
-			// Two-byte sequence: 110xxxxx 10xxxxxx
-			codePoint = ((byte1 & 31) << 6) | (byte2 & 63);
-			out += String.fromCharCode(codePoint);
-			continue;
-		}
-		byte3 = orig.charCodeAt(i++);
-		if (byte1 < 240) {
-			// Three-byte sequence: 1110xxxx 10xxxxxx 10xxxxxx
-			out += String.fromCharCode(((byte1 & 15) << 12) | ((byte2 & 63) << 6) | (byte3 & 63));
-			continue;
-		}
-		// Four-byte sequence: 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
-		// Produces a code point above U+FFFF, requiring a UTF-16 surrogate pair
-		byte4 = orig.charCodeAt(i++);
-		codePoint = (((byte1 & 7) << 18) | ((byte2 & 63) << 12) | ((byte3 & 63) << 6) | (byte4 & 63)) - 65536;
-		// High surrogate: 0xD800 + upper 10 bits
-		out += String.fromCharCode(0xd800 + ((codePoint >>> 10) & 1023));
-		// Low surrogate: 0xDC00 + lower 10 bits
-		out += String.fromCharCode(0xdc00 + (codePoint & 1023));
-	}
-	return out;
-}
-
 /** Regex matching NUL (U+0000) characters globally */
 
 export const NULL_CHAR_REGEX = /\0/g;

--- a/src/xlsx/parse-zip.ts
+++ b/src/xlsx/parse-zip.ts
@@ -23,7 +23,6 @@ import { parseVml } from "./vml.js";
 import { parseMetadataXml } from "./metadata.js";
 import { parseCalcChainXml } from "./calc-chain.js";
 import { resetFormatTable } from "../ssf/table.js";
-import { utf8read } from "../utils/buffer.js";
 import { RELS as RELTYPE } from "../xml/namespaces.js";
 import { assertXmlPartLimits } from "../xml/limits.js";
 
@@ -194,7 +193,7 @@ function safe_parse_sheet(
 			const dfile = resolve_path((_ws as any)["!legdrawel"].Target, path);
 			const draw = getZipString(zip, dfile, true, opts);
 			if (draw) {
-				parseVml(utf8read(draw), _ws, comments);
+				parseVml(draw, _ws, comments);
 			}
 		}
 	} catch (e) {

--- a/src/xlsx/shared-strings.ts
+++ b/src/xlsx/shared-strings.ts
@@ -3,7 +3,6 @@ import { parseXmlTag, XML_TAG_REGEX, XML_HEADER } from "../xml/parser.js";
 import { unescapeXml, escapeXml, escapeHtml } from "../xml/escape.js";
 import { writeXmlElement } from "../xml/writer.js";
 import { XMLNS_main } from "../xml/namespaces.js";
-import { utf8read } from "../utils/buffer.js";
 import type { XmlLimitOptions } from "../xml/limits.js";
 import {
 	assertXmlCountWithinLimit,
@@ -311,20 +310,20 @@ function parseStringItem(x: string, opts?: SstParseOptions): XLString {
 
 	if (x.match(/^\s*<(?:\w+:)?t[^>]*>/)) {
 		// Plain text: extract content between <t> and </t>
-		result.t = unescapeXml(utf8read(x.slice(x.indexOf(">") + 1).split(/<\/(?:\w+:)?t>/)[0] || ""), true);
-		result.r = utf8read(x);
+		result.t = unescapeXml(x.slice(x.indexOf(">") + 1).split(/<\/(?:\w+:)?t>/)[0] || "", true);
+		result.r = x;
 		if (html) {
 			result.h = escapeHtml(result.t);
 		}
 	} else if (x.match(sirregex)) {
 		// Rich text: concatenate text from all runs
-		result.r = utf8read(x);
+		result.r = x;
 		// Strip phonetic run (<rPh>) elements before extracting text
 		const stripped = str_remove_xml_ns_g_local(x, "rPh");
 		sitregex.lastIndex = 0;
 		const matches = stripped.match(sitregex) || [];
 		// Join all <t> content and strip tags to get plain text
-		result.t = unescapeXml(utf8read(matches.join("").replace(XML_TAG_REGEX, "")), true);
+		result.t = unescapeXml(matches.join("").replace(XML_TAG_REGEX, ""), true);
 		if (html) {
 			result.h = richTextToHtml(parseRichTextRuns(result.r, opts));
 		}

--- a/src/xlsx/workbook.ts
+++ b/src/xlsx/workbook.ts
@@ -3,7 +3,6 @@ import { parseXmlTag, XML_TAG_REGEX, XML_HEADER, stripNamespace, parseXmlBoolean
 import { unescapeXml, escapeXml } from "../xml/escape.js";
 import { writeXmlElement } from "../xml/writer.js";
 import { XMLNS_main, XMLNS } from "../xml/namespaces.js";
-import { utf8read } from "../utils/buffer.js";
 import type { WorkBook } from "../types.js";
 
 /** Parsed workbook.xml structure */
@@ -384,7 +383,7 @@ export function parseWorkbookXml(data: string, _opts?: any): WorkbookFile {
 					}
 				});
 				if (parsedTag.codeName) {
-					workbook.WBProps.CodeName = utf8read(parsedTag.codeName);
+					workbook.WBProps.CodeName = parsedTag.codeName;
 				}
 				break;
 
@@ -407,14 +406,14 @@ export function parseWorkbookXml(data: string, _opts?: any): WorkbookFile {
 						parsedTag.Hidden = 0;
 				}
 				delete parsedTag.state;
-				parsedTag.name = unescapeXml(utf8read(parsedTag.name));
+				parsedTag.name = unescapeXml(parsedTag.name);
 				delete parsedTag[0];
 				workbook.Sheets.push(parsedTag);
 				break;
 
 			case "<definedName": {
 				dname = {};
-				dname.Name = utf8read(parsedTag.name);
+				dname.Name = parsedTag.name;
 				if (parsedTag.comment) {
 					dname.Comment = parsedTag.comment;
 				}
@@ -430,7 +429,7 @@ export function parseWorkbookXml(data: string, _opts?: any): WorkbookFile {
 			}
 			case "</definedName>": {
 				// Extract the defined name reference formula from between open/close tags
-				dname.Ref = unescapeXml(utf8read(data.slice(dnstart, idx)));
+				dname.Ref = unescapeXml(data.slice(dnstart, idx));
 				workbook.Names.push(dname);
 				break;
 			}

--- a/src/zip/index.ts
+++ b/src/zip/index.ts
@@ -409,6 +409,7 @@ export async function zipWrite(archive: ZipArchive, compress?: boolean): Promise
 
 /**
  * Read a file from a ZIP archive as a UTF-8 string.
+ * XML parsers consume this decoded text directly; do not decode it again.
  *
  * Falls back to trying with/without a leading slash if the exact path is not found.
  *


### PR DESCRIPTION
## What

Preserve Unicode text when reading XLSX files by removing the second UTF-8 decoding pass from shared strings (including rich text), sheet names, workbook code names, defined names and references, and VML input. Remove the now-unused internal binary-string decoder and document the decoding boundary in `zipReadString`.

## Why

`zipReadString` already converts ZIP bytes into JavaScript strings with `TextDecoder`. Passing those strings through the legacy byte-oriented `utf8read` interprets Unicode characters as UTF-8 lead bytes and corrupts the text. For example, a sheet named `Büro Süd` becomes `B𲯠S𤀀`. Subsequent exports preserve or compound the corruption.

Six regression cases use synthetic, literal OOXML encoded as UTF-8, independently of the library's XML writer. They cover accented Latin text, Japanese, emoji, plain and rich shared strings, HTML enabled/disabled, XML entities and OOXML escapes, workbook metadata, sheet-only reads, CSV conversion, and XLSX re-export with and without a shared string table. All six failed before the fix and pass after it.

## Checklist

- [x] Tests added or updated
- [x] `npm run check` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (1,030 tests through the coverage command)
- [x] Commit messages follow Conventional Commits

## Validation

Format, ESLint, TypeScript, all 1,030 tests with coverage, ESM/CJS builds, publint, package type-resolution checks, and export smoke checks passed. The commit hook also passed.

The full `pnpm run verify` reached the documentation step, which encountered an existing unmarked local generated-docs directory. In a clean temporary source snapshot, API generation and client/server compilation succeeded, but prerendering could not bind the local preview port in the sandbox (`EPERM`). That build also reported a generated link to the missing `/api-reference/variables` index. Documentation build completion remains for CI; no documentation, dependency manifests, or lockfiles are changed by this PR.
