### PR TITLE
fix: harden workbook authoring helpers

### DIFF
--- a/src/api/aoa.test.ts
+++ b/src/api/aoa.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { addArrayToSheet, arrayToSheet, sheetToArray } from "./aoa.js";
+import { createSheet } from "./book.js";
 
 describe("sheetToArray", () => {
 	it("returns worksheet values as an array of arrays", () => {
@@ -111,6 +112,27 @@ describe("aoa.ts — addArrayToSheet edge cases", () => {
 		let ws = arrayToSheet([["Row1"]]);
 		ws = addArrayToSheet(ws, [["Row2"]], { origin: -1 });
 		expect((ws as any).A2.v).toBe("Row2");
+	});
+
+	it("should treat origin -1 as row zero on an empty sparse sheet", () => {
+		const ws = addArrayToSheet(createSheet(), [["First"]], { origin: -1 });
+		expect(ws["!ref"]).toBe("A1");
+		expect((ws as any).A1.v).toBe("First");
+		expect((ws as any).A0).toBeUndefined();
+	});
+
+	it("should treat origin -1 as row zero on an empty dense sheet", () => {
+		const ws = addArrayToSheet(createSheet({ dense: true }), [["First"]], { origin: -1 });
+		expect(ws["!ref"]).toBe("A1");
+		expect(ws["!data"]?.[0]?.[0]?.v).toBe("First");
+		expect(ws["!data"]?.[-1]).toBeUndefined();
+	});
+
+	it("should append after the last row in a populated dense sheet", () => {
+		const ws = arrayToSheet([["First"]], { dense: true });
+		addArrayToSheet(ws, [["Second"]], { origin: -1 });
+		expect(ws["!ref"]).toBe("A1:A2");
+		expect(ws["!data"]?.[1]?.[0]?.v).toBe("Second");
 	});
 
 	it("should handle null values with nullError", () => {

--- a/src/api/aoa.ts
+++ b/src/api/aoa.ts
@@ -54,6 +54,10 @@ export function addArrayToSheet(worksheet: WorkSheet | null, data: any[][], opts
 		}
 	} else {
 		range.s.c = range.e.c = range.s.r = range.e.r = 0;
+		// On an empty sheet, append starts at the first row rather than row -1.
+		if (originRow === -1) {
+			originRow = 0;
+		}
 	}
 
 	let seen = false;

--- a/src/api/book.test.ts
+++ b/src/api/book.test.ts
@@ -15,7 +15,7 @@ import {
 import { arrayToSheet } from "./aoa.js";
 import type { CellObject } from "../types.js";
 
-import { jsonToSheet } from "../index.js";
+import { formatCell, jsonToSheet, read, sheetToCsv, sheetToHtml, write } from "../index.js";
 
 describe("createWorkbook", () => {
 	it("should create an empty workbook", () => {
@@ -35,6 +35,31 @@ describe("createWorkbook", () => {
 		const ws = createSheet();
 		const wb = createWorkbook(ws);
 		expect(wb.SheetNames).toStrictEqual(["Sheet1"]);
+	});
+
+	it("should preserve special sheet names as own enumerable properties", async () => {
+		const ws = arrayToSheet([["value"]]);
+		const wb = createWorkbook();
+
+		appendSheet(wb, ws, "__proto__");
+
+		expect(Object.keys(wb.Sheets)).toContain("__proto__");
+		expect(Object.hasOwn(wb.Sheets, "__proto__")).toBe(true);
+		expect(Object.getOwnPropertyDescriptor(wb.Sheets, "__proto__")?.value).toBe(ws);
+		expect(Object.getPrototypeOf(wb.Sheets)).toBe(Object.prototype);
+		expect(({} as any).polluted).toBeUndefined();
+		expect((await write(wb)) instanceof Uint8Array).toBe(true);
+	});
+
+	it("should append to an ordinary caller-provided Sheets map", () => {
+		const wb = { SheetNames: [], Sheets: {} };
+		const ws = createSheet();
+
+		appendSheet(wb, ws, "__proto__");
+
+		expect(wb.SheetNames).toStrictEqual(["__proto__"]);
+		expect(Object.getOwnPropertyDescriptor(wb.Sheets, "__proto__")?.value).toBe(ws);
+		expect(Object.keys(wb.Sheets)).toStrictEqual(["__proto__"]);
 	});
 });
 
@@ -114,6 +139,30 @@ describe("setCellNumberFormat", () => {
 		const cell: CellObject = { t: "n", v: 42 };
 		setCellNumberFormat(cell, "#,##0.00");
 		expect(cell.z).toBe("#,##0.00");
+	});
+
+	it("should invalidate cached display text for formatting and exports", () => {
+		const cell: CellObject = { t: "n", v: 0.25, w: "0.25" };
+		const ws = arrayToSheet([[cell]]);
+
+		setCellNumberFormat(cell, "0.00%");
+
+		expect(cell.w).toBeUndefined();
+		expect(formatCell(cell)).toBe("25.00%");
+		expect(sheetToCsv(ws)).toContain("25.00%");
+		expect(sheetToHtml(ws)).toContain(">25.00%<");
+	});
+
+	it("should invalidate cached display text on parsed cells", async () => {
+		const source = createWorkbook(arrayToSheet([[0.25]]), "Sheet1");
+		const parsed = await read(await write(source));
+		const cell = parsed.Sheets.Sheet1.A1;
+
+		setCellNumberFormat(cell, "0.00%");
+
+		expect(formatCell(cell)).toBe("25.00%");
+		expect(sheetToCsv(parsed.Sheets.Sheet1)).toContain("25.00%");
+		expect(sheetToHtml(parsed.Sheets.Sheet1)).toContain(">25.00%<");
 	});
 });
 

--- a/src/api/book.ts
+++ b/src/api/book.ts
@@ -69,7 +69,14 @@ export function appendSheet(wb: WorkBook, ws: WorkSheet, name?: string, roll?: b
 	}
 
 	wb.SheetNames.push(name);
-	wb.Sheets[name] = ws;
+	// Define the property explicitly so names such as "__proto__" remain own,
+	// enumerable sheet entries on ordinary caller-provided maps.
+	Object.defineProperty(wb.Sheets, name, {
+		value: ws,
+		enumerable: true,
+		configurable: true,
+		writable: true,
+	});
 	return name;
 }
 
@@ -153,6 +160,7 @@ export function setSheetVisibility(wb: WorkBook, sh: number | string, vis: 0 | 1
  */
 export function setCellNumberFormat(cell: CellObject, fmt: string | number): CellObject {
 	cell.z = fmt;
+	delete cell.w;
 	return cell;
 }
 


### PR DESCRIPTION
## What changed

- `setCellNumberFormat()` now clears the cached display string, so formatting and CSV/HTML exports reflect the new number format for both directly constructed and parsed cells.
- `addArrayToSheet()` treats `origin: -1` as row zero on an empty worksheet while preserving append-after-last-row behavior for populated sparse and dense sheets.
- `appendSheet()` defines sheet entries as enumerable own properties, preserving special names such as `__proto__` on both created and ordinary caller-provided workbook maps without changing object prototypes.

Fixes #103
Fixes #105
Fixes #106

## Validation

- `npm run format:check`
- `npm run lint`
- `npm run check`
- `npm test` (1,039 tests)
- `npm run test:coverage`

The docs build generated the site but could not complete its final prerender server in the sandbox (`EPERM` binding `::1`) and reported the existing generated `/api-reference/variables` missing route. No docs or dependency files were changed in this PR.
