### PR TITLE
fix: preserve XML escapes and Unicode code points

### DIFF
--- a/src/xml/escape.ts
+++ b/src/xml/escape.ts
@@ -17,14 +17,31 @@ const XML_ESCAPE_MAP: Record<string, string> = {
 };
 
 // Matches XML named entities (&quot; etc.) and numeric character references (&#x1A; or &#26;)
-const encregex = /&(?:quot|apos|gt|lt|amp|#x?([\da-f]+));/gi;
+const encregex = /&(?:quot|apos|gt|lt|amp|#(?:x([\da-f]+)|(\d+)));/gi;
 // Matches OOXML-style escaped Unicode characters like _x0020_ (underscore-hex encoding)
 const coderegex = /_x([\da-fA-F]{4})_/g;
+// Matches the leading underscore of literal text that would otherwise be interpreted as an OOXML escape on read.
+const literalCoderegex = /_(?=x[\da-fA-F]{4}_)/g;
 // Matches characters that must be escaped in XML: & < > ' "
 const decregex = /[&<>'"]/g;
 // Matches XML-illegal control characters (U+0000-U+0008, U+000B-U+001F, U+FFFE-U+FFFF)
 // eslint-disable-next-line no-control-regex
 const charegex = /[\u0000-\u0008\u000b-\u001f\uFFFE\uFFFF]/g;
+
+/**
+ * Check whether a number is a character allowed by the XML 1.0 Char production.
+ * XML excludes surrogate code points and values outside the listed ranges.
+ */
+function isValidXmlCodePoint(codePoint: number): boolean {
+	return (
+		codePoint === 0x9 ||
+		codePoint === 0xa ||
+		codePoint === 0xd ||
+		(codePoint >= 0x20 && codePoint <= 0xd7ff) ||
+		(codePoint >= 0xe000 && codePoint <= 0xfffd) ||
+		(codePoint >= 0x10000 && codePoint <= 0x10ffff)
+	);
+}
 
 /**
  * Recursively unescape XML entities, handling CDATA sections.
@@ -37,9 +54,13 @@ function rawUnescapeXml(text: string): string {
 	if (i === -1) {
 		// No CDATA: replace named/numeric entities then OOXML _xHHHH_ escapes
 		return str
-			.replace(encregex, ($$, $1) => {
+			.replace(encregex, ($$, $1, $2) => {
 				// Try named entity first, then parse as hex (&#xHH;) or decimal (&#DD;)
-				return encodings[$$] || String.fromCharCode(parseInt($1, $$.indexOf("x") > -1 ? 16 : 10)) || $$;
+				if (encodings[$$]) {
+					return encodings[$$];
+				}
+				const codePoint = Number.parseInt($1 || $2, $1 ? 16 : 10);
+				return isValidXmlCodePoint(codePoint) ? String.fromCodePoint(codePoint) : $$;
 			})
 			.replace(coderegex, (_m, c) => {
 				return String.fromCharCode(parseInt(c, 16));
@@ -70,9 +91,14 @@ export function unescapeXml(text: string, xlsx?: boolean): string {
  */
 export function escapeXml(text: string): string {
 	const str = text;
-	return str
-		.replace(decregex, (char) => XML_ESCAPE_MAP[char])
-		.replace(charegex, (char) => "_x" + ("000" + char.charCodeAt(0).toString(16)).slice(-4) + "_");
+	return (
+		str
+			.replace(decregex, (char) => XML_ESCAPE_MAP[char])
+			// A literal _xHHHH_ would be decoded as an OOXML escape during a roundtrip.
+			// Escaping its leading underscore as _x005F_ makes the reader decode it once.
+			.replace(literalCoderegex, () => "_x005F_")
+			.replace(charegex, (char) => "_x" + ("000" + char.charCodeAt(0).toString(16)).slice(-4) + "_")
+	);
 }
 
 /**

--- a/src/xml/xml.test.ts
+++ b/src/xml/xml.test.ts
@@ -21,6 +21,14 @@ describe("escapeXml", () => {
 		expect(escapeXml("\x1F")).toBe("_x001f_");
 	});
 
+	it("should preserve literal OOXML escape-looking sequences", () => {
+		const input = "_x0041_ _x000A_ _x005F_ _x0041_x0042_ _x0041__x0042_";
+		expect(escapeXml(input)).toBe(
+			"_x005F_x0041_ _x005F_x000A_ _x005F_x005F_ _x005F_x0041_x005F_x0042_ _x005F_x0041__x005F_x0042_",
+		);
+		expect(unescapeXml(escapeXml(input))).toBe(input);
+	});
+
 	it("should pass through normal text unchanged", () => {
 		expect(escapeXml("Hello World 123")).toBe("Hello World 123");
 	});
@@ -38,6 +46,12 @@ describe("unescapeXml", () => {
 	it("should unescape numeric character references", () => {
 		expect(unescapeXml("&#65;")).toBe("A");
 		expect(unescapeXml("&#x41;")).toBe("A");
+		expect(unescapeXml("&#x1F600;")).toBe("😀");
+		expect(unescapeXml("&#128512;")).toBe("😀");
+	});
+
+	it("should preserve invalid XML numeric character references", () => {
+		expect(unescapeXml("&#x0; &#xD800; &#x110000; &#1;")).toBe("&#x0; &#xD800; &#x110000; &#1;");
 	});
 
 	it("should unescape _xHHHH_ OOXML escapes", () => {


### PR DESCRIPTION
## What changed

XML numeric character references now decode with Unicode code point semantics, including supplementary characters such as emoji. Invalid XML code points (controls, surrogates, and out-of-range values) remain unchanged instead of being truncated or producing invalid JavaScript strings.

XML output now protects literal OOXML `_xHHHH_` sequences by escaping their leading underscore. This preserves user text through write/read roundtrips, including adjacent tokens that share an underscore.

Fixes #95
Fixes #96

## Validation

- `npm run format:check`
- `npm run lint`
- `npm run check`
- `npm test` (1,032 tests)
- `npm run test:coverage`
