### PR TITLE
fix: reject unsupported workbook passwords

### DIFF
--- a/docs/app/routes/guide/security.mdx
+++ b/docs/app/routes/guide/security.mdx
@@ -43,6 +43,10 @@ const previewRows = sheetToJson(firstSheet);
 
 The default ZIP and XML limits are intentionally high enough for ordinary workbooks. Lower them when a service receives arbitrary uploads and does not need to parse very large sheets.
 
+## Password-protected workbooks
+
+xlsx-format does not read or write encrypted or password-protected workbooks. Passing a non-empty `password` option to `read()` or `write()` throws an `XlsxError` with code `UNSUPPORTED` before parsing or serialization starts. Omit the option for ordinary unencrypted workbooks.
+
 ## Handling errors
 
 xlsx-format throws `XlsxError`, a subclass of `Error`, for deterministic library failures. Existing `catch` blocks keep working, but new integrations should branch on `error.code` instead of matching message text.

--- a/src/read.test.ts
+++ b/src/read.test.ts
@@ -48,6 +48,14 @@ describe("read.ts — input type handling", () => {
 		await expect(read(junk)).rejects.toThrow("Unsupported");
 	});
 
+	it("should reject password-protected reads before parsing", async () => {
+		await expect(read(new Uint8Array([0x00]), { password: "secret" })).rejects.toMatchObject({
+			name: "XlsxError",
+			code: "UNSUPPORTED",
+			message: "Password-protected workbooks are not supported",
+		});
+	});
+
 	it("should read from plain number array", async () => {
 		const ws = arrayToSheet([["Data"]]);
 		const wb = createWorkbook(ws, "Sheet1");

--- a/src/read.ts
+++ b/src/read.ts
@@ -79,8 +79,11 @@ function sheetToWorkBook(ws: any, name?: string): WorkBook {
  * @throws XlsxError if the input is a PDF, PNG, or other unsupported format
  */
 export async function read(data: any, opts?: ReadOptions): Promise<WorkBook> {
-	resetFormatTable();
 	const options: any = opts ? { ...opts } : {};
+	if (options.password) {
+		throw new XlsxError("UNSUPPORTED", "Password-protected workbooks are not supported");
+	}
+	resetFormatTable();
 	if (!options.type) {
 		options.type = detect_type(data);
 	}

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,7 +73,7 @@ export interface CommonOptions {
 	sheetStubs?: boolean;
 	/** If true, include style/theme information on cells */
 	cellStyles?: boolean;
-	/** Workbook password for encrypted files */
+	/** Password for encrypted workbooks; non-empty values are unsupported and throw XlsxError ("UNSUPPORTED") */
 	password?: string;
 }
 

--- a/src/write.test.ts
+++ b/src/write.test.ts
@@ -35,6 +35,18 @@ describe("write.ts — output types", () => {
 		expect(typeof b64).toBe("string");
 	});
 
+	it("should reject password-protected writes before validation", async () => {
+		await expect(write({} as any, { password: "secret" })).rejects.toMatchObject({
+			name: "XlsxError",
+			code: "UNSUPPORTED",
+			message: "Password-protected workbooks are not supported",
+		});
+	});
+
+	it("should preserve empty password behavior", async () => {
+		await expect(write(simpleWb(), { bookType: "csv", type: "string", password: "" })).resolves.toContain("A");
+	});
+
 	it("should write empty workbook CSV", async () => {
 		const emptyWb = { SheetNames: ["S1"], Sheets: { S1: {} } } as any;
 		const csv = await write(emptyWb, { bookType: "csv", type: "string" });

--- a/src/write.ts
+++ b/src/write.ts
@@ -1,4 +1,5 @@
 import type { WorkBook, WriteOptions } from "./types.js";
+import { XlsxError } from "./errors.js";
 import { zipWrite } from "./zip/index.js";
 import { writeZipXlsx } from "./xlsx/write-zip.js";
 import { validateWorkbook } from "./xlsx/workbook.js";
@@ -46,11 +47,14 @@ function firstSheet(wb: WorkBook) {
  * @returns Promise resolving to the serialized data in the requested format
  */
 export async function write(wb: WorkBook, opts?: WriteOptions): Promise<any> {
+	const options: any = { ...opts };
+	if (options.password) {
+		throw new XlsxError("UNSUPPORTED", "Password-protected workbooks are not supported");
+	}
 	resetFormatTable();
 	if (!opts || !(opts as any).unsafe) {
 		validateWorkbook(wb);
 	}
-	const options: any = { ...opts };
 	// cellStyles implies cellNF (number format) and sheetStubs (empty cell placeholders)
 	if (options.cellStyles) {
 		options.cellNF = true;


### PR DESCRIPTION
## What changed

`read()` and `write()` now reject non-empty `password` options with the typed `UNSUPPORTED` `XlsxError` before parsing, workbook validation, or serialization. This prevents callers from mistaking an ordinary unencrypted workbook for password protection. Omitted and empty password options retain existing behavior.

The option documentation and Security Considerations guide now state that encrypted/password-protected workbooks are unsupported on both read and write paths.

Fixes #88

## Validation

- `npm run format:check`
- `npm run lint`
- `npm run check`
- `npm test` (1,033 tests)
- `npm run test:coverage`

The docs build could not start in the run-owned clone because its existing dependencies do not provide the `react-router` executable; no dependency manifests or lockfiles were changed.
